### PR TITLE
Acknowledgment fragment is not written

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Adjust/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Adjust/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Adjust/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -101,7 +101,9 @@ acknowledged_target(
   name = "Adjust_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Adjust/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -189,7 +191,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Adjust/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Sociomantic_hdrs",
@@ -272,7 +276,9 @@ acknowledged_target(
   name = "Sociomantic_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Adjust/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Criteo_hdrs",
@@ -355,7 +361,9 @@ acknowledged_target(
   name = "Criteo_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Adjust/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Trademob_hdrs",
@@ -438,5 +446,7 @@ acknowledged_target(
   name = "Trademob_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Adjust/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Bolts/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Bolts/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Bolts/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -101,7 +101,9 @@ acknowledged_target(
   deps = [
     ":Tasks_acknowledgement",
     ":AppLinks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Bolts/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Tasks_hdrs",
@@ -236,7 +238,9 @@ acknowledged_target(
   name = "Tasks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Bolts/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "AppLinks_hdrs",
@@ -317,5 +321,7 @@ acknowledged_target(
   name = "AppLinks_acknowledgement",
   deps = [
     ":Tasks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Bolts/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Braintree/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Braintree/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Braintree/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -81,7 +81,9 @@ acknowledged_target(
     ":Core_acknowledgement",
     ":Card_acknowledgement",
     ":UI_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -165,7 +167,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Apple-Pay_hdrs",
@@ -237,7 +241,9 @@ acknowledged_target(
   name = "Apple-Pay_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Card_hdrs",
@@ -311,7 +317,9 @@ acknowledged_target(
   name = "Card_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "DataCollector_hdrs",
@@ -382,7 +390,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     ":DataCollector_VendoredLibraries_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_import(
   name = "DataCollector_VendoredLibraries",
@@ -394,7 +404,9 @@ acknowledged_target(
   name = "DataCollector_VendoredLibraries_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PayPal_hdrs",
@@ -467,7 +479,9 @@ acknowledged_target(
   deps = [
     ":PayPalOneTouch_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Venmo_hdrs",
@@ -538,7 +552,9 @@ acknowledged_target(
   deps = [
     ":PayPalDataCollector_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
   name = "UI_Bundle_Braintree-UI-Localization",
@@ -553,7 +569,9 @@ acknowledged_target(
   name = "UI_Bundle_Braintree-UI-Localization_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
   name = "UI_Bundle_Braintree-Drop-In-Localization",
@@ -568,7 +586,9 @@ acknowledged_target(
   name = "UI_Bundle_Braintree-Drop-In-Localization_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "UI_hdrs",
@@ -646,7 +666,9 @@ acknowledged_target(
   deps = [
     ":Card_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "UnionPay_hdrs",
@@ -720,7 +742,9 @@ acknowledged_target(
   deps = [
     ":Card_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
   name = "3D-Secure_Bundle_Braintree-3D-Secure-Localization",
@@ -735,7 +759,9 @@ acknowledged_target(
   name = "3D-Secure_Bundle_Braintree-3D-Secure-Localization_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "3D-Secure_hdrs",
@@ -812,7 +838,9 @@ acknowledged_target(
   deps = [
     ":Card_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PayPalOneTouch_hdrs",
@@ -896,7 +924,9 @@ acknowledged_target(
     ":PayPalDataCollector_acknowledgement",
     ":Core_acknowledgement",
     ":PayPalUtils_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PayPalDataCollector_hdrs",
@@ -980,7 +1010,9 @@ acknowledged_target(
     ":PayPalDataCollector_VendoredLibraries_acknowledgement",
     ":Core_acknowledgement",
     ":PayPalUtils_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_import(
   name = "PayPalDataCollector_VendoredLibraries",
@@ -992,7 +1024,9 @@ acknowledged_target(
   name = "PayPalDataCollector_VendoredLibraries_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PayPalUtils_hdrs",
@@ -1070,5 +1104,7 @@ acknowledged_target(
   name = "PayPalUtils_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Braintree/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Branch/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Branch/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Branch/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -77,7 +77,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     ":without-IDFA_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Branch/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -153,7 +155,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Branch/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "without-IDFA_hdrs",
@@ -228,5 +232,7 @@ acknowledged_target(
   name = "without-IDFA_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Branch/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Calabash/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Calabash/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Calabash/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -108,5 +108,7 @@ acknowledged_target(
   name = "Calabash_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Calabash/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/CardIO/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/CardIO/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/CardIO/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -90,7 +90,9 @@ acknowledged_target(
   name = "CardIO_acknowledgement",
   deps = [
     ":CardIO_VendoredLibraries_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/CardIO/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/CardIO/pod_support_buildable:acknowledgement_fragment"
   )
 objc_import(
   name = "CardIO_VendoredLibraries",
@@ -104,5 +106,7 @@ acknowledged_target(
   name = "CardIO_VendoredLibraries_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/CardIO/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/CardIO/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/ColorCube/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/ColorCube/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/ColorCube/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -83,5 +83,7 @@ acknowledged_target(
   name = "ColorCube_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/ColorCube/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/ColorCube/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/EarlGrey/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/EarlGrey/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/EarlGrey/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -91,7 +91,9 @@ acknowledged_target(
   name = "EarlGrey_acknowledgement",
   deps = [
     ":EarlGrey_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/EarlGrey/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/EarlGrey/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "EarlGrey_VendoredFrameworks",
@@ -114,5 +116,7 @@ acknowledged_target(
   name = "EarlGrey_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/EarlGrey/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/EarlGrey/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FBSDKCoreKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FBSDKCoreKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FBSDKCoreKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -286,7 +286,9 @@ acknowledged_target(
   deps = [
     "//Vendor/Bolts:Bolts_acknowledgement",
     ":FBSDKCoreKit_Bundle_FacebookSDKStrings_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle(
   name = "FBSDKCoreKit_Bundle_FacebookSDKStrings",
@@ -301,5 +303,7 @@ acknowledged_target(
   name = "FBSDKCoreKit_Bundle_FacebookSDKStrings_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FBSDKLoginKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FBSDKLoginKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FBSDKLoginKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -97,5 +97,7 @@ acknowledged_target(
   name = "FBSDKLoginKit_acknowledgement",
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FBSDKLoginKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FBSDKLoginKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FBSDKMessengerShareKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FBSDKMessengerShareKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FBSDKMessengerShareKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -83,5 +83,7 @@ acknowledged_target(
   name = "FBSDKMessengerShareKit_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FBSDKMessengerShareKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FBSDKMessengerShareKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FBSDKShareKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FBSDKShareKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FBSDKShareKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -190,5 +190,7 @@ acknowledged_target(
   name = "FBSDKShareKit_acknowledgement",
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FBSDKShareKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FBSDKShareKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FLAnimatedImage/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FLAnimatedImage/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FLAnimatedImage/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -89,5 +89,7 @@ acknowledged_target(
   name = "FLAnimatedImage_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FLAnimatedImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FLAnimatedImage/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FLEX/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FLEX/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FLEX/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -92,5 +92,7 @@ acknowledged_target(
   name = "FLEX_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FLEX/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FLEX/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/FMDB/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FMDB/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FMDB/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -75,7 +75,9 @@ acknowledged_target(
   name = "FMDB_acknowledgement",
   deps = [
     ":standard_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FMDB/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "standard_hdrs",
@@ -148,7 +150,9 @@ acknowledged_target(
   name = "standard_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FMDB/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "FTS_hdrs",
@@ -217,7 +221,9 @@ acknowledged_target(
   name = "FTS_acknowledgement",
   deps = [
     ":standard_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FMDB/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "standalone_hdrs",
@@ -269,7 +275,9 @@ acknowledged_target(
   name = "standalone_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/FMDB/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "SQLCipher_hdrs",
@@ -342,5 +350,7 @@ acknowledged_target(
   name = "SQLCipher_acknowledgement",
   deps = [
     "//Vendor/SQLCipher:SQLCipher_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FMDB/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleAppIndexing/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleAppIndexing/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleAppIndexing/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -84,7 +84,9 @@ acknowledged_target(
   deps = [
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources_acknowledgement",
     ":GoogleAppIndexing_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle(
   name = "GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
@@ -99,7 +101,9 @@ acknowledged_target(
   name = "GoogleAppIndexing_Bundle_GoogleAppIndexingResources_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleAppIndexing_VendoredFrameworks",
@@ -118,5 +122,7 @@ acknowledged_target(
   name = "GoogleAppIndexing_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleAppUtilities/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleAppUtilities/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleAppUtilities/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -77,7 +77,9 @@ acknowledged_target(
   deps = [
     ":GoogleAppUtilities_VendoredFrameworks_acknowledgement",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleAppUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAppUtilities/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleAppUtilities_VendoredFrameworks",
@@ -96,5 +98,7 @@ acknowledged_target(
   name = "GoogleAppUtilities_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleAppUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAppUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleAuthUtilities/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleAuthUtilities/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleAuthUtilities/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -86,7 +86,9 @@ acknowledged_target(
     ":GoogleAuthUtilities_VendoredFrameworks_acknowledgement",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement",
     "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleAuthUtilities_VendoredFrameworks",
@@ -105,5 +107,7 @@ acknowledged_target(
   name = "GoogleAuthUtilities_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleNetworkingUtilities/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleNetworkingUtilities/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleNetworkingUtilities/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -80,7 +80,9 @@ acknowledged_target(
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement",
     ":GoogleNetworkingUtilities_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleNetworkingUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleNetworkingUtilities/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleNetworkingUtilities_VendoredFrameworks",
@@ -99,5 +101,7 @@ acknowledged_target(
   name = "GoogleNetworkingUtilities_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleNetworkingUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleNetworkingUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleSignIn/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleSignIn/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleSignIn/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -93,7 +93,9 @@ acknowledged_target(
     "//Vendor/GTMOAuth2:GTMOAuth2_acknowledgement",
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments_acknowledgement",
     "//Vendor/GTMSessionFetcher:Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle(
   name = "GoogleSignIn_Bundle_GoogleSignIn",
@@ -108,7 +110,9 @@ acknowledged_target(
   name = "GoogleSignIn_Bundle_GoogleSignIn_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleSignIn_VendoredFrameworks",
@@ -127,5 +131,7 @@ acknowledged_target(
   name = "GoogleSignIn_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleSymbolUtilities/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleSymbolUtilities/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleSymbolUtilities/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -75,7 +75,9 @@ acknowledged_target(
   name = "GoogleSymbolUtilities_acknowledgement",
   deps = [
     ":GoogleSymbolUtilities_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleSymbolUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleSymbolUtilities/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleSymbolUtilities_VendoredFrameworks",
@@ -94,5 +96,7 @@ acknowledged_target(
   name = "GoogleSymbolUtilities_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleSymbolUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleSymbolUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/GoogleUtilities/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/GoogleUtilities/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/GoogleUtilities/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -84,7 +84,9 @@ acknowledged_target(
   deps = [
     ":GoogleUtilities_VendoredFrameworks_acknowledgement",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/GoogleUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleUtilities/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "GoogleUtilities_VendoredFrameworks",
@@ -103,5 +105,7 @@ acknowledged_target(
   name = "GoogleUtilities_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/GoogleUtilities/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/GoogleUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/IBActionSheet/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/IBActionSheet/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/IBActionSheet/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -86,5 +86,7 @@ acknowledged_target(
   name = "IBActionSheet_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/IBActionSheet/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/IBActionSheet/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/IGListKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/IGListKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/IGListKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -110,7 +110,9 @@ acknowledged_target(
   name = "IGListKit_acknowledgement",
   deps = [
     ":Default_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Diffing_hdrs",
@@ -213,7 +215,9 @@ acknowledged_target(
   name = "Diffing_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Default_hdrs",
@@ -331,5 +335,7 @@ acknowledged_target(
   name = "Default_acknowledgement",
   deps = [
     ":Diffing_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/KVOController/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/KVOController/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/KVOController/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -83,5 +83,7 @@ acknowledged_target(
   name = "KVOController_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/KVOController/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KVOController/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/KakaoOpenSDK/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/KakaoOpenSDK/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/KakaoOpenSDK/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -79,7 +79,9 @@ acknowledged_target(
   name = "KakaoOpenSDK_acknowledgement",
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "KakaoOpenSDK_hdrs",
@@ -149,7 +151,9 @@ acknowledged_target(
   name = "KakaoOpenSDK_acknowledgement",
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "KakaoOpenSDK_VendoredFrameworks",
@@ -168,7 +172,9 @@ acknowledged_target(
   name = "KakaoOpenSDK_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "KakaoNavi_hdrs",
@@ -226,7 +232,9 @@ acknowledged_target(
   name = "KakaoNavi_acknowledgement",
   deps = [
     ":KakaoNavi_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "KakaoNavi_VendoredFrameworks",
@@ -245,7 +253,9 @@ acknowledged_target(
   name = "KakaoNavi_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "KakaoLink_hdrs",
@@ -303,7 +313,9 @@ acknowledged_target(
   name = "KakaoLink_acknowledgement",
   deps = [
     ":KakaoLink_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "KakaoLink_VendoredFrameworks",
@@ -322,7 +334,9 @@ acknowledged_target(
   name = "KakaoLink_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "KakaoS2_hdrs",
@@ -380,7 +394,9 @@ acknowledged_target(
   name = "KakaoS2_acknowledgement",
   deps = [
     ":KakaoS2_VendoredFrameworks_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )
 objc_framework(
   name = "KakaoS2_VendoredFrameworks",
@@ -399,5 +415,7 @@ acknowledged_target(
   name = "KakaoS2_VendoredFrameworks_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Masonry/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Masonry/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Masonry/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -117,5 +117,7 @@ acknowledged_target(
   name = "Masonry_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Masonry/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Masonry/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/OnePasswordExtension/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/OnePasswordExtension/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/OnePasswordExtension/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -108,7 +108,9 @@ acknowledged_target(
   name = "OnePasswordExtension_acknowledgement",
   deps = [
     ":OnePasswordExtension_Bundle_OnePasswordExtensionResources_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/OnePasswordExtension/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/OnePasswordExtension/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
   name = "OnePasswordExtension_Bundle_OnePasswordExtensionResources",
@@ -124,5 +126,7 @@ acknowledged_target(
   name = "OnePasswordExtension_Bundle_OnePasswordExtensionResources_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/OnePasswordExtension/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/OnePasswordExtension/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/PINCache/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/PINCache/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/PINCache/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -102,7 +102,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     ":Arc-exception-safe_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINCache/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -187,7 +189,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
     "//Vendor/PINOperation:PINOperation_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINCache/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Arc-exception-safe_hdrs",
@@ -263,5 +267,7 @@ acknowledged_target(
   name = "Arc-exception-safe_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINCache/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/PINOperation/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/PINOperation/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/PINOperation/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -87,5 +87,7 @@ acknowledged_target(
   name = "PINOperation_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/PINOperation/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINOperation/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/PINRemoteImage/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/PINRemoteImage/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/PINRemoteImage/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -77,7 +77,9 @@ acknowledged_target(
   deps = [
     ":FLAnimatedImage_acknowledgement",
     ":PINCache_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -162,7 +164,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
     "//Vendor/PINOperation:PINOperation_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "iOS_hdrs",
@@ -220,7 +224,9 @@ acknowledged_target(
   name = "iOS_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "OSX_hdrs",
@@ -279,7 +285,9 @@ acknowledged_target(
   name = "OSX_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "tvOS_hdrs",
@@ -334,7 +342,9 @@ acknowledged_target(
   name = "tvOS_acknowledgement",
   deps = [
     ":iOS_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "FLAnimatedImage_hdrs",
@@ -405,7 +415,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     "//Vendor/FLAnimatedImage:FLAnimatedImage_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "WebP_hdrs",
@@ -462,7 +474,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     "//Vendor/libwebp:libwebp_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PINCache_hdrs",
@@ -533,5 +547,7 @@ acknowledged_target(
   deps = [
     "//Vendor/PINCache:PINCache_acknowledgement",
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/PaymentKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/PaymentKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/PaymentKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -87,5 +87,7 @@ acknowledged_target(
   name = "PaymentKit_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/PaymentKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/PaymentKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/RadarKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/RadarKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/RadarKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -87,5 +87,7 @@ acknowledged_target(
   name = "RadarKit_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/RadarKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/RadarKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/React/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/React/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/React/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -75,7 +75,9 @@ acknowledged_target(
   name = "React_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -179,7 +181,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "ART_hdrs",
@@ -248,7 +252,9 @@ acknowledged_target(
   name = "ART_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTActionSheet_hdrs",
@@ -317,7 +323,9 @@ acknowledged_target(
   name = "RCTActionSheet_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTAdSupport_hdrs",
@@ -386,7 +394,9 @@ acknowledged_target(
   name = "RCTAdSupport_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTGeolocation_hdrs",
@@ -455,7 +465,9 @@ acknowledged_target(
   name = "RCTGeolocation_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTImage_hdrs",
@@ -524,7 +536,9 @@ acknowledged_target(
   name = "RCTImage_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTNetwork_hdrs",
@@ -593,7 +607,9 @@ acknowledged_target(
   name = "RCTNetwork_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTPushNotification_hdrs",
@@ -662,7 +678,9 @@ acknowledged_target(
   name = "RCTPushNotification_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTSettings_hdrs",
@@ -731,7 +749,9 @@ acknowledged_target(
   name = "RCTSettings_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTText_hdrs",
@@ -800,7 +820,9 @@ acknowledged_target(
   name = "RCTText_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTVibration_hdrs",
@@ -869,7 +891,9 @@ acknowledged_target(
   name = "RCTVibration_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTWebSocket_hdrs",
@@ -938,7 +962,9 @@ acknowledged_target(
   name = "RCTWebSocket_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "RCTLinkingIOS_hdrs",
@@ -1007,5 +1033,7 @@ acknowledged_target(
   name = "RCTLinkingIOS_acknowledgement",
   deps = [
     ":Core_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/React/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/SFHFKeychainUtils/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/SFHFKeychainUtils/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/SFHFKeychainUtils/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -96,5 +96,7 @@ acknowledged_target(
   name = "SFHFKeychainUtils_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/SPUserResizableView+Pion/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/SPUserResizableView+Pion/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/SPUserResizableView+Pion/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -83,5 +83,7 @@ acknowledged_target(
   name = "SPUserResizableView_Pion_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/SPUserResizableView+Pion/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/SPUserResizableView+Pion/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/SevenSwitch/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/SevenSwitch/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/SevenSwitch/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -76,5 +76,7 @@ acknowledged_target(
   name = "SevenSwitch_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/SevenSwitch/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/SevenSwitch/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/SlackTextViewController/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/SlackTextViewController/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/SlackTextViewController/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -83,5 +83,7 @@ acknowledged_target(
   name = "SlackTextViewController_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/SlackTextViewController/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/SlackTextViewController/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Smartling/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Smartling/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Smartling/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -78,5 +78,7 @@ acknowledged_target(
   name = "Smartling_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Smartling/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Smartling/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Stripe/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Stripe/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Stripe/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -107,7 +107,9 @@ acknowledged_target(
   name = "Stripe_acknowledgement",
   deps = [
     ":Stripe_Bundle_Stripe_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Stripe/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Stripe/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
   name = "Stripe_Bundle_Stripe",
@@ -126,5 +128,7 @@ acknowledged_target(
   name = "Stripe_Bundle_Stripe_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Stripe/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Stripe/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Texture/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Texture/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Texture/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -84,7 +84,9 @@ acknowledged_target(
   name = "AsyncDisplayKit_acknowledgement",
   deps = [
     ":PINRemoteImage_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Texture/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Core_hdrs",
@@ -167,7 +169,9 @@ acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Texture/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "PINRemoteImage_hdrs",
@@ -235,7 +239,9 @@ acknowledged_target(
     ":Core_acknowledgement",
     "//Vendor/PINRemoteImage:iOS_acknowledgement",
     "//Vendor/PINRemoteImage:PINCache_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Texture/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "IGListKit_hdrs",
@@ -301,7 +307,9 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     "//Vendor/IGListKit:IGListKit_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Texture/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Yoga_hdrs",
@@ -368,5 +376,7 @@ acknowledged_target(
   deps = [
     ":Core_acknowledgement",
     "//Vendor/Yoga:Yoga_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Texture/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -88,5 +88,7 @@ acknowledged_target(
   name = "UICollectionViewLeftAlignedLayout_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/Weixin/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/Weixin/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/Weixin/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -84,7 +84,9 @@ acknowledged_target(
   name = "Weixin_acknowledgement",
   deps = [
     ":Weixin_VendoredLibraries_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/Weixin/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Weixin/pod_support_buildable:acknowledgement_fragment"
   )
 objc_import(
   name = "Weixin_VendoredLibraries",
@@ -96,5 +98,7 @@ acknowledged_target(
   name = "Weixin_VendoredLibraries_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/Weixin/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/Weixin/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/ZipArchive/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/ZipArchive/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/ZipArchive/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -101,5 +101,7 @@ acknowledged_target(
   name = "ZipArchive_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/ZipArchive/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/ZipArchive/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/googleapis/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/googleapis/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/googleapis/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -79,7 +79,9 @@ acknowledged_target(
     ":Services_acknowledgement",
     "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin_acknowledgement",
     ":Messages_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/googleapis/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Messages_hdrs",
@@ -146,7 +148,9 @@ acknowledged_target(
   name = "Messages_acknowledgement",
   deps = [
     "//Vendor/Protobuf:Protobuf_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/googleapis/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
   )
 filegroup(
   name = "Services_hdrs",
@@ -217,5 +221,7 @@ acknowledged_target(
   deps = [
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC_acknowledgement",
     ":Messages_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/googleapis/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/iRate/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/iRate/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/iRate/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -89,7 +89,9 @@ acknowledged_target(
   name = "iRate_acknowledgement",
   deps = [
     ":iRate_Bundle_iRate_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/iRate/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/iRate/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle(
   name = "iRate_Bundle_iRate",
@@ -104,5 +106,7 @@ acknowledged_target(
   name = "iRate_Bundle_iRate_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/iRate/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/iRate/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/kingpin/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/kingpin/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/kingpin/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -87,5 +87,7 @@ acknowledged_target(
   name = "kingpin_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/kingpin/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/kingpin/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/pop/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/pop/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/pop/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -89,5 +89,7 @@ acknowledged_target(
   name = "pop_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/pop/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/pop/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -1,6 +1,6 @@
-load('//:pod_support_buildable/extensions.bzl', 'pch_with_name_hint')
-load('//:pod_support_buildable/extensions.bzl', 'acknowledged_target')
-load('//:pod_support_buildable/extensions.bzl', 'gen_module_map')
+load('//Vendor/youtube-ios-player-helper/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/youtube-ios-player-helper/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/youtube-ios-player-helper/pod_support_buildable:extensions.bzl', 'gen_module_map')
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -153,7 +153,9 @@ acknowledged_target(
   name = "youtube-ios-player-helper_acknowledgement",
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle(
   name = "youtube-ios-player-helper_Bundle_Assets",
@@ -168,5 +170,7 @@ acknowledged_target(
   name = "youtube-ios-player-helper_Bundle_Assets_acknowledgement",
   deps = [
 
-  ]
+  ],
+  merger = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
   )

--- a/RepoTools/RepoActions.swift
+++ b/RepoTools/RepoActions.swift
@@ -265,7 +265,7 @@ enum RepoActions {
                 let cmd = shell.command("/bin/ls", arguments: [cleansedPath])
                 return cmd.standardOutputAsString.components(separatedBy: "\n").map{ String($0) }
             })
-        
+
         // Get the rest of the header searchpaths
         let customHeaderSearchPaths = Set([podSpec.name])
             .union(searchPaths(ComposedSpec.composed(child: podSpec, parent: nil)))
@@ -313,12 +313,10 @@ enum RepoActions {
         }
 
         // Write out contents of PodSupportBuildableDir
-  
+
         // Write out the acknowledgement entry plist
         let entry = RenderAcknowledgmentEntry(entry: AcknowledgmentEntry(forPodspec: podSpec))
-        let acknowledgementFilePath = URL(
-            fileURLWithPath: PodSupportBuidableDir + "acknowledgement.plist",
-            relativeTo: URL(fileURLWithPath: "../"))
+        let acknowledgementFilePath = URL(fileURLWithPath: PodSupportBuidableDir + "acknowledgement.plist")
         shell.write(value: entry, toPath: acknowledgementFilePath)
 
         // assume _PATH_TO_SOME/bin/RepoTools

--- a/Source/BuildFile.swift
+++ b/Source/BuildFile.swift
@@ -116,11 +116,20 @@ public struct AcknowledgmentNode: SkylarkConvertible {
 
     public func toSkylark() -> SkylarkNode {
         let nodeName = ObjcLibrary.bazelLabel(fromString: name + "_acknowledgement").toSkylark()
+        let options = GetBuildOptions()
+        let podSupportBuildableDir = String(PodSupportBuidableDir.utf8.dropLast())!
+        let merger = ("//Vendor/" + options.podName + "/"  +
+             podSupportBuildableDir + ":acknowledgement_merger").toSkylark()
+        let value = ("//Vendor/" + options.podName + "/" +
+             podSupportBuildableDir +
+             ":acknowledgement_fragment").toSkylark()
         let target = SkylarkNode.functionCall(
             name: "acknowledged_target",
             arguments: [
                 .named(name: "name", value: nodeName),
                 .named(name: "deps", value: deps.map { $0 + "_acknowledgement" }.toSkylark()),
+                .named(name: "merger", value: merger),
+                .named(name: "value", value: value)
             ]
         )
         return target


### PR DESCRIPTION
This patch fixes the writing of acknowledgment fragment into
pod_support_buildable.

Also, it fixes an error message of writes failing.