### PR TITLE
Add wildcard glob parsing

### DIFF
--- a/Examples/FolioReaderKit.podspec.json
+++ b/Examples/FolioReaderKit.podspec.json
@@ -1,0 +1,59 @@
+{
+  "name": "FolioReaderKit",
+  "version": "1.3.0",
+  "summary": "A Swift ePub reader and parser framework for iOS.",
+  "description": "Written in Swift.\nThe Best Open Source ePub Reader.",
+  "homepage": "https://github.com/FolioReader/FolioReaderKit",
+  "screenshots": [
+    "https://raw.githubusercontent.com/FolioReader/FolioReaderKit/assets/custom-fonts.gif",
+    "https://raw.githubusercontent.com/FolioReader/FolioReaderKit/assets/highlight.gif"
+  ],
+  "license": "BSD",
+  "authors": {
+    "Heberti Almeida": "hebertialmeida@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/FolioReader/FolioReaderKit.git",
+    "tag": "1.3.0"
+  },
+  "social_media_url": "https://twitter.com/hebertialmeida",
+  "platforms": {
+    "ios": "8.0"
+  },
+  "requires_arc": true,
+  "source_files": [
+    "Source/*.{h,swift}",
+    "Source/**/*.swift",
+    "Vendor/**/*.swift"
+  ],
+  "resources": [
+    "Source/**/*.{js,css}",
+    "Source/Resources/*.xcassets",
+    "Source/Resources/Fonts/**/*.{otf,ttf}"
+  ],
+  "public_header_files": "Source/*.h",
+  "libraries": "z",
+  "dependencies": {
+    "SSZipArchive": [
+      "2.1.1"
+    ],
+    "MenuItemKit": [
+      "3.0.0"
+    ],
+    "ZFDragableModalTransition": [
+      "0.6"
+    ],
+    "AEXML": [
+      "4.2.2"
+    ],
+    "FontBlaster": [
+      "4.0.1"
+    ],
+    "JSQWebViewController": [
+      "6.0.0"
+    ],
+    "RealmSwift": [
+      "3.1.1"
+    ]
+  }
+}

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -1,0 +1,101 @@
+load('//Vendor/FolioReaderKit/pod_support_buildable:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/FolioReaderKit/pod_support_buildable:extensions.bzl', 'acknowledged_target')
+load('//Vendor/FolioReaderKit/pod_support_buildable:extensions.bzl', 'gen_module_map')
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://bazel.build/versions/master/docs/bazel-user-manual.html
+native.config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+  )
+filegroup(
+  name = "FolioReaderKit_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*.h"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_module_map(
+  "FolioReaderKit",
+  "FolioReaderKit_module_map",
+  "FolioReaderKit",
+  [
+    "FolioReaderKit_hdrs"
+  ]
+  )
+objc_library(
+  name = "FolioReaderKit",
+  enable_modules = 0,
+  hdrs = [
+    ":FolioReaderKit_hdrs"
+  ],
+  pch = pch_with_name_hint(
+    "FolioReaderKit",
+    [
+
+    ]
+    ),
+  includes = [
+    "pod_support/Headers/Public/",
+    "FolioReaderKit_module_map"
+  ],
+  sdk_dylibs = [
+    "z"
+  ],
+  deps = [
+    "//Vendor/JSQWebViewController:JSQWebViewController",
+    "//Vendor/RealmSwift:RealmSwift",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition",
+    "//Vendor/AEXML:AEXML",
+    "//Vendor/FontBlaster:FontBlaster",
+    "//Vendor/SSZipArchive:SSZipArchive",
+    "//Vendor/MenuItemKit:MenuItemKit"
+  ],
+  copts = [
+
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+    ) + [
+    "-IVendor/FolioReaderKit/pod_support/Headers/Public/FolioReaderKit/"
+  ] + [
+    "-fmodule-name=FolioReaderKit_pod_module"
+  ],
+  resources = [
+    "Source/**/*.css",
+    "Source/**/*.js",
+    "Source/Resources/*.xcassets",
+    "Source/Resources/Fonts/**/*.otf",
+    "Source/Resources/Fonts/**/*.ttf"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+acknowledged_target(
+  name = "FolioReaderKit_acknowledgement",
+  deps = [
+    "//Vendor/FontBlaster:FontBlaster_acknowledgement",
+    "//Vendor/MenuItemKit:MenuItemKit_acknowledgement",
+    "//Vendor/SSZipArchive:SSZipArchive_acknowledgement",
+    "//Vendor/JSQWebViewController:JSQWebViewController_acknowledgement",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition_acknowledgement",
+    "//Vendor/RealmSwift:RealmSwift_acknowledgement",
+    "//Vendor/AEXML:AEXML_acknowledgement"
+  ]
+  )

--- a/IntegrationTests/README.md
+++ b/IntegrationTests/README.md
@@ -1,0 +1,21 @@
+# PodToBUILD output testing system
+
+## Adding a new example:
+
+First Download the podspec
+
+```
+wget https://raw.githubusercontent.com/FolioReader/FolioReaderKit/master/FolioReaderKit.podspec
+```
+
+Check in the IPC json version under Goldmaster
+
+```
+pod ipc spec FolioReaderKit.podspec 2>&1 | cat > Examples/FolioReaderKit.podspec.json
+```
+
+Update the current output
+
+```
+make goldmaster
+```

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -324,11 +324,11 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         self.copts = AttrSet(basic: xcconfigFlags) <> (fallbackSpec ^* ComposedSpec.lens.fallback(liftToAttr(PodSpec.lens.compilerFlags)))
 
         // Select resources that are not prebuilt bundles
-        self.resources = (spec ^* liftToAttr(PodSpec.lens.resources)).map { (strArr: [String]) -> [String] in
+        self.resources = ((spec ^* liftToAttr(PodSpec.lens.resources)).map { (strArr: [String]) -> [String] in
             strArr.filter({ (str: String) -> Bool in
                 !str.hasSuffix(".bundle")
             })
-        }
+        }).map(extractResources)
 
         let prebuiltBundles = spec ^* liftToAttr(PodSpec.lens.resources .. ReadonlyLens {
             $0.filter { s in s.hasSuffix(".bundle") }
@@ -679,6 +679,12 @@ private func extractSources(patterns: [String]) -> [String] {
     }
 }
 
+private func extractResources(patterns: [String]) -> [String] {
+    return patterns.flatMap { (p: String) -> [String] in
+        pattern(fromPattern: p, includingFileTypes: [])
+    }
+}
+
 private func extractHeaders(patterns: [String]) -> [String] {
     return patterns.flatMap { (p: String) -> [String] in
         pattern(fromPattern: p, includingFileTypes: ["h"])
@@ -688,6 +694,7 @@ private func extractHeaders(patterns: [String]) -> [String] {
 func extract(headers: AttrSet<[String]>) -> AttrSet<[String]> {
     return headers.map(extractHeaders)
 }
+
 func extract(sources: AttrSet<[String]>) -> AttrSet<[String]> {
     return sources.map(extractSources)
 }


### PR DESCRIPTION
Allow all file types for resources, and parse them as globs. Previously, we didn't parse out the globs.

Additionally, I added output testing for Folio