### PR TITLE
Use Bazel for release builds / update_pods.py

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,51 @@
-# This is a blank file. In Bazel, it is a convention and requirement to have a
-# blank file if you want to reference some path.
-# The reason this exists, is because this directory is referenced by workspaces
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
+
+objc_library(
+    name = "ObjcSupport",
+    srcs = glob(["Sources/ObjcSupport/*.m"]),
+    hdrs = glob(["Sources/ObjcSupport/include/*"]),
+    includes = ["Sources/ObjcSupport/include"]
+)
+
+# PodToBUILD is a core library enabling Skylark code generation
+swift_library(
+    name = "PodToBUILD",
+    srcs = glob(["Sources/PodToBUILD/*.swift"]),
+    deps = [":ObjcSupport"],
+    copts = ["-swift-version", "4", "-static-stdlib"],
+)
+
+# Compiler
+macos_command_line_application(
+    name = "Compiler",
+    minimum_os_version = "10.13",
+    deps = [":CompilerLib"],
+)
+
+swift_library(
+    name = "CompilerLib",
+    srcs = glob(["Sources/Compiler/*.swift"]),
+    deps = [":PodToBUILD"],
+)
+
+# RepoTools
+macos_command_line_application(
+    name = "RepoTools",
+    minimum_os_version = "10.13",
+    deps = [":RepoToolsLib"],
+)
+
+swift_library(
+    name = "RepoToolsLib",
+    srcs = glob(["Sources/RepoTools/*.swift"]),
+    deps = [":RepoToolsCore"],
+)
+
+swift_library(
+    name = "RepoToolsCore",
+    srcs = glob(["Sources/RepoToolsCore/*.swift"]),
+    deps = [":PodToBUILD"],
+    copts = ["-swift-version", "4", "-static-stdlib"],
+)
+

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -97,5 +97,7 @@ acknowledged_target(
     "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition_acknowledgement",
     "//Vendor/RealmSwift:RealmSwift_acknowledgement",
     "//Vendor/AEXML:AEXML_acknowledgement"
-  ]
+  ],
+  merger = "//Vendor/FolioReaderKit/pod_support_buildable:acknowledgement_merger",
+  value = "//Vendor/FolioReaderKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY : \
 	build \
 	release \
+	release-spm \
 	goldmaster \
 	test \
 	unit-test \
@@ -8,24 +9,26 @@
 
 build: CONFIG = debug
 build: SWIFTBFLAGS = --configuration $(CONFIG)
-build: build-impl
+build: build-impl-spm
 
 clean:
 	rm -rf .build/debug
 	rm -rf .build/release
+	tools/bazelwrapper clean
 
 compiler: release
 
 repo-tools: release
 
-release: CONFIG = release
-release: SWIFTBFLAGS = --configuration $(CONFIG) -Xswiftc -static-stdlib
-release: build-impl
-release:
-	ditto .build/$(CONFIG)/Compiler bin/Compiler
-	ditto .build/$(CONFIG)/RepoTools bin/RepoTools
+release-spm: CONFIG = release
+release-spm: SWIFTBFLAGS = --configuration $(CONFIG) -Xswiftc -static-stdlib
+release-spm: build-impl-spm
+release-spm:
+	@ditto .build/$(CONFIG)/Compiler bin/Compiler
+	@ditto .build/$(CONFIG)/RepoTools bin/RepoTools
 
-build-impl:
+
+build-impl-spm:
 	swift build $(SWIFTBFLAGS) \
 	    -Xswiftc -target -Xswiftc x86_64-apple-macosx10.13
 
@@ -41,4 +44,10 @@ integration-test: release
 	./IntegrationTests/RunTests.sh
 
 test: unit-test integration-test
+
+release:
+	tools/bazelwrapper build :RepoTools :Compiler
+	@ditto bazel-bin/RepoTools bin/RepoTools
+	@ditto bazel-bin/Compiler bin/Compiler
+
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,11 @@
+git_repository(
+    name = "bazel_skylib",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
+    tag = "0.3.1",
+)
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    tag = "0.5.0",
+)

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we're in the project root directory.
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+trap popd > /dev/null ERR EXIT
+
+BAZEL_VERSION="0.12.0rc1"
+BAZEL_VERSION_SHA="fe9bf6e4d920c668f28a37d5d2ea11cee38871e90ccf5c2a52c7a327dd6de9a9"
+BAZEL_VERSION_URL="https://releases.bazel.build/0.12.0/rc1/bazel-0.12.0rc1-installer-darwin-x86_64.sh"
+
+BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
+BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
+LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
+
+BAZEL=""
+
+function install_bazel() {
+    curl -L "$BAZEL_VERSION_URL" > $PWD/install_bazel.sh
+    SHA=$(shasum -a 256 install_bazel.sh | awk '{ print $1 }')
+    if [[ $SHA == $BAZEL_VERSION_SHA ]]; then
+        chmod +x install_bazel.sh
+        $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
+    else
+        echo "You version of bazel is out of date; ask for help in #cx-ios"
+        exit 1
+    fi
+}
+
+# Check if we have the correct version of bazel installed in the home
+# directory.
+# Fallback to ./Scripts/bazel/bin/bazel for legacy installations
+# Lastly, check if there is one installed on the path
+if [[ -e "$BAZEL_PATH" ]]; then
+  BAZEL="$BAZEL_PATH"
+elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL="$LEGACY_BAZEL_PATH"
+elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL=$(which bazel)
+fi
+
+# Ensure we can execute the path for bazel and that it's the correct version
+if ! [[ -e "$BAZEL" ]]; then
+  echo "WARNING: Missing installation or incorrect bazel version ($BAZEL_VERSION)" >&2;
+  echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
+  install_bazel
+  BAZEL=$BAZEL_PATH
+fi
+
+if [[ -x "${BAZEL}" ]]; then
+    exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "$@"
+else
+  echo "WARNING: Missing installation of bazel" >&2;
+  exit 1
+fi


### PR DESCRIPTION
This patch adds the ability to build with Bazel. We much prefer Bazel
due to its stability, reproducibility, and nix friendliness.