### PR TITLE
Use FileManager API for creating symbolic links

### DIFF
--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -97,8 +97,6 @@ public func makeConfigSettingNodes() -> SkylarkNode {
 // Make Nodes to be inserted at the beginning of skylark output
 // public for test purposes
 public func makePrefixNodes() -> SkylarkNode {
-    let options = GetBuildOptions()
-    let podSupportBuildableDir = String(PodSupportBuidableDir.utf8.dropLast())!
     return .lines([
         SkylarkNode.skylark("load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'pch_with_name_hint')"),
         SkylarkNode.skylark("load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'acknowledged_target')"),

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -690,7 +690,7 @@ private func extractResources(patterns: [String]) -> [String] {
 
 private func extractHeaders(patterns: [String]) -> [String] {
     return patterns.flatMap { (p: String) -> [String] in
-        pattern(fromPattern: p, includingFileTypes: ["h", "hpp"])
+        pattern(fromPattern: p, includingFileTypes: ["h", "hpp", "hxx"])
     }
 }
 

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -34,7 +34,7 @@ protocol BazelTarget: SkylarkConvertible {
 
 extension BazelTarget {
     var acknowledgedDeps: [String]? {
-        return nil 
+        return nil
     }
 
     var acknowledged: Bool {
@@ -438,7 +438,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
        
         let allModuleInternalHeaders = headers.toSkylark() .+. depHdrs.toSkylark()
 
-        let podSupportHeaders = GlobNode(include: AttrSet<Set<String>>(basic: [PodSupportSystemPublicHeaderDir + "**/*.h"]),
+        let podSupportHeaders = GlobNode(include: AttrSet<Set<String>>(basic: [PodSupportSystemPublicHeaderDir + "**/*"]),
                                                          exclude: AttrSet<Set<String>>.empty).toSkylark()
         
         if isTopLevelTarget {
@@ -690,7 +690,7 @@ private func extractResources(patterns: [String]) -> [String] {
 
 private func extractHeaders(patterns: [String]) -> [String] {
     return patterns.flatMap { (p: String) -> [String] in
-        pattern(fromPattern: p, includingFileTypes: ["h"])
+        pattern(fromPattern: p, includingFileTypes: ["h", "hpp"])
     }
 }
 

--- a/Sources/PodToBUILD/ShellContext.swift
+++ b/Sources/PodToBUILD/ShellContext.swift
@@ -211,10 +211,14 @@ public struct SystemShellContext : ShellContext {
 
     public func symLink(from: String, to: String) {
         log("LINK FROM \(from) to \(to)")
-        let status = command("/bin/ln", arguments: ["-s", escape(from), escape(to)]).terminationStatus
-        log("LINK STATUS \(status)")
+        do {
+            try FileManager.default.createSymbolicLink(atPath: to, withDestinationPath: from)
+            print("LINK SUCCESS")
+        } catch {
+            print("LINK ERROR: ", error.localizedDescription)
+        }
     }
-    
+
     public func write(value: String, toPath path: URL) {
         log("WRITE \(value) TO \(path)")
         try? value.write(to: path, atomically: false, encoding: String.Encoding.utf8)

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -305,7 +305,7 @@ public enum RepoActions {
         customHeaderSearchPaths.forEach { searchPath in
             let linkPath = currentDirectoryPath + "/" + searchPath
             guard FileManager.default.changeCurrentDirectoryPath(linkPath) else {
-                print("Can't change path while creating symlink")
+                print("WARNING: Can't change path while creating symlink")
                 return
             }
             globResults.forEach { globResult in

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -205,11 +205,11 @@ public enum RepoActions {
         let hasPodspec: () -> Bool = { hasFile(podspecName + ".podspec") }
         let hasPodspecJson: () -> Bool = { hasFile(podspecName + ".podspec.json") }
 
-        if hasPodspec() {
+        if hasPodspecJson() {
+            jsonData = shell.command("/bin/cat", arguments: [podspecName + ".podspec.json"]).standardOutputData
+        } else if hasPodspec() {
             let podBin = whichPod.components(separatedBy: "\n")[0]
             jsonData = shell.command(podBin, arguments: ["ipc", "spec", podspecName + ".podspec"]).standardOutputData
-        } else if hasPodspecJson() {
-            jsonData = shell.command("/bin/cat", arguments: [podspecName + ".podspec.json"]).standardOutputData
         } else {
             fatalError("Missing podspec!")
         }
@@ -300,18 +300,20 @@ public enum RepoActions {
         // Batch create several symlinks for Pod style includes
         // creating thousands of processes in few milliseconds will
         // blow up otherwise.
+        let currentDirectoryPath = FileManager.default.currentDirectoryPath
         let globResults = Set(globResultsArr)
         customHeaderSearchPaths.forEach { searchPath in
-            var script = "cd " + searchPath + ";\n"
+            let linkPath = currentDirectoryPath + "/" + searchPath
+            guard FileManager.default.changeCurrentDirectoryPath(linkPath) else {
+                print("Can't change path while creating symlink")
+                return
+            }
             globResults.forEach { globResult in
                 // i.e. pod_support/Headers/Public/__POD_NAME__
-                let from = "\"../../../../\(globResult)\""
-                let to =  String(globResult.split(separator: "/").last!)
-                script += "ln -sf \(from) \(to);\n"
+                let from = "../../../../\(globResult)"
+                let to = String(globResult.split(separator: "/").last!)
+                shell.symLink(from: from, to: to)
             }
-            // Run the script without checking exit codes. It's possible that pods
-            // contain garbage that Xcode previously dealt with.
-            let _ = shell.shellOut(script)
         }
 
         // Write out contents of PodSupportBuildableDir


### PR DESCRIPTION
Due to calling `ln` via our shell bridge cannot handle symlinking boost headers we should move to use `FileManager`
- Use FileManager API for creating symbolic links
- Prefer `.podspec.json` in advance of `.podspec`
- Small cleanup