### PR TITLE
Use Vendor instead of external for XCConfig Transform

### DIFF
--- a/Sources/PodToBUILD/XCConfig.swift
+++ b/Sources/PodToBUILD/XCConfig.swift
@@ -109,7 +109,8 @@ public struct HeaderSearchPathTransformer: XCConfigValueTransformer {
     }
     
     public func string(forXCConfigValue value: String) -> String {
-        let cleaned = value.replacingOccurrences(of: "$(PODS_TARGET_SRCROOT)", with: "external/\(externalName)").replacingOccurrences(of: "\"", with: "")
+        let cleaned = value.replacingOccurrences(of: "$(PODS_TARGET_SRCROOT)",
+            with: "Vendor/\(externalName)").replacingOccurrences(of: "\"", with: "")
         return "-I\(cleaned)"
     }
 }


### PR DESCRIPTION
Previously we built ontop of Bazel's WORKSPACE rules and external. This
is a missed opportunity from that refactor.