### PR TITLE
Setup end to end testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: generic
 os:
   - osx
-sudo: false
+before_install:
+  - sudo gem install cocoapods
 osx_image: xcode9.3
-script: make test
+script: make ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# PodToBUILD requires CocoaPods installed onto the path
+# Gems is one way to install it.
+source 'https://rubygems.org'
+gem 'cocoapods', '1.1.1'
+

--- a/Package.swift
+++ b/Package.swift
@@ -45,5 +45,10 @@ let package = Package(
         .testTarget(
             name: "PodToBUILDTests",
             dependencies: ["RepoToolsCore", "SwiftCheck"]),
+        .testTarget(
+            name: "BuildTests",
+            // We only depend on this for the shell lib.
+            // TODO: Factor that out.
+            dependencies: ["RepoToolsCore"]),
     ]
 )

--- a/Tests/BuildTests/BuildTest.swift
+++ b/Tests/BuildTests/BuildTest.swift
@@ -1,0 +1,76 @@
+//
+//  BuildTest.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 6/18/18.
+//  Copyright © 2017 Pinterest Inc. All rights reserved.
+//
+
+import XCTest
+@testable import PodToBUILD
+import Foundation
+
+class BuildTests: XCTestCase {
+    let shell = SystemShellContext(trace: true)
+    let bazelVersion = "0.12.0rc1"
+
+    /// Build Tests: Test that a given Pod can build end to end.
+    /// 1) Setup a test workspace.
+    /// 2) Copy over the Pods.WORKSPACE for the given example case.
+    /// 3) Run bazel and check output.
+    /// Ideally: we can build all of the specs:
+    /// `bazel build //Vendor/Pod:*`
+    func build(pod: String, specs: [String] = ["*"]) {
+        let components = #file .split(separator: "/")
+        let rootDir = "/" + components [0 ... components.count - 4].joined(separator: "/")
+
+        // Warning: we don't totally tear down the sandbox after every
+        // test method invocation.
+        // This is an implementation detail and in a way, is ideal for an
+        // integration test due to the nature of how the user is constantly
+        // changing and updating cocoapods.
+        let sandbox = "/var/tmp/PodTestSandbox"
+        let podSandbox = sandbox + "/Vendor/\(pod)"
+        shell.dir(podSandbox)
+        shell.shellOut("ditto $PWD \(sandbox)/Vendor/rules_pods")
+        shell.shellOut("ditto \(rootDir)/Tests/BuildTests/Examples/\(pod)/Pods.WORKSPACE \(sandbox)/Pods.WORKSPACE")
+        let task = ShellTask(command: "/bin/bash", arguments: [
+                "-c", sandbox +
+                "/Vendor/rules_pods/bin/update_pods.py --src_root \(sandbox)"
+                ], timeout: 1200.0)
+        let result = task.launch()
+        XCTAssertEqual(result.terminationStatus, 0)
+        print("PodUpdate Result:", result.standardOutputAsString)
+        print("PodUpdate Result:", result.standardErrorAsString)
+        guard result.terminationStatus == 0 else {
+            fatalError("Can't setup test root")
+        }
+
+        // Setup the bazel directory
+        shell.shellOut("touch \(sandbox)/WORKSPACE")
+        shell.shellOut("touch \(sandbox)/BUILD")
+        shell.shellOut("touch \(sandbox)/Vendor/BUILD")
+        specs.forEach {
+            spec in
+            let label = "//Vendor/\(pod):\(spec)"
+            let bazelScript = "~/.bazelenv/versions/\(bazelVersion)/bin/bazel build \(label)"
+            print("running bazel:", bazelScript)
+            let buildResult = ShellTask(command: "/bin/bash", arguments: [
+                    "-c", bazelScript ], timeout: 1200.0, cwd: sandbox).launch()
+            XCTAssertEqual(buildResult.terminationStatus, 0, "building \(label)")
+            print("Bazel completed with stderror:", buildResult.standardErrorAsString)
+            print("Bazel completed with stdout:", buildResult.standardOutputAsString)
+
+            // For now, we assume that the if bazel exits with 0 it passed.
+            if buildResult.terminationStatus != 0 {
+                print("Bazel failed with stderror:", buildResult.standardErrorAsString)
+                print("Bazel failed with stdout:", buildResult.standardOutputAsString)
+            }
+        }
+    }
+
+    func testPINRemoteImage() {
+        build(pod: "PINRemoteImage", specs: ["Core"])
+    }
+}
+

--- a/Tests/BuildTests/Examples/PINRemoteImage/Pods.WORKSPACE
+++ b/Tests/BuildTests/Examples/PINRemoteImage/Pods.WORKSPACE
@@ -1,0 +1,21 @@
+new_pod_repository(
+  name = "PINRemoteImage",
+  url = "https://github.com/pinterest/PINRemoteImage/archive/a06b4746ebbe45c87c2b449e8a40a6b7ddf96051.zip",
+  # PINRemoteImage_Core conditionally compiles in PINCache based on these
+  # headers
+  user_options = ["Core.deps += //Vendor/PINCache:PINCache"],
+
+  # TODO:
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "PINOperation",
+  url = "https://github.com/pinterest/PINOperation/archive/1.1.zip"
+)
+
+new_pod_repository(
+  name = "PINCache",
+  url = "https://github.com/pinterest/PINCache/archive/d886490de6d297e38f80bb750ff2dec4822fb870.zip"
+)
+


### PR DESCRIPTION
This patch adds end to end testing for PodToBUILD.

We want to be certian, that a given Pod can build end to end.

Process:
0) Install Bazel onto host.
1) Setup a test workspace.
2) Copy over the Pods.WORKSPACE for the given example case.
3) Run bazel and check output.

It instruments the first example for PINRemoteImage as an example, more
to come soon.