### PR TITLE
Public transitive headermap rule first pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/Compiler
 bin/RepoTools
 compile_commands.json
 *.xcode_select_env
+*.pyc

--- a/BazelExtensions/BUILD
+++ b/BazelExtensions/BUILD
@@ -21,3 +21,9 @@ sh_library(
     visibility = ["//visibility:public"]
 )
 
+py_binary(
+    name = "headermap_builder",
+    srcs = ["headermap_builder.py", "headermap_tool.py"],
+    visibility = ["//visibility:public"]
+)
+

--- a/BazelExtensions/LLVM.LICENSE.TXT
+++ b/BazelExtensions/LLVM.LICENSE.TXT
@@ -1,0 +1,69 @@
+==============================================================================
+LLVM Release License
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2010 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+Copyrights and Licenses for Third Party Software Distributed with LLVM:
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+
+The following pieces of software have additional or alternate copyrights,
+licenses, and/or restrictions:
+
+Program             Directory
+-------             ---------
+Autoconf            llvm/autoconf
+                    llvm/projects/ModuleMaker/autoconf
+                    llvm/projects/sample/autoconf
+CellSPU backend     llvm/lib/Target/CellSPU/README.txt
+Google Test         llvm/utils/unittest/googletest
+OpenBSD regex       llvm/lib/Support/{reg*, COPYRIGHT.regex}

--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -233,8 +233,10 @@ def _make_headermap_impl(ctx):
     inputs = [json_f]
 
     # Extract propagated headermaps
-    # FIXME: Add safety around this
     for hdr_provider in ctx.attr.deps:
+        if not hasattr(hdr_provider, "objc"):
+            continue
+
         hdrs = hdr_provider.objc.header.to_list()
         for hdr in hdrs:
             if hdr.path.endswith(".hmap"):

--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -20,7 +20,7 @@ def _acknowledgement_merger_impl(ctx):
         args.append(f.path)
 
     # Write the final output. Bazel only writes the file when required
-    ctx.action(
+    ctx.actions.run_shell(
         inputs=concat,
         arguments=args,
         executable=ctx.attr.merger.files.to_list()[0],
@@ -112,15 +112,17 @@ def pch_with_name_hint(hint, sources):
     return None
 
 
-def _make_module_map(pod_name, module_name, hdr_providers):
+def _make_module_map(pod_name, module_name, deps):
     # Up some dirs to the compilation root
     # bazel-out/ios_x86_64-fastbuild/genfiles/external/__Pod__
     relative_path = "../../../../../../"
 
     template = "module " + module_name + " {\n"
     template += "    export * \n"
-    for provider in hdr_providers:
+    for provider in deps:
         for input_file in provider.files.to_list():
+            if input_file.path.endswith(".hmap"):
+                continue
             hdr = input_file
             template += "    header \"%s%s\"\n" % (relative_path, hdr.path)
     template += "}\n"
@@ -177,22 +179,115 @@ def gen_module_map(pod_name,
                     tags=tags)
 
 def _gen_includes_impl(ctx):
+    includes = []
+    includes.extend(ctx.attr.include)
+    for target in ctx.attr.include_files:
+        for f in target.files:
+            includes.append(f.path)
+
     return apple_common.new_objc_provider(
-            include=depset(ctx.attr.include))
+            include=depset(includes))
 
 _gen_includes = rule(
     implementation=_gen_includes_impl,
     attrs = {
         "include": attr.string_list(mandatory=True),
+        "include_files": attr.label_list(mandatory=True),
     }
 )
 
 def gen_includes(name,
-                 include,
+                 include=[],
+                 include_files=[],
                  tags=["xchammer"],
                  visibility=["//visibility:public"]):
     _gen_includes(name=name,
                   include=include,
+                  include_files=include_files,
                   tags=tags,
                   visibility=visibility)
+
+
+def _make_headermap_json(namespace, hdrs):
+    mappings = {}
+    for provider in hdrs:
+        for input_file in provider.files.to_list():
+            hdr = input_file
+            namespaced_key = namespace + "/" + hdr.basename
+            mappings[namespaced_key] = hdr.path
+            mappings[hdr.basename] = hdr.path
+    return struct(mappings=mappings).to_json()
+
+
+def _make_headermap_impl(ctx):
+    # Write a JSON file for *this* headermap
+    json_f = ctx.actions.declare_file(ctx.label.name + "_internal.json")
+    out = _make_headermap_json(ctx.attr.namespace, ctx.attr.hdrs)
+    ctx.actions.write(
+        content=out,
+        output=json_f
+    )
+
+    # Add a list of headermaps in JSON or hmap format
+    args = [ctx.outputs.headermap.path, json_f.path]
+    inputs = [json_f]
+
+    # Extract propagated headermaps
+    # FIXME: Add safety around this
+    for hdr_provider in ctx.attr.deps:
+        hdrs = hdr_provider.objc.header.to_list()
+        for hdr in hdrs:
+            if hdr.path.endswith(".hmap"):
+                # Add headermaps
+                inputs.append(hdr)
+                args.append(hdr.path)
+
+    ctx.actions.run(
+        inputs=inputs,
+        arguments=args,
+        executable=ctx.attr.headermap_builder.files.to_list()[0],
+        outputs=[ctx.outputs.headermap]
+    )
+
+    objc_provider = apple_common.new_objc_provider(
+        header=depset([ctx.outputs.headermap]),
+    )
+    return struct(
+        files=depset([ctx.outputs.headermap]),
+        providers=[objc_provider],
+        objc=objc_provider,
+        headers=depset([ctx.outputs.headermap]),
+    )
+
+def headermap(
+    tags=["xchammer"],**kwargs):
+    _headermap(tags=tags, **kwargs)
+
+# Derive a headermap from transitive headermaps
+# hdrs: a file group containing headers for this rule
+# namespace: the Apple style namespace these header should be under
+# deps: rules providing headers. i.e. an `objc_library`
+# Note: this intententionally does not propgate the include. We don't want to
+# end up with O(N) includes.
+# The pattern in PodToBUILD is:
+# - Add all deps to a headermap
+# - Include the headermap
+# TODO(Add the ability to disallow propagation of "internal" includes )
+# e.g. "MyLib.h" instead of <MyLib/MyLib.h>
+_headermap = rule(
+    implementation=_make_headermap_impl,
+    output_to_genfiles=True,
+    attrs={
+        "namespace": attr.string(mandatory=True),
+        "hdrs": attr.label_list(mandatory=True),
+        "deps": attr.label_list(mandatory=False),
+        "headermap_builder": attr.label(
+            executable=True,
+            cfg="host",
+            default=Label(
+                "//Vendor/rules_pods/BazelExtensions:headermap_builder"),
+        )
+    },
+    outputs={"headermap": "%{name}.hmap"}
+)
 

--- a/BazelExtensions/headermap_builder.py
+++ b/BazelExtensions/headermap_builder.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import json
+import optparse
+import os
+import struct
+import sys
+import headermap_tool
+
+# The data structure that LLVM uses is { mappings: { name: path } }
+
+
+def main():
+    """ Helper program for headermap rule"""
+    output_path = sys.argv[1]
+    json_path = sys.argv[2]
+
+    if len(sys.argv) == 3:
+        headermap_tool.action_write("write", [json_path, output_path])
+        return
+
+    # We write an intermediate JSON file, which represents the trans hmap
+    merge_file = "intermediate.json"
+    with open(json_path, "r") as f:
+        input_data = json.load(f)
+        # For every additional headermap, read it in and merge
+        for path in sys.argv[3:]:
+            add_hmap = headermap_tool.HeaderMap.frompath(path)
+            for mapping in add_hmap.mappings:
+                input_data["mappings"][mapping[0]] = mapping[1]
+
+        with open(merge_file, "w") as f:
+            json.dump(input_data, f, indent=2)
+
+    try:
+        headermap_tool.action_write("write", [merge_file, output_path])
+    except:
+        # It's possible to hit an empty hmap.
+        # Consider having a warning
+        headermap_tool.action_write("write", [json_path, output_path])
+
+if __name__ == '__main__':
+    main()

--- a/BazelExtensions/headermap_tool.py
+++ b/BazelExtensions/headermap_tool.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+# This file is part of The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See BazelExtensions/LLVM.LICENSE.TXT for details.
+
+from __future__ import print_function
+
+import json
+import optparse
+import os
+import struct
+import sys
+
+###
+
+k_header_magic_LE = 'pamh'
+k_header_magic_BE = 'hmap'
+
+def hmap_hash(str):
+    """hash(str) -> int
+
+    Apply the "well-known" headermap hash function.
+    """
+
+    return sum((ord(c.lower()) * 13
+                for c in str), 0)
+
+class HeaderMap(object):
+    @staticmethod
+    def frompath(path):
+        with open(path, 'rb') as f:
+            magic = f.read(4)
+            if magic == k_header_magic_LE:
+                endian_code = '<'
+            elif magic == k_header_magic_BE:
+                endian_code = '>'
+            else:
+                raise SystemExit("error: %s: not a headermap" % (
+                        path,))
+
+            # Read the header information.
+            header_fmt = endian_code + 'HHIIII'
+            header_size = struct.calcsize(header_fmt)
+            data = f.read(header_size)
+            if len(data) != header_size:
+                raise SystemExit("error: %s: truncated headermap header" % (
+                        path,))
+
+            (version, reserved, strtable_offset, num_entries,
+             num_buckets, max_value_len) = struct.unpack(header_fmt, data)
+
+            if version != 1:
+                raise SystemExit("error: %s: unknown headermap version: %r" % (
+                        path, version))
+            if reserved != 0:
+                raise SystemExit("error: %s: invalid reserved value in header" % (
+                        path,))
+
+            # The number of buckets must be a power of two.
+            if num_buckets == 0 or (num_buckets & num_buckets - 1) != 0:
+                raise SystemExit("error: %s: invalid number of buckets" % (
+                        path,))
+
+            # Read all of the buckets.
+            bucket_fmt = endian_code + 'III'
+            bucket_size = struct.calcsize(bucket_fmt)
+            buckets_data = f.read(num_buckets * bucket_size)
+            if len(buckets_data) != num_buckets * bucket_size:
+                raise SystemExit("error: %s: truncated headermap buckets" % (
+                        path,))
+            buckets = [struct.unpack(bucket_fmt,
+                                     buckets_data[i*bucket_size:(i+1)*bucket_size])
+                       for i in range(num_buckets)]
+
+            # Read the string table; the format doesn't explicitly communicate the
+            # size of the string table (which is dumb), so assume it is the rest of
+            # the file.
+            f.seek(0, 2)
+            strtable_size = f.tell() - strtable_offset
+            f.seek(strtable_offset)
+
+            if strtable_size == 0:
+                raise SystemExit("error: %s: unable to read zero-sized string table"%(
+                        path,))
+            strtable = f.read(strtable_size)
+
+            if len(strtable) != strtable_size:
+                raise SystemExit("error: %s: unable to read complete string table"%(
+                        path,))
+            if strtable[-1] != '\0':
+                raise SystemExit("error: %s: invalid string table in headermap" % (
+                        path,))
+
+            return HeaderMap(num_entries, buckets, strtable)
+
+    def __init__(self, num_entries, buckets, strtable):
+        self.num_entries = num_entries
+        self.buckets = buckets
+        self.strtable = strtable
+
+    def get_string(self, idx):
+        if idx >= len(self.strtable):
+            raise SystemExit("error: %s: invalid string index" % (
+                    path,))
+        end_idx = self.strtable.index('\0', idx)
+        return self.strtable[idx:end_idx]
+
+    @property
+    def mappings(self):
+        for key_idx,prefix_idx,suffix_idx in self.buckets:
+            if key_idx == 0:
+                continue
+            yield (self.get_string(key_idx),
+                   self.get_string(prefix_idx) + self.get_string(suffix_idx))
+
+###
+
+def action_dump(name, args):
+    "dump a headermap file"
+
+    parser = optparse.OptionParser("%%prog %s [options] <headermap path>" % (
+            name,))
+    parser.add_option("-v", "--verbose", dest="verbose",
+                      help="show more verbose output [%default]",
+                      action="store_true", default=False)
+    (opts, args) = parser.parse_args(args)
+
+    if len(args) != 1:
+        parser.error("invalid number of arguments")
+
+    path, = args
+
+    hmap = HeaderMap.frompath(path)
+
+    # Dump all of the buckets.
+    print ('Header Map: %s' % (path,))
+    if opts.verbose:
+        print ('headermap: %r' % (path,))
+        print ('  num entries: %d' % (hmap.num_entries,))
+        print ('  num buckets: %d' % (len(hmap.buckets),))
+        print ('  string table size: %d' % (len(hmap.strtable),))
+        for i,bucket in enumerate(hmap.buckets):
+            key_idx,prefix_idx,suffix_idx = bucket
+
+            if key_idx == 0:
+                continue
+
+            # Get the strings.
+            key = hmap.get_string(key_idx)
+            prefix = hmap.get_string(prefix_idx)
+            suffix = hmap.get_string(suffix_idx)
+
+            print ("  bucket[%d]: %r -> (%r, %r) -- %d" % (
+                i, key, prefix, suffix, (hmap_hash(key) & (num_buckets - 1))))
+    else:
+        mappings = sorted(hmap.mappings)
+        for key,value in mappings:
+            print ("%s -> %s" % (key, value))
+    print ()
+
+def next_power_of_two(value):
+    if value < 0:
+        raise ArgumentError
+    return 1 if value == 0 else 2**(value - 1).bit_length()
+
+def action_write(name, args):
+    "write a headermap file from a JSON definition"
+
+    parser = optparse.OptionParser("%%prog %s [options] <input path> <output path>" % (
+            name,))
+    (opts, args) = parser.parse_args(args)
+
+    if len(args) != 2:
+        parser.error("invalid number of arguments")
+
+    input_path,output_path = args
+
+    with open(input_path, "r") as f:
+        input_data = json.load(f)
+
+    # Compute the headermap contents, we make a table that is 1/3 full.
+    mappings = input_data['mappings']
+    num_buckets = next_power_of_two(len(mappings) * 3)
+
+    table = [(0, 0, 0)
+             for i in range(num_buckets)]
+    max_value_len = 0
+    strtable = "\0"
+    for key,value in mappings.items():
+        if not isinstance(key, str):
+            key = key.decode('utf-8')
+        if not isinstance(value, str):
+            value = value.decode('utf-8')
+        max_value_len = max(max_value_len, len(value))
+
+        key_idx = len(strtable)
+        strtable += key + '\0'
+        prefix = os.path.dirname(value) + '/'
+        suffix = os.path.basename(value)
+        prefix_idx = len(strtable)
+        strtable += prefix + '\0'
+        suffix_idx = len(strtable)
+        strtable += suffix + '\0'
+
+        hash = hmap_hash(key)
+        for i in range(num_buckets):
+            idx = (hash + i) % num_buckets
+            if table[idx][0] == 0:
+                table[idx] = (key_idx, prefix_idx, suffix_idx)
+                break
+        else:
+            raise RuntimeError
+
+    endian_code = '<'
+    magic = k_header_magic_LE
+    magic_size = 4
+    header_fmt = endian_code + 'HHIIII'
+    header_size = struct.calcsize(header_fmt)
+    bucket_fmt = endian_code + 'III'
+    bucket_size = struct.calcsize(bucket_fmt)
+    strtable_offset = magic_size + header_size + num_buckets * bucket_size
+    header = (1, 0, strtable_offset, len(mappings),
+              num_buckets, max_value_len)
+
+    # Write out the headermap.
+    with open(output_path, 'wb') as f:
+        f.write(magic.encode())
+        f.write(struct.pack(header_fmt, *header))
+        for bucket in table:
+            f.write(struct.pack(bucket_fmt, *bucket))
+        f.write(strtable.encode())
+
+def action_tovfs(name, args):
+    "convert a headermap to a VFS layout"
+
+    parser = optparse.OptionParser("%%prog %s [options] <headermap path>" % (
+            name,))
+    parser.add_option("", "--build-path", dest="build_path",
+                      help="build path prefix",
+                      action="store", type=str)
+    (opts, args) = parser.parse_args(args)
+
+    if len(args) != 2:
+        parser.error("invalid number of arguments")
+    if opts.build_path is None:
+        parser.error("--build-path is required")
+
+    input_path,output_path = args
+
+    hmap = HeaderMap.frompath(input_path)
+
+    # Create the table for all the objects.
+    vfs = {}
+    vfs['version'] = 0
+    build_dir_contents = []
+    vfs['roots'] = [{
+            'name' : opts.build_path,
+            'type' : 'directory',
+            'contents' : build_dir_contents }]
+
+    # We assume we are mapping framework paths, so a key of "Foo/Bar.h" maps to
+    # "<build path>/Foo.framework/Headers/Bar.h".
+    for key,value in hmap.mappings:
+        # If this isn't a framework style mapping, ignore it.
+        components = key.split('/')
+        if len(components) != 2:
+            continue
+        framework_name,header_name = components
+        build_dir_contents.append({
+                'name' : '%s.framework/Headers/%s' % (framework_name,
+                                                      header_name),
+                'type' : 'file',
+                'external-contents' : value })
+
+    with open(output_path, 'w') as f:
+        json.dump(vfs, f, indent=2)
+
+commands = dict((name[7:].replace("_","-"), f)
+                for name,f in locals().items()
+                if name.startswith('action_'))
+
+def usage():
+    print ("Usage: %s command [options]" % (
+        os.path.basename(sys.argv[0])), file=sys.stderr)
+    print (file=sys.stderr)
+    print ("Available commands:", file=sys.stderr)
+    cmds_width = max(map(len, commands))
+    for name,func in sorted(commands.items()):
+        print ("  %-*s - %s" % (cmds_width, name, func.__doc__), file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in commands:
+        usage()
+
+    cmd = sys.argv[1]
+    commands[cmd](cmd, sys.argv[2:])
+
+if __name__ == '__main__':
+    main()

--- a/Examples/.gitignore
+++ b/Examples/.gitignore
@@ -1,1 +1,3 @@
-*/Vendor
+!*/Vendor/PodSpecs/*
+*/Vendor/
+

--- a/Examples/PINRemoteImage/Pods.WORKSPACE
+++ b/Examples/PINRemoteImage/Pods.WORKSPACE
@@ -6,16 +6,19 @@ new_pod_repository(
   user_options = ["Core.deps += //Vendor/PINCache:PINCache"],
 
   # TODO:
-  generate_module_map = False
+  generate_module_map = False,
+  generate_header_map = True
 )
 
 new_pod_repository(
   name = "PINOperation",
-  url = "https://github.com/pinterest/PINOperation/archive/1.1.zip"
+  url = "https://github.com/pinterest/PINOperation/archive/1.1.zip",
+  generate_header_map = True
 )
 
 new_pod_repository(
   name = "PINCache",
-  url = "https://github.com/pinterest/PINCache/archive/d886490de6d297e38f80bb750ff2dec4822fb870.zip"
+  url = "https://github.com/pinterest/PINCache/archive/d886490de6d297e38f80bb750ff2dec4822fb870.zip",
+  generate_header_map = True
 )
 

--- a/Examples/React/BUILD
+++ b/Examples/React/BUILD
@@ -6,4 +6,5 @@ objc_library(name="all", deps=[
     "//Vendor/React:RCTNetwork",
     "//Vendor/React:RCTText",
     "//Vendor/React:RCTWebSocket",
-    "//Vendor/React:RCTAnimation"])
+    "//Vendor/React:RCTAnimation",
+    "//Vendor/React:RCTLinkingIOS"])

--- a/Examples/React/Pods.WORKSPACE
+++ b/Examples/React/Pods.WORKSPACE
@@ -2,66 +2,107 @@ new_pod_repository(
   name = "boost-for-react-native",
   url = 'https://github.com/react-native-community/boost-for-react-native/archive/v1.63.0-0.zip',
   # This podspec isn't included in the http archives of boost.
-  podspec_url = 'PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec',
+  podspec_url = 'Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec',
   generate_module_map = False,
   install_script = """
     __INIT_REPO__
-    # TODO: We need to add the ability to not generate this dir.
-    rm -rf pod_support/Headers/Public/boost
+    # This isn't actually necessary but nice.
+    rm -rf pod_support/Headers/Public/*
   """,
 )
 
-new_pod_repository(
-  name = "Folly",
-  podspec_url = "PodSpecs/react-0.57/third-party-podspecs/Folly.podspec",
-  url = "https://github.com/facebook/folly/archive/v2016.09.26.00.zip",
-  generate_module_map = False
-)
-
-new_pod_repository(
-  name = "DoubleConversion",
-  url = 'https://github.com/google/double-conversion/archive/v1.1.5.zip',
-  podspec_url = 'PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec',
-  install_script = """
-    # prepare_command
-    mv src double-conversion
-    __INIT_REPO__
-  """,
-
-  generate_module_map = False
-)
-
-new_pod_repository(
-  name = "glog",
-  url = 'https://github.com/google/glog/archive/v0.3.4.zip',
-  podspec_url = 'PodSpecs/react-0.57/third-party-podspecs/GLog.podspec',
-  install_script = """
-    # prepare_command
-    pwd
-    sh ../../PodSpecs/glog-0.3.4/ios-configure-glog.sh || exit 1
-  	__INIT_REPO__
-  """,
-  generate_module_map = False
-)
-
-# Prior, required manual changes
-# - Copy over third-party-podspecs to Podspecs
+# Prior hacks for podspecs
+# - Copy over third-party-podspecs to Vendor/Podspecs
 # - Comment out busted prepare commands
+
+# Apply this patch for headermaps to work.
+# Will fix in a followup
+"""
+$ diff -Naru Vendor/React/BUILD /tmp/React.base.BUILD
+--- Vendor/React/BUILD  2019-10-01 12:47:05.000000000 -0700
++++ /tmp/React.base.BUILD       2019-10-01 12:45:04.000000000 -0700
+@@ -3057,9 +3057,7 @@
+   name = "RCTBlob_cxx_hmap",
+   namespace = "React",
+   hdrs = [
+-    ":RCTBlob_cxx_union_hdrs",
+-    ":RCTNetwork_union_hdrs",
+-    ":RCTWebSocket_union_hdrs"
++    ":RCTBlob_cxx_union_hdrs"
+   ],
+   hdr_providers = [
+     ":Core"
+"""
+
 new_pod_repository(
   name = "React",
-  url = 'https://github.com/facebook/react-native/archive/v0.57.0.zip',
+  owner = "@ios-cx",
+  url = 'https://github.com/facebook/react-native/archive/v0.59.10.zip',
   user_options = [
-    # TODO: https://github.com/pinterest/PodToBUILD/issues/51
+    # TODO: If Xcode is compiling CppLike with this standard, P2B should too.
+    "CxxBridge_cxx.copts += -std=c++14",
+    "cxxreact.copts += -std=c++14",
     "jsinspector.copts += -std=c++14",
+    "jsiexecutor.copts += -std=c++14",
+    "jsi.copts += -std=c++14",
+    "Core_cxx.deps += //Vendor/Folly:Folly",
   ],
 
   # Module map doesn't work because it seems to be expecting the folly library
   generate_module_map = False,
   inhibit_warnings = True,
+  generate_header_map = True
 )
 
 new_pod_repository(
+  name = "Folly",
+  owner = "@ios-cx",
+  podspec_url = "Vendor/PodSpecs/react-0.59/third-party-podspecs/Folly.podspec",
+  url = 'https://github.com/facebook/folly/archive/v2018.10.22.00.zip',
+  install_script = """
+    # Force folly demangler off, we don't need it and it's being incorrectly enabled causing compile errors.
+    /usr/bin/sed -i '' 's/FOLLY_DETAIL_HAVE_DEMANGLE_H 1/FOLLY_DETAIL_HAVE_DEMANGLE_H 0 \/\/ PINTEREST HACK, SEE Pods.WORKSPACE/g' folly/detail/Demangle.h
+    # Rename 'build' directory temporarily as its name conflicts with bazel generated BUILD file.
+    # Better future solution is to update P2B to export BUILD.bazel files.
+    mv build build.orig
+    __INIT_REPO__
+    mv BUILD BUILD.bazel
+    mv build.orig build
+  """,
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "DoubleConversion",
+  url = 'https://github.com/google/double-conversion/archive/v1.1.6.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.59/third-party-podspecs/DoubleConversion.podspec',
+  install_script = """
+    # prepare_command
+    mv src double-conversion
+    __INIT_REPO__
+  """,
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "glog",
+  url = 'https://github.com/google/glog/archive/v0.3.5.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.59/third-party-podspecs/glog.podspec',
+  install_script = """
+    # prepare_command
+  	sh ../PodSpecs/glog-0.3.5/ios-configure-glog.sh
+  	__INIT_REPO__
+  """,
+  generate_module_map = False,
+  # See above patch
+  # generate_header_map = True
+)
+
+
+# WARNING: the version of react-native here doesn't match up with yoga.
+new_pod_repository(
   name = "yoga",
+  owner = "@ios-cx",
   url = 'https://github.com/facebook/react-native/archive/v0.55.4.zip',
   strip_prefix = 'react-native-0.55.4/ReactCommon/yoga',
   install_script = """
@@ -69,8 +110,9 @@ new_pod_repository(
     # because the evaluation of the podspec in Ruby will fail. The package parameter
     # points to a JSON.parse of a file outside the yoga sandbox.
     /usr/bin/sed -i "" "s,^package.*,package = { 'version' => '0.46.3' },g" Yoga.podspec
-  	__INIT_REPO__
+    __INIT_REPO__
   """,
-
-  generate_module_map = False
+  generate_module_map = False,
+  generate_header_map = True
 )
+

--- a/Examples/React/Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
+++ b/Examples/React/Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost-for-react-native'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+end

--- a/Examples/React/Vendor/PodSpecs/boost-react-native-1.63.0-0/boost.podspec
+++ b/Examples/React/Vendor/PodSpecs/boost-react-native-1.63.0-0/boost.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+  spec.source_files = 'boost/boost/*.hpp'
+end

--- a/Examples/React/Vendor/PodSpecs/glog-0.3.5/ios-configure-glog.sh
+++ b/Examples/React/Vendor/PodSpecs/glog-0.3.5/ios-configure-glog.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+CURRENT_ARCH="${CURRENT_ARCH}"
+
+if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
+    # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
+    # it's better to rely on platform name as fallback because architecture differs between simulator and device
+
+    if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
+        CURRENT_ARCH="x86_64"
+    else
+        CURRENT_ARCH="armv7"
+    fi
+fi
+
+export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+export CXX="$CC"
+
+# Remove automake symlink if it exists
+if [ -h "test-driver" ]; then
+    rm test-driver
+fi
+
+./configure --host arm-apple-darwin
+
+# Fix build for tvOS
+cat << EOF >> src/config.h
+
+/* Add in so we have Apple Target Conditionals */
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <Availability.h>
+#endif
+
+/* Special configuration for AppleTVOS */
+#if TARGET_OS_TV
+#undef HAVE_SYSCALL_H
+#undef HAVE_SYS_SYSCALL_H
+#undef OS_MACOSX
+#endif
+
+/* Special configuration for ucontext */
+#undef HAVE_UCONTEXT_H
+#undef PC_FROM_UCONTEXT
+#if defined(__x86_64__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip
+#elif defined(__i386__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip
+#endif
+EOF
+
+# Prepare exported header include
+EXPORTED_INCLUDE_DIR="exported/glog"
+mkdir -p exported/glog
+cp -f src/glog/log_severity.h "$EXPORTED_INCLUDE_DIR/"
+cp -f src/glog/logging.h "$EXPORTED_INCLUDE_DIR/"
+cp -f src/glog/raw_logging.h "$EXPORTED_INCLUDE_DIR/"
+cp -f src/glog/stl_logging.h "$EXPORTED_INCLUDE_DIR/"
+cp -f src/glog/vlog_is_on.h "$EXPORTED_INCLUDE_DIR/"

--- a/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/DoubleConversion.podspec
+++ b/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/DoubleConversion.podspec
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+  spec.name = 'DoubleConversion'
+  spec.version = '1.1.6'
+  spec.license = { :type => 'MIT' }
+  spec.homepage = 'https://github.com/google/double-conversion'
+  spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
+  spec.authors = 'Google'
+  spec.prepare_command = 'mv src double-conversion'
+  spec.source = { :git => 'https://github.com/google/double-conversion.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'DoubleConversion'
+  spec.source_files = 'double-conversion/*.{h,cc}'
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/Folly.podspec
+++ b/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/Folly.podspec
@@ -1,0 +1,53 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+  spec.name = 'Folly'
+  spec.version = '2018.10.22.00'
+  spec.license = { :type => 'Apache License, Version 2.0' }
+  spec.homepage = 'https://github.com/facebook/folly'
+  spec.summary = 'An open-source C++ library developed and used at Facebook.'
+  spec.authors = 'Facebook'
+  spec.source = { :git => 'https://github.com/facebook/folly.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'folly'
+  spec.dependency 'boost-for-react-native'
+  spec.dependency 'DoubleConversion'
+  spec.dependency 'glog'
+  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+  spec.source_files = 'folly/String.cpp',
+                      'folly/Conv.cpp',
+                      'folly/Demangle.cpp',
+                      'folly/Format.cpp',
+                      'folly/ScopeGuard.cpp',
+                      'folly/Unicode.cpp',
+                      'folly/dynamic.cpp',
+                      'folly/json.cpp',
+                      'folly/json_pointer.cpp',
+                      'folly/container/detail/F14Table.cpp',
+                      'folly/detail/Demangle.cpp',
+                      'folly/hash/SpookyHashV2.cpp',
+                      'folly/lang/Assume.cpp',
+                      'folly/lang/ColdClass.cpp',
+                      'folly/memory/detail/MallocImpl.cpp'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'folly/*.h',
+                        'folly/container/*.h',
+                        'folly/container/detail/*.h',
+                        'folly/detail/*.h',
+                        'folly/functional/*.h',
+                        'folly/hash/*.h',
+                        'folly/lang/*.h',
+                        'folly/memory/*.h',
+                        'folly/memory/detail/*.h',
+                        'folly/portability/*.h'
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\"" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+end

--- a/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/glog.podspec
+++ b/Examples/React/Vendor/PodSpecs/react-0.59/third-party-podspecs/glog.podspec
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+  spec.name = 'glog'
+  spec.version = '0.3.5'
+  spec.license = { :type => 'Google', :file => 'COPYING' }
+  spec.homepage = 'https://github.com/google/glog'
+  spec.summary = 'Google logging module'
+  spec.authors = 'Google'
+
+  # spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
+  spec.source = { :git => 'https://github.com/google/glog.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'glog'
+  spec.header_dir = 'glog'
+  spec.source_files = 'src/glog/*.h',
+                      'src/demangle.cc',
+                      'src/logging.cc',
+                      'src/raw_logging.cc',
+                      'src/signalhandler.cc',
+                      'src/symbolize.cc',
+                      'src/utilities.cc',
+                      'src/vlog_is_on.cc'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'src/*.h',
+                        'src/base/*.h'
+  spec.exclude_files       = "src/windows/**/*"
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -36,6 +37,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Adjust_hmap",
+  namespace = "Adjust",
+  hdrs = [
+    ":Adjust_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -126,6 +140,17 @@ filegroup(
     "Core_hdrs",
     "Adjust_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_hmap",
+  namespace = "Adjust",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -223,6 +248,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Sociomantic_hmap",
+  namespace = "Adjust",
+  hdrs = [
+    ":Sociomantic_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Sociomantic_includes",
   include = [
@@ -311,6 +349,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Criteo_hmap",
+  namespace = "Adjust",
+  hdrs = [
+    ":Criteo_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Criteo_includes",
   include = [
@@ -394,6 +445,19 @@ filegroup(
   srcs = [
     "Trademob_hdrs",
     "Adjust_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Trademob_hmap",
+  namespace = "Adjust",
+  hdrs = [
+    ":Trademob_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -49,6 +50,20 @@ filegroup(
   ) + [
     ":Tasks_hdrs",
     ":AppLinks_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Bolts_hmap",
+  namespace = "Bolts",
+  hdrs = [
+    ":Bolts_hdrs"
+  ],
+  deps = [
+    ":AppLinks",
+    ":Tasks"
   ],
   visibility = [
     "//visibility:public"
@@ -151,6 +166,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Tasks_hmap",
+  namespace = "Bolts",
+  hdrs = [
+    ":Tasks_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Tasks_includes",
   include = [
@@ -248,6 +274,19 @@ filegroup(
   srcs = [
     "AppLinks_hdrs",
     "Bolts_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "AppLinks_hmap",
+  namespace = "Bolts",
+  hdrs = [
+    ":AppLinks_union_hdrs"
+  ],
+  deps = [
+    ":Tasks"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,22 @@ filegroup(
     ":Card_hdrs",
     ":PayPal_hdrs",
     ":UI_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Braintree_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":Braintree_hdrs"
+  ],
+  deps = [
+    ":Card",
+    ":Core",
+    ":PayPal",
+    ":UI"
   ],
   visibility = [
     "//visibility:public"
@@ -108,6 +125,17 @@ filegroup(
     "Core_hdrs",
     "Braintree_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -205,6 +233,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Apple-Pay_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":Apple-Pay_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Apple-Pay_includes",
   include = [
@@ -279,6 +320,19 @@ filegroup(
   srcs = [
     "Card_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Card_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":Card_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -360,6 +414,20 @@ filegroup(
   srcs = [
     "DataCollector_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "DataCollector_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":DataCollector_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":DataCollector_VendoredLibraries"
   ],
   visibility = [
     "//visibility:public"
@@ -449,6 +517,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "PayPal_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":PayPal_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":PayPalOneTouch"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "PayPal_includes",
   include = [
@@ -521,6 +603,20 @@ filegroup(
   srcs = [
     "Venmo_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Venmo_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":Venmo_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":PayPalDataCollector"
   ],
   visibility = [
     "//visibility:public"
@@ -621,6 +717,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "UI_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":UI_union_hdrs"
+  ],
+  deps = [
+    ":Card",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "UI_includes",
   include = [
@@ -700,6 +810,20 @@ filegroup(
   srcs = [
     "UnionPay_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "UnionPay_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":UnionPay_union_hdrs"
+  ],
+  deps = [
+    ":Card",
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -794,6 +918,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "3D-Secure_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":3D-Secure_union_hdrs"
+  ],
+  deps = [
+    ":Card",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "3D-Secure_includes",
   include = [
@@ -872,6 +1010,21 @@ filegroup(
   srcs = [
     "PayPalOneTouch_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PayPalOneTouch_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":PayPalOneTouch_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":PayPalDataCollector",
+    ":PayPalUtils"
   ],
   visibility = [
     "//visibility:public"
@@ -961,6 +1114,21 @@ filegroup(
   srcs = [
     "PayPalDataCollector_hdrs",
     "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PayPalDataCollector_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":PayPalDataCollector_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":PayPalDataCollector_VendoredLibraries",
+    ":PayPalUtils"
   ],
   visibility = [
     "//visibility:public"
@@ -1057,6 +1225,17 @@ filegroup(
     "PayPalUtils_hdrs",
     "Braintree_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PayPalUtils_hmap",
+  namespace = "Braintree",
+  hdrs = [
+    ":PayPalUtils_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -25,6 +26,20 @@ filegroup(
   ) + [
     ":Core_hdrs",
     ":without-IDFA_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Branch_hmap",
+  namespace = "Branch",
+  hdrs = [
+    ":Branch_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":without-IDFA"
   ],
   visibility = [
     "//visibility:public"
@@ -107,6 +122,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Core_hmap",
+  namespace = "Branch",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Core_includes",
   include = [
@@ -184,6 +210,17 @@ filegroup(
     "without-IDFA_hdrs",
     "Branch_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "without-IDFA_hmap",
+  namespace = "Branch",
+  hdrs = [
+    ":without-IDFA_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -42,6 +43,17 @@ filegroup(
     "Calabash_cxx_hdrs",
     "Calabash_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Calabash_cxx_hmap",
+  namespace = "Calabash",
+  hdrs = [
+    ":Calabash_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -152,6 +164,20 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":Calabash_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Calabash_hmap",
+  namespace = "Calabash",
+  hdrs = [
+    ":Calabash_hdrs"
+  ],
+  deps = [
+    ":Calabash_cxx",
+    ":Calabash_swift"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "CardIO_hmap",
+  namespace = "CardIO",
+  hdrs = [
+    ":CardIO_hdrs"
+  ],
+  deps = [
+    ":CardIO_VendoredLibraries"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "ColorCube_hmap",
+  namespace = "ColorCube",
+  hdrs = [
+    ":ColorCube_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -30,6 +31,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "EarlGrey_hmap",
+  namespace = "EarlGrey",
+  hdrs = [
+    ":EarlGrey_hdrs"
+  ],
+  deps = [
+    ":EarlGrey_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -85,6 +86,25 @@ filegroup(
         ],
         exclude_directories = 1
       )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKCoreKit_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    ":FBSDKCoreKit_hdrs"
+  ],
+  deps = [
+    ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
+  ] + select(
+    {
+      "//conditions:default": [
+        "//Vendor/Bolts:Bolts"
+      ]
     }
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKLoginKit_hmap",
+  namespace = "FBSDKLoginKit",
+  hdrs = [
+    ":FBSDKLoginKit_hdrs"
+  ],
+  deps = [
+    "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -31,6 +32,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKMessengerShareKit_hmap",
+  namespace = "FBSDKMessengerShareKit",
+  hdrs = [
+    ":FBSDKMessengerShareKit_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -83,6 +84,19 @@ filegroup(
       )
     }
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKShareKit_hmap",
+  namespace = "FBSDKShareKit",
+  hdrs = [
+    ":FBSDKShareKit_hdrs"
+  ],
+  deps = [
+    "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FLAnimatedImage_hmap",
+  namespace = "FLAnimatedImage",
+  hdrs = [
+    ":FLAnimatedImage_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FLEX_hmap",
+  namespace = "FLEX",
+  hdrs = [
+    ":FLEX_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":standard_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FMDB_hmap",
+  namespace = "FMDB",
+  hdrs = [
+    ":FMDB_hdrs"
+  ],
+  deps = [
+    ":standard"
   ],
   visibility = [
     "//visibility:public"
@@ -99,6 +113,17 @@ filegroup(
     "standard_hdrs",
     "FMDB_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "standard_hmap",
+  namespace = "FMDB",
+  hdrs = [
+    ":standard_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -183,6 +208,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "FTS_hmap",
+  namespace = "FMDB",
+  hdrs = [
+    ":FTS_union_hdrs"
+  ],
+  deps = [
+    ":standard"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "FTS_includes",
   include = [
@@ -252,6 +290,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "standalone_hmap",
+  namespace = "FMDB",
+  hdrs = [
+    ":standalone_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "standalone_includes",
   include = [
@@ -314,6 +363,19 @@ filegroup(
   srcs = [
     "SQLCipher_hdrs",
     "FMDB_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SQLCipher_hmap",
+  namespace = "FMDB",
+  hdrs = [
+    ":SQLCipher_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/SQLCipher:SQLCipher"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -30,6 +31,21 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Folly_hmap",
+  namespace = "folly",
+  hdrs = [
+    ":Folly_hdrs"
+  ],
+  deps = [
+    "//Vendor/DoubleConversion:DoubleConversion",
+    "//Vendor/boost-for-react-native:boost-for-react-native",
+    "//Vendor/glog:glog"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -5,7 +5,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -32,6 +33,20 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleAppIndexing_hmap",
+  namespace = "GoogleAppIndexing",
+  hdrs = [
+    ":GoogleAppIndexing_hdrs"
+  ],
+  deps = [
+    ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
+    ":GoogleAppIndexing_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,20 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleAppUtilities_hmap",
+  namespace = "GoogleAppUtilities",
+  hdrs = [
+    ":GoogleAppUtilities_hdrs"
+  ],
+  deps = [
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleAppUtilities_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,21 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleAuthUtilities_hmap",
+  namespace = "GoogleAuthUtilities",
+  hdrs = [
+    ":GoogleAuthUtilities_hdrs"
+  ],
+  deps = [
+    "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities",
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleAuthUtilities_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,20 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleNetworkingUtilities_hmap",
+  namespace = "GoogleNetworkingUtilities",
+  hdrs = [
+    ":GoogleNetworkingUtilities_hdrs"
+  ],
+  deps = [
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleNetworkingUtilities_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -5,7 +5,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -25,6 +26,24 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleSignIn_hmap",
+  namespace = "GoogleSignIn",
+  hdrs = [
+    ":GoogleSignIn_hdrs"
+  ],
+  deps = [
+    "//Vendor/GTMOAuth2:GTMOAuth2",
+    "//Vendor/GTMSessionFetcher:Core",
+    "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments",
+    "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
+    ":GoogleSignIn_Bundle_GoogleSignIn",
+    ":GoogleSignIn_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleSymbolUtilities_hmap",
+  namespace = "GoogleSymbolUtilities",
+  hdrs = [
+    ":GoogleSymbolUtilities_hdrs"
+  ],
+  deps = [
+    ":GoogleSymbolUtilities_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,20 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "GoogleUtilities_hmap",
+  namespace = "GoogleUtilities",
+  hdrs = [
+    ":GoogleUtilities_hdrs"
+  ],
+  deps = [
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleUtilities_VendoredFrameworks"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "IBActionSheet_hmap",
+  namespace = "IBActionSheet",
+  hdrs = [
+    ":IBActionSheet_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -42,6 +43,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":Default_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "IGListKit_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    ":IGListKit_hdrs"
+  ],
+  deps = [
+    ":Default"
   ],
   visibility = [
     "//visibility:public"
@@ -134,6 +148,17 @@ filegroup(
     "Diffing_cxx_hdrs",
     "IGListKit_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Diffing_cxx_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    ":Diffing_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -246,6 +271,19 @@ filegroup(
   srcs = [
     "Diffing_hdrs",
     "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Diffing_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    ":Diffing_union_hdrs"
+  ],
+  deps = [
+    ":Diffing_cxx"
   ],
   visibility = [
     "//visibility:public"
@@ -373,6 +411,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Default_cxx_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    ":Default_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Diffing"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Default_cxx_includes",
   include = [
@@ -491,6 +542,20 @@ filegroup(
   srcs = [
     "Default_hdrs",
     "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Default_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    ":Default_union_hdrs"
+  ],
+  deps = [
+    ":Default_cxx",
+    ":Diffing"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "KVOController_hmap",
+  namespace = "KVOController",
+  hdrs = [
+    ":KVOController_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,19 @@ filegroup(
   srcs = [
     "KakaoOpenSDK_hdrs",
     "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "KakaoOpenSDK_hmap",
+  namespace = "KakaoOpenSDK",
+  hdrs = [
+    ":KakaoOpenSDK_union_hdrs"
+  ],
+  deps = [
+    ":KakaoOpenSDK_VendoredFrameworks"
   ],
   visibility = [
     "//visibility:public"
@@ -93,6 +107,19 @@ filegroup(
   srcs = [
     "KakaoOpenSDK_hdrs",
     "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "KakaoOpenSDK_hmap",
+  namespace = "KakaoOpenSDK",
+  hdrs = [
+    ":KakaoOpenSDK_union_hdrs"
+  ],
+  deps = [
+    ":KakaoOpenSDK_VendoredFrameworks"
   ],
   visibility = [
     "//visibility:public"
@@ -175,6 +202,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "KakaoNavi_hmap",
+  namespace = "KakaoOpenSDK",
+  hdrs = [
+    ":KakaoNavi_union_hdrs"
+  ],
+  deps = [
+    ":KakaoNavi_VendoredFrameworks"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "KakaoNavi_includes",
   include = [
@@ -251,6 +291,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "KakaoLink_hmap",
+  namespace = "KakaoOpenSDK",
+  hdrs = [
+    ":KakaoLink_union_hdrs"
+  ],
+  deps = [
+    ":KakaoLink_VendoredFrameworks"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "KakaoLink_includes",
   include = [
@@ -322,6 +375,19 @@ filegroup(
   srcs = [
     "KakaoS2_hdrs",
     "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "KakaoS2_hmap",
+  namespace = "KakaoOpenSDK",
+  hdrs = [
+    ":KakaoS2_union_hdrs"
+  ],
+  deps = [
+    ":KakaoS2_VendoredFrameworks"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -46,6 +47,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Masonry_hmap",
+  namespace = "Masonry",
+  hdrs = [
+    ":Masonry_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -34,6 +35,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "OnePasswordExtension_hmap",
+  namespace = "OnePasswordExtension",
+  hdrs = [
+    ":1PasswordExtension_hdrs"
+  ],
+  deps = [
+    ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -37,6 +38,20 @@ filegroup(
   ) + [
     ":Core_hdrs",
     ":Arc-exception-safe_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PINCache_hmap",
+  namespace = "PINCache",
+  hdrs = [
+    ":PINCache_hdrs"
+  ],
+  deps = [
+    ":Arc-exception-safe",
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -130,6 +145,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Core_hmap",
+  namespace = "PINCache",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/PINOperation:PINOperation"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Core_includes",
   include = [
@@ -212,6 +240,19 @@ filegroup(
   srcs = [
     "Arc-exception-safe_hdrs",
     "PINCache_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Arc-exception-safe_hmap",
+  namespace = "PINCache",
+  hdrs = [
+    ":Arc-exception-safe_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -33,6 +34,17 @@ filegroup(
     "PINOperation_cxx_hdrs",
     "PINOperation_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PINOperation_cxx_hmap",
+  namespace = "PINOperation",
+  hdrs = [
+    ":PINOperation_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -108,6 +120,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":PINOperation_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PINOperation_hmap",
+  namespace = "PINOperation",
+  hdrs = [
+    ":PINOperation_hdrs"
+  ],
+  deps = [
+    ":PINOperation_cxx"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -25,6 +26,20 @@ filegroup(
   ) + [
     ":FLAnimatedImage_hdrs",
     ":PINCache_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PINRemoteImage_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":PINRemoteImage_hdrs"
+  ],
+  deps = [
+    ":FLAnimatedImage",
+    ":PINCache"
   ],
   visibility = [
     "//visibility:public"
@@ -109,6 +124,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Core_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/PINOperation:PINOperation"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Core_includes",
   include = [
@@ -188,6 +216,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "iOS_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":iOS_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "iOS_includes",
   include = [
@@ -247,6 +288,19 @@ filegroup(
   srcs = [
     "OSX_hdrs",
     "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "OSX_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":OSX_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -317,6 +371,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "tvOS_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":tvOS_union_hdrs"
+  ],
+  deps = [
+    ":iOS"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "tvOS_includes",
   include = [
@@ -378,6 +445,20 @@ filegroup(
   srcs = [
     "FLAnimatedImage_hdrs",
     "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FLAnimatedImage_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":FLAnimatedImage_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/FLAnimatedImage:FLAnimatedImage",
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -455,6 +536,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "WebP_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":WebP_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/libwebp:libwebp",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "WebP_includes",
   include = [
@@ -521,6 +616,20 @@ filegroup(
   srcs = [
     "PINCache_hdrs",
     "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PINCache_hmap",
+  namespace = "PINRemoteImage",
+  hdrs = [
+    ":PINCache_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/PINCache:PINCache",
+    ":Core"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PaymentKit_hmap",
+  namespace = "PaymentKit",
+  hdrs = [
+    ":PaymentKit_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RadarKit_hmap",
+  namespace = "RadarKit",
+  hdrs = [
+    ":RadarKit_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -37,6 +38,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "React_hmap",
+  namespace = "React",
+  hdrs = [
+    ":React_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -195,6 +209,19 @@ filegroup(
   srcs = [
     "Core_cxx_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":Core_cxx_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Yoga:Yoga"
   ],
   visibility = [
     "//visibility:public"
@@ -620,6 +647,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Core_hmap",
+  namespace = "React",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Yoga:Yoga",
+    ":Core_cxx"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Core_includes",
   include = [
@@ -953,6 +994,21 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "CxxBridge_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":CxxBridge_cxx_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    ":Core",
+    ":cxxreact"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "CxxBridge_cxx_includes",
   include = [
@@ -1032,6 +1088,22 @@ filegroup(
   srcs = [
     "CxxBridge_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "CxxBridge_hmap",
+  namespace = "React",
+  hdrs = [
+    ":CxxBridge_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    ":Core",
+    ":CxxBridge_cxx",
+    ":cxxreact"
   ],
   visibility = [
     "//visibility:public"
@@ -1118,6 +1190,20 @@ filegroup(
   srcs = [
     "DevSupport_cxx_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "DevSupport_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":DevSupport_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTWebSocket"
   ],
   visibility = [
     "//visibility:public"
@@ -1237,6 +1323,22 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "DevSupport_hmap",
+  namespace = "React",
+  hdrs = [
+    ":DevSupport_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":DevSupport_cxx",
+    ":DevSupport_swift",
+    ":RCTWebSocket"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "DevSupport_includes",
   include = [
@@ -1324,6 +1426,21 @@ filegroup(
   srcs = [
     "RCTFabric_cxx_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTFabric_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTFabric_cxx_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    ":Core",
+    ":fabric"
   ],
   visibility = [
     "//visibility:public"
@@ -1435,6 +1552,22 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTFabric_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTFabric_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    ":Core",
+    ":RCTFabric_cxx",
+    ":fabric"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTFabric_includes",
   include = [
@@ -1532,6 +1665,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "tvOS_hmap",
+  namespace = "React",
+  hdrs = [
+    ":tvOS_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "tvOS_includes",
   include = [
@@ -1601,6 +1747,20 @@ filegroup(
   srcs = [
     "jschelpers_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "jschelpers_hmap",
+  namespace = "React",
+  hdrs = [
+    ":jschelpers_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    ":PrivateDatabase"
   ],
   visibility = [
     "//visibility:public"
@@ -1702,6 +1862,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "jsinspector_hmap",
+  namespace = "React",
+  hdrs = [
+    ":jsinspector_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "jsinspector_includes",
   include = [
@@ -1785,6 +1956,17 @@ filegroup(
     "PrivateDatabase_hdrs",
     "React_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "PrivateDatabase_hmap",
+  namespace = "React",
+  hdrs = [
+    ":PrivateDatabase_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -1877,6 +2059,22 @@ filegroup(
   srcs = [
     "cxxreact_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "cxxreact_hmap",
+  namespace = "React",
+  hdrs = [
+    ":cxxreact_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly",
+    "//Vendor/boost-for-react-native:boost-for-react-native",
+    ":jschelpers",
+    ":jsinspector"
   ],
   visibility = [
     "//visibility:public"
@@ -1975,6 +2173,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "fabric_hmap",
+  namespace = "React",
+  hdrs = [
+    ":fabric_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "fabric_includes",
   include = [
@@ -2043,6 +2252,19 @@ filegroup(
   srcs = [
     "RCTFabricSample_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTFabricSample_hmap",
+  namespace = "fabric/sample",
+  hdrs = [
+    ":RCTFabricSample_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Folly:Folly"
   ],
   visibility = [
     "//visibility:public"
@@ -2138,6 +2360,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "ART_hmap",
+  namespace = "React",
+  hdrs = [
+    ":ART_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "ART_includes",
   include = [
@@ -2207,6 +2442,19 @@ filegroup(
   srcs = [
     "RCTActionSheet_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTActionSheet_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTActionSheet_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -2291,6 +2539,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTAnimation_hmap",
+  namespace = "RCTAnimation",
+  hdrs = [
+    ":RCTAnimation_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTAnimation_includes",
   include = [
@@ -2362,6 +2623,19 @@ filegroup(
   srcs = [
     "RCTBlob_cxx_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTBlob_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTBlob_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -2463,6 +2737,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTBlob_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTBlob_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTBlob_cxx"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTBlob_includes",
   include = [
@@ -2557,6 +2845,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTCameraRoll_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTCameraRoll_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTImage"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTCameraRoll_includes",
   include = [
@@ -2627,6 +2929,19 @@ filegroup(
   srcs = [
     "RCTGeolocation_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTGeolocation_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTGeolocation_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -2706,6 +3021,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTImage_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTImage_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTNetwork"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTImage_includes",
   include = [
@@ -2779,6 +3108,19 @@ filegroup(
   srcs = [
     "RCTNetwork_cxx_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTNetwork_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTNetwork_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -2865,6 +3207,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTNetwork_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTNetwork_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTNetwork_cxx"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTNetwork_includes",
   include = [
@@ -2944,6 +3300,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTPushNotification_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTPushNotification_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTPushNotification_includes",
   include = [
@@ -3013,6 +3382,19 @@ filegroup(
   srcs = [
     "RCTSettings_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTSettings_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTSettings_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -3092,6 +3474,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTText_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTText_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTText_includes",
   include = [
@@ -3166,6 +3561,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTVibration_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTVibration_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTVibration_includes",
   include = [
@@ -3235,6 +3643,21 @@ filegroup(
   srcs = [
     "RCTWebSocket_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTWebSocket_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTWebSocket_union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":RCTBlob",
+    ":fishhook"
   ],
   visibility = [
     "//visibility:public"
@@ -3337,6 +3760,17 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "fishhook_hmap",
+  namespace = "fishhook",
+  hdrs = [
+    ":fishhook_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "fishhook_includes",
   include = [
@@ -3429,6 +3863,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTLinkingIOS_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTLinkingIOS_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTLinkingIOS_includes",
   include = [
@@ -3503,6 +3950,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTTest_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTTest_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTTest_includes",
   include = [
@@ -3570,6 +4030,20 @@ filegroup(
   srcs = [
     "_ignore_me_subspec_for_linting__hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "_ignore_me_subspec_for_linting__hmap",
+  namespace = "React",
+  hdrs = [
+    ":_ignore_me_subspec_for_linting__union_hdrs"
+  ],
+  deps = [
+    ":Core",
+    ":CxxBridge"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -43,6 +44,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "React_hmap",
+  namespace = "React",
+  hdrs = [
+    ":React_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -141,6 +155,17 @@ filegroup(
     "Core_hdrs",
     "React_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_hmap",
+  namespace = "React",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -252,6 +277,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "ART_hmap",
+  namespace = "React",
+  hdrs = [
+    ":ART_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "ART_includes",
   include = [
@@ -321,6 +359,19 @@ filegroup(
   srcs = [
     "RCTActionSheet_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTActionSheet_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTActionSheet_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -400,6 +451,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTAdSupport_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTAdSupport_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTAdSupport_includes",
   include = [
@@ -469,6 +533,19 @@ filegroup(
   srcs = [
     "RCTGeolocation_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTGeolocation_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTGeolocation_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -548,6 +625,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTImage_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTImage_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTImage_includes",
   include = [
@@ -617,6 +707,19 @@ filegroup(
   srcs = [
     "RCTNetwork_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTNetwork_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTNetwork_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -696,6 +799,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTPushNotification_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTPushNotification_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTPushNotification_includes",
   include = [
@@ -765,6 +881,19 @@ filegroup(
   srcs = [
     "RCTSettings_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTSettings_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTSettings_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -844,6 +973,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTText_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTText_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTText_includes",
   include = [
@@ -913,6 +1055,19 @@ filegroup(
   srcs = [
     "RCTVibration_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTVibration_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTVibration_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -992,6 +1147,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "RCTWebSocket_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTWebSocket_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "RCTWebSocket_includes",
   include = [
@@ -1061,6 +1229,19 @@ filegroup(
   srcs = [
     "RCTLinkingIOS_hdrs",
     "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "RCTLinkingIOS_hmap",
+  namespace = "React",
+  hdrs = [
+    ":RCTLinkingIOS_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -36,6 +37,17 @@ filegroup(
     "SFHFKeychainUtils_cxx_hdrs",
     "SFHFKeychainUtils_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SFHFKeychainUtils_cxx_hmap",
+  namespace = "SFHFKeychainUtils",
+  hdrs = [
+    ":SFHFKeychainUtils_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -138,6 +150,20 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":SFHFKeychainUtils_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SFHFKeychainUtils_hmap",
+  namespace = "SFHFKeychainUtils",
+  hdrs = [
+    ":SFHFKeychainUtils_hdrs"
+  ],
+  deps = [
+    ":SFHFKeychainUtils_cxx",
+    ":SFHFKeychainUtils_swift"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SPUserResizableView+Pion_hmap",
+  namespace = "SPUserResizableView+Pion",
+  hdrs = [
+    ":SPUserResizableView+Pion_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SlackTextViewController_hmap",
+  namespace = "SlackTextViewController",
+  hdrs = [
+    ":SlackTextViewController_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Smartling_hmap",
+  namespace = "Smartling",
+  hdrs = [
+    ":Smartling_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -36,6 +37,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Stripe_hmap",
+  namespace = "Stripe",
+  hdrs = [
+    ":Stripe_hdrs"
+  ],
+  deps = [
+    ":Stripe_Bundle_Stripe"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -34,6 +35,22 @@ filegroup(
     ":MapKit_hdrs",
     ":Photos_hdrs",
     ":AssetsLibrary_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Texture_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":Texture_hdrs"
+  ],
+  deps = [
+    ":AssetsLibrary",
+    ":MapKit",
+    ":PINRemoteImage",
+    ":Photos"
   ],
   visibility = [
     "//visibility:public"
@@ -120,6 +137,17 @@ filegroup(
     "Core_cxx_hdrs",
     "Texture_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_cxx_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":Core_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -213,6 +241,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Core_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [
+    ":Core_cxx"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Core_includes",
   include = [
@@ -296,6 +337,21 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "PINRemoteImage_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":PINRemoteImage_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/PINRemoteImage:PINCache",
+    "//Vendor/PINRemoteImage:iOS",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "PINRemoteImage_includes",
   include = [
@@ -372,6 +428,20 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "IGListKit_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":IGListKit_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/IGListKit:IGListKit",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "IGListKit_includes",
   include = [
@@ -441,6 +511,20 @@ filegroup(
   srcs = [
     "Yoga_hdrs",
     "Texture_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Yoga_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":Yoga_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Yoga:Yoga",
+    ":Core"
   ],
   visibility = [
     "//visibility:public"
@@ -522,6 +606,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "MapKit_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":MapKit_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "MapKit_includes",
   include = [
@@ -598,6 +695,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Photos_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":Photos_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Photos_includes",
   include = [
@@ -669,6 +779,19 @@ filegroup(
   srcs = [
     "AssetsLibrary_hdrs",
     "Texture_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "AssetsLibrary_hmap",
+  namespace = "AsyncDisplayKit",
+  hdrs = [
+    ":AssetsLibrary_union_hdrs"
+  ],
+  deps = [
+    ":Core"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -36,6 +37,17 @@ filegroup(
     "UICollectionViewLeftAlignedLayout_cxx_hdrs",
     "UICollectionViewLeftAlignedLayout_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "UICollectionViewLeftAlignedLayout_cxx_hmap",
+  namespace = "UICollectionViewLeftAlignedLayout",
+  hdrs = [
+    ":UICollectionViewLeftAlignedLayout_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -127,6 +139,20 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "UICollectionViewLeftAlignedLayout_hmap",
+  namespace = "UICollectionViewLeftAlignedLayout",
+  hdrs = [
+    ":UICollectionViewLeftAlignedLayout_hdrs"
+  ],
+  deps = [
+    ":UICollectionViewLeftAlignedLayout_cxx",
+    ":UICollectionViewLeftAlignedLayout_swift"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Weixin_hmap",
+  namespace = "Weixin",
+  hdrs = [
+    ":Weixin_hdrs"
+  ],
+  deps = [
+    ":Weixin_VendoredLibraries"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -33,6 +34,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "ZipArchive_hmap",
+  namespace = "ZipArchive",
+  hdrs = [
+    ":ZipArchive_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -30,6 +31,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "boost-for-react-native_hmap",
+  namespace = "boost",
+  hdrs = [
+    ":boost-for-react-native_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -38,6 +39,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "glog_hmap",
+  namespace = "glog",
+  hdrs = [
+    ":glog_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -25,6 +26,21 @@ filegroup(
   ) + [
     ":Messages_hdrs",
     ":Services_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "googleapis_hmap",
+  namespace = "googleapis",
+  hdrs = [
+    ":googleapis_hdrs"
+  ],
+  deps = [
+    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
+    ":Messages",
+    ":Services"
   ],
   visibility = [
     "//visibility:public"
@@ -110,6 +126,19 @@ filegroup(
     "//visibility:public"
   ]
 )
+headermap(
+  name = "Messages_hmap",
+  namespace = "googleapis",
+  hdrs = [
+    ":Messages_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/Protobuf:Protobuf"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 gen_includes(
   name = "Messages_includes",
   include = [
@@ -186,6 +215,20 @@ filegroup(
   srcs = [
     "Services_hdrs",
     "googleapis_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Services_hmap",
+  namespace = "googleapis",
+  hdrs = [
+    ":Services_union_hdrs"
+  ],
+  deps = [
+    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
+    ":Messages"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -24,6 +25,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "iOSSnapshotTestCase_hmap",
+  namespace = "FBSnapshotTestCase",
+  hdrs = [
+    ":iOSSnapshotTestCase_hdrs"
+  ],
+  deps = [
+    ":SwiftSupport"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -108,6 +122,17 @@ filegroup(
     "Core_hdrs",
     "iOSSnapshotTestCase_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_hmap",
+  namespace = "FBSnapshotTestCase",
+  hdrs = [
+    ":Core_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -29,6 +30,19 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "iRate_hmap",
+  namespace = "iRate",
+  hdrs = [
+    ":iRate_hdrs"
+  ],
+  deps = [
+    ":iRate_Bundle_iRate"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -28,6 +29,17 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "kingpin_hmap",
+  namespace = "kingpin",
+  hdrs = [
+    ":kingpin_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -33,6 +34,17 @@ filegroup(
     "pop_cxx_hdrs",
     "pop_hdrs"
   ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "pop_cxx_hmap",
+  namespace = "pop",
+  hdrs = [
+    ":pop_cxx_union_hdrs"
+  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -112,6 +124,19 @@ filegroup(
     exclude_directories = 1
   ) + [
     ":pop_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "pop_hmap",
+  namespace = "pop",
+  hdrs = [
+    ":pop_hdrs"
+  ],
+  deps = [
+    ":pop_cxx"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -5,7 +5,8 @@ load(
   "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
-  "gen_includes"
+  "gen_includes",
+  "headermap"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -70,6 +71,19 @@ filegroup(
   srcs = [
     "youtube-ios-player-helper_cxx_hdrs",
     "youtube-ios-player-helper_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "youtube-ios-player-helper_cxx_hmap",
+  namespace = "youtube-ios-player-helper",
+  hdrs = [
+    ":youtube-ios-player-helper_cxx_union_hdrs"
+  ],
+  deps = [
+    ":youtube-ios-player-helper_Bundle_Assets"
   ],
   visibility = [
     "//visibility:public"
@@ -241,6 +255,21 @@ filegroup(
     }
   ) + [
     ":youtube-ios-player-helper_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "youtube-ios-player-helper_hmap",
+  namespace = "youtube-ios-player-helper",
+  hdrs = [
+    ":youtube-ios-player-helper_hdrs"
+  ],
+  deps = [
+    ":youtube-ios-player-helper_Bundle_Assets",
+    ":youtube-ios-player-helper_cxx",
+    ":youtube-ios-player-helper_swift"
   ],
   visibility = [
     "//visibility:public"

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,19 @@ build-test: test-impl
 
 # Run the integration tests a few times. We want to make sure output is working
 # and stable.
+debug-spm: CONFIG = debug
+debug-spm: SWIFT_OPTS= --configuration $(CONFIG) -Xswiftc -static-stdlib
+debug-spm: build-impl-spm
+
+build-example: EXAMPLE=Examples/PINCache.podspec.json
+build-example: CONFIG = debug
+build-example: debug-spm
+	@ditto .build/$(CONFIG)/Compiler bin/Compiler
+	@ditto .build/$(CONFIG)/RepoTools bin/RepoTools
+	stat $(EXAMPLE) || exit 1
+	bin/Compiler $(EXAMPLE)
+
+
 integration-test: release
 	for i in $$(seq 1 10); do ./IntegrationTests/RunTests.sh; done
 

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -18,6 +18,8 @@ public protocol BuildOptions {
 
     var enableModules: Bool { get }
     var generateModuleMap: Bool { get }
+    var generateHeaderMap: Bool { get }
+
     // pod_support, everything, none
     var headerVisibility: String { get }
     
@@ -34,6 +36,7 @@ public struct EmptyBuildOptions: BuildOptions {
 
     public let enableModules: Bool = false
     public let generateModuleMap: Bool = false
+    public let generateHeaderMap: Bool = false
     public let headerVisibility: String = ""
     public let alwaysSplitRules: Bool = false
     public let vendorize: Bool = true
@@ -49,6 +52,7 @@ public struct BasicBuildOptions: BuildOptions {
 
     public let enableModules: Bool
     public let generateModuleMap: Bool
+    public let generateHeaderMap: Bool
     public let headerVisibility: String
     public let alwaysSplitRules: Bool
     public let vendorize: Bool
@@ -59,6 +63,7 @@ public struct BasicBuildOptions: BuildOptions {
                 trace: Bool,
                 enableModules: Bool = false,
                 generateModuleMap: Bool = false,
+                generateHeaderMap: Bool = false,
                 headerVisibility: String = "",
                 alwaysSplitRules: Bool = true,
                 vendorize: Bool = true
@@ -69,6 +74,7 @@ public struct BasicBuildOptions: BuildOptions {
         self.trace = trace
         self.enableModules = enableModules
         self.generateModuleMap = generateModuleMap
+        self.generateHeaderMap = generateHeaderMap
         self.headerVisibility = headerVisibility
         self.alwaysSplitRules = alwaysSplitRules
         self.vendorize = vendorize
@@ -133,7 +139,8 @@ public func makePrefixNodes() -> SkylarkNode {
             .basic(.string("pch_with_name_hint")),
             .basic(.string("acknowledged_target")),
             .basic(.string("gen_module_map")),
-            .basic(.string("gen_includes"))]),
+            .basic(.string("gen_includes")),
+            .basic(.string("headermap"))]),
         makeConfigSettingNodes(),
     ]
     return .lines(lineNodes)

--- a/Tests/BuildTests/Examples/PodSpecs/boost-react-native-1.63.0-0/boost.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/boost-react-native-1.63.0-0/boost.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+  spec.source_files = 'boost/boost/*.hpp'
+end

--- a/Tests/BuildTests/Examples/PodSpecs/boost-react-native-1.63.0-0/boost.podspec.json
+++ b/Tests/BuildTests/Examples/PodSpecs/boost-react-native-1.63.0-0/boost.podspec.json
@@ -1,0 +1,21 @@
+{
+  "name": "boost",
+  "version": "1.63.0",
+  "license": {
+    "type": "Boost Software License",
+    "file": "LICENSE_1_0.txt"
+  },
+  "homepage": "http://www.boost.org",
+  "summary": "Boost provides free peer-reviewed portable C++ source libraries.",
+  "authors": "Rene Rivera",
+  "source": {
+    "git": "https://github.com/react-native-community/boost-for-react-native.git",
+    "tag": "v1.63.0-0"
+  },
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "9.2"
+  },
+  "requires_arc": false,
+  "source_files": "boost/**/*.hpp"
+}

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.json
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.json
@@ -1,0 +1,21 @@
+{
+  "name": "DoubleConversion",
+  "version": "1.1.5",
+  "license": {
+    "type": "BSD"
+  },
+  "homepage": "https://github.com/google/double-conversion",
+  "summary": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles",
+  "authors": "Google",
+  "prepare_command": "mv src double-conversion",
+  "source": {
+    "git": "https://github.com/google/double-conversion.git",
+    "tag": "v1.1.5"
+  },
+  "module_name": "DoubleConversion",
+  "source_files": "double-conversion/*.{h,cc}",
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "9.2"
+  }
+}

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name = 'DoubleConversion'
+  spec.version = '1.1.5'
+  spec.license = { :type => 'BSD' }
+  spec.homepage = 'https://github.com/google/double-conversion'
+  spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
+  spec.authors = 'Google'
+  spec.prepare_command = 'mv src double-conversion'
+  spec.source = { :git => 'https://github.com/google/double-conversion.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'DoubleConversion'
+  spec.source_files = 'double-conversion/*.{h,cc}'
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "8.0", :tvos => "9.2" }
+
+end

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/Folly.json
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/Folly.json
@@ -1,0 +1,53 @@
+{
+  "name": "Folly",
+  "version": "2016.09.26.00",
+  "license": {
+    "type": "Apache License, Version 2.0"
+  },
+  "homepage": "https://github.com/facebook/folly",
+  "summary": "An open-source C++ library developed and used at Facebook.",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/folly.git",
+    "tag": "v2016.09.26.00"
+  },
+  "module_name": "folly",
+  "dependencies": {
+    "boost": [
+
+    ],
+    "DoubleConversion": [
+
+    ],
+    "GLog": [
+
+    ]
+  },
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+  "source_files": [
+    "folly/Bits.cpp",
+    "folly/Conv.cpp",
+    "folly/Demangle.cpp",
+    "folly/StringBase.cpp",
+    "folly/Unicode.cpp",
+    "folly/dynamic.cpp",
+    "folly/json.cpp",
+    "folly/portability/BitsFunctexcept.cpp",
+    "folly/detail/MallocImpl.cpp"
+  ],
+  "preserve_paths": [
+    "folly/*.h",
+    "folly/detail/*.h",
+    "folly/portability/*.h"
+  ],
+  "libraries": "stdc++",
+  "pod_target_xcconfig": {
+    "USE_HEADERMAP": "NO",
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
+    "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\""
+  },
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "9.2"
+  }
+}

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/Folly.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/Folly.podspec
@@ -1,0 +1,34 @@
+Pod::Spec.new do |spec|
+  spec.name = 'Folly'
+  spec.version = '2016.09.26.00'
+  spec.license = { :type => 'Apache License, Version 2.0' }
+  spec.homepage = 'https://github.com/facebook/folly'
+  spec.summary = 'An open-source C++ library developed and used at Facebook.'
+  spec.authors = 'Facebook'
+  spec.source = { :git => 'https://github.com/facebook/folly.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'folly'
+  spec.dependency 'boost'
+  spec.dependency 'DoubleConversion'
+  spec.dependency 'GLog'
+  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+  spec.source_files = 'folly/Bits.cpp',
+                      'folly/Conv.cpp',
+                      'folly/Demangle.cpp',
+                      'folly/StringBase.cpp',
+                      'folly/Unicode.cpp',
+                      'folly/dynamic.cpp',
+                      'folly/json.cpp',
+                      'folly/portability/BitsFunctexcept.cpp',
+                      'folly/detail/MallocImpl.cpp',
+                      'folly/*.h',
+                      'folly/detail/*.h',
+                      'folly/portability/*.h'
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\"" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "8.0", :tvos => "9.2" }
+end

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/GLog.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/GLog.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |spec|
+  spec.name = 'GLog'
+  spec.version = '0.3.4'
+  spec.license = { :type => 'Google', :file => 'COPYING' }
+  spec.homepage = 'https://github.com/google/glog'
+  spec.summary = 'Google logging module'
+  spec.authors = 'Google'
+
+  # spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
+  spec.source = { :git => 'https://github.com/google/glog.git',
+                  :tag => "v#{spec.version}" }
+  # spec.module_name = 'glog'
+  spec.source_files = 'src/glog/*.h',
+                      'src/demangle.cc',
+                      'src/logging.cc',
+                      'src/raw_logging.cc',
+                      'src/signalhandler.cc',
+                      'src/symbolize.cc',
+                      'src/utilities.cc',
+                      'src/vlog_is_on.cc',
+                      'src/*.h',
+                      'src/base/*.h'
+
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  # spec.preserve_paths = 'src/*.h',
+  #                      'src/base/*.h'
+  spec.exclude_files       = "src/windows/**/*"
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "8.0", :tvos => "9.2" }
+
+end

--- a/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/ios-configure-glog.sh
+++ b/Tests/BuildTests/Examples/PodSpecs/react-native-third-party-0.51.0/ios-configure-glog.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+CURRENT_ARCH="${CURRENT_ARCH:-armv7}"
+
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+
+# Remove automake symlink if it exists
+if [ -h "test-driver" ]; then
+    rm test-driver
+fi
+
+# source ../PodSpecs/react-native-third-party-0.51.0/Env.sh
+
+echo  "set -o xtrace" > config2
+chmod +x config2
+cat configure >> config2
+
+./config2 --host arm-apple-darwin
+
+# Fix build for tvOS
+cat << EOF >> src/config.h
+
+/* Add in so we have Apple Target Conditionals */
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <Availability.h>
+#endif
+
+/* Special configuration for AppleTVOS */
+#if TARGET_OS_TV
+#undef HAVE_SYSCALL_H
+#undef HAVE_SYS_SYSCALL_H
+#undef OS_MACOSX
+#endif
+
+/* Special configuration for ucontext */
+#undef HAVE_UCONTEXT_H
+#undef PC_FROM_UCONTEXT
+#if defined(__x86_64__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip
+#elif defined(__i386__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip
+#endif
+EOF

--- a/Tests/BuildTests/Examples/React/Pods.WORKSPACE
+++ b/Tests/BuildTests/Examples/React/Pods.WORKSPACE
@@ -1,0 +1,126 @@
+new_pod_repository(
+  name = "React",
+  url = 'https://github.com/facebook/react-native/archive/v0.51.0.zip',
+  # In the React podspec, C++14 is specified as the std lib. In Xcode, this
+  # is fine as this flag is only used on C++ files. But in Bazel, it is used
+  # on all files. This breaks builds for objective-c and C code.
+  #
+  # We can't just treat all files as objective-c++ either because some of the
+  # files have code that is valid C but invalid C++. Luckily, the set of
+  # libraries that are invalid C++ are disjoint from the ones that contain C++
+  # so we're able to get this working by treating some as gnu99 and others
+  # as just objective-c++ files.
+  user_options = [
+    "RCTImage.copts += -std=gnu99",
+    "DevSupport.copts += -x, objective-c++",
+    "RCTNetwork.copts += -x, objective-c++",
+    "RCTText.copts += -std=gnu99",
+    "RCTWebSocket.copts += -std=gnu99",
+    "RCTAnimation.copts += -x, objective-c++",
+    "RCTBlob.copts += -x, objective-c++",
+    "fishhook.copts += -std=gnu99",
+    # FIXME: the way that these headers are being imported is causing massive
+    # issues. We need to run in sandbox'd mode to get around this.
+    "cxxreact.copts += -IVendor/boost",
+    "jschelpers.copts += -IVendor/boost, -IVendor/DoubleConversion, -IVendor/Folly",
+    "CxxBridge.copts += -IVendor/boost, -IVendor/DoubleConversion, -IVendor/Folly"
+  ],
+  install_script = """
+    # Make sure we refer to yoga as Yoga since case-sensitivity matters in Bazel
+
+    echo $PWD
+    /usr/bin/sed -i "" 's,"yoga","Yoga",g' React.podspec
+    __INIT_REPO__
+
+    # TODO: Make variable replacement
+    /usr/bin/sed -i '' 's,$(PODS_ROOT),Vendor,g' BUILD
+    /usr/bin/sed -i '' 's,Folly:Folly,Folly:folly,g' BUILD
+  """,
+  # Module map doesn't work because it seems to be expecting the folly library
+  generate_module_map = False,
+  header_visibility = "everything",
+  inhibit_warnings = True
+)
+
+new_pod_repository(
+  name = "Yoga",
+  url = 'https://github.com/facebook/react-native/archive/v0.51.0.zip',
+  strip_prefix = 'react-native-0.51.0/ReactCommon/yoga',
+  install_script = """
+    mv yoga.podspec Yoga.podspec.bak
+    mv Yoga.podspec.bak Yoga.podspec
+
+    # We need to fix the package parameter here (even though we don't use in pod2build)
+    # because the evaluation of the podspec in Ruby will fail. The package parameter
+    # points to a JSON.parse of a file outside the yoga sandbox.
+    /usr/bin/sed -i "" "s,^package.*,package = { 'version' => '0.46.3' },g" Yoga.podspec
+    /usr/bin/sed -i "" "s,spec.module_name.*yoga,spec.module_name = 'Yoga,g" Yoga.podspec
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "boost",
+  url = 'https://github.com/react-native-community/boost-for-react-native/archive/v1.63.0-0.zip',
+  podspec_url = 'Vendor/PodSpecs/boost-react-native-1.63.0-0/boost.podspec.json',
+  generate_module_map = False,
+)
+
+new_pod_repository(
+  name = "Folly",
+  podspec_url = "Vendor/PodSpecs/react-native-third-party-0.51.0/Folly.podspec",
+  url = "https://github.com/facebook/folly/archive/v2016.09.26.00.zip",
+  generate_module_map = False,
+  user_options = [ "folly.copts += -IVendor/Glog" ],
+  install_script = """
+    __INIT_REPO__
+    # TODO: Why is the Podspec using this as a ModuleName, if Folly imports
+    # it like so.
+    /usr/bin/sed -i '' 's,<double-conversion,<DoubleConversion,g' folly/Conv.h
+
+    # TODO: Make variable replacement
+    /usr/bin/sed -i '' 's,$(PODS_ROOT),Vendor,g' BUILD
+  """,
+  header_visibility = 'everything',
+)
+
+new_pod_repository(
+  name = "DoubleConversion",
+  url = 'https://github.com/google/double-conversion/archive/v1.1.5.zip',
+  podspec_url = 'Vendor/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.podspec',
+  install_script = """
+    mv src double-conversion
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "Glog",
+  url = 'https://github.com/google/glog/archive/v0.3.4.zip',
+  podspec_url = 'Vendor/PodSpecs/react-native-third-party-0.51.0/GLog.podspec',
+  install_script = """
+    # prepare_command
+  	sh ../PodSpecs/react-native-third-party-0.51.0/ios-configure-glog.sh
+  	__INIT_REPO__
+  """,
+  generate_module_map = False
+)
+
+# TODO: The fact that this name is "DoubleConversion" is not very idomatic
+# and causes issues.
+new_pod_repository(
+  name = "DoubleConversion",
+  url = 'https://github.com/google/double-conversion/archive/v1.1.5.zip',
+  podspec_url = 'Vendor/PodSpecs/react-native-third-party-0.51.0/DoubleConversion.podspec',
+  install_script = """
+    # prepare_command
+    mv src double-conversion
+    __INIT_REPO__
+  """,
+  generate_module_map = False
+)
+

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -57,6 +57,7 @@ class RepositoryContext(object):
             trace = False,
             enable_modules = True,
             generate_module_map = True,
+            generate_header_map = False,
             header_visibility = "pod_support",
             src_root = None):
         self.target_name = target_name
@@ -69,6 +70,7 @@ class RepositoryContext(object):
         self.trace = trace
         self.enable_modules = enable_modules
         self.generate_module_map = generate_module_map
+        self.generate_header_map = generate_header_map
         self.header_visibility = header_visibility
         self.src_root = src_root
 
@@ -237,7 +239,9 @@ def _update_repo_impl(repository_ctx):
                 "--header_visibility",
                 repository_ctx.header_visibility,
                 "--generate_module_map",
-                _cli_bool(repository_ctx.generate_module_map)
+                _cli_bool(repository_ctx.generate_module_map),
+                "--generate_header_map",
+                _cli_bool(repository_ctx.generate_header_map)
             ])
             substitutions[INIT_REPO_PLACEHOLDER] = " ".join(entry)
         else:
@@ -285,6 +289,7 @@ def new_pod_repository(name,
             trace = False,
             enable_modules = True,
             generate_module_map = True,
+            generate_header_map = False,
             owner = "", # This is a Noop
             header_visibility = "pod_support"):
     """Declare a repository for a Pod
@@ -366,6 +371,7 @@ def new_pod_repository(name,
             trace = trace,
             enable_modules = enable_modules,
             generate_module_map = generate_module_map,
+            generate_header_map = generate_header_map,
             header_visibility = header_visibility,
             src_root = SRC_ROOT)
     _update_repo_impl(repository_ctx)


### PR DESCRIPTION
This patch prototypes a headermap rule in skylark!

It works quite well, and sacrifices usability, since it isn't implicitly
created.

Public transitive `objc_library` header usage:
- `deps` go into `hdr_providers`
- `hdrs` into `hdrs` wrapped in a filegroup
- the actual header map goes into `hdrs` for public usage

Other consumers of the rules can wrap `objc_library` in a macro, which
both instantiate and consume this rule.

It works by transitively merging public headermaps. This works
effortlessly, since headermaps are propagated transitively along with the
headers.

Usage:
Create a basic headermap ( for the pod PINOperation )
```
headermap(
  name = "PINOperation_hmap",
  namespace = "PINOperation",
  # File group to headers
  hdrs = [
    "PINOperation_hdrs"
  ],
  hdr_providers = []
)
```

It supports transitive propagation via the `hdr_providers` rule,
which are currently objc providers only, we can expand this to multiple
types once swift support is added.
```
headermap(
  name = "PINCache_hmap",
  namespace = "PINCache",
  hdrs = [
    "PINCache_hdrs"
  ],
  hdr_providers = [ "//Vendor/PINOperation:PINOperation" ]
)
```

Compilation flags:
.hmaps will need to be explicitly added to the command line. Likely,
this will be achieved with `copts` in PodToBUILD. I'm not sure if the
behavior of replacing `GENFILES` with the correct directory is
available in Bazel, so that may rely on a custom toolchain or simply use
the `include` attribute.

Other considerations:
Be smarter about headers that actually exist. This needs more thought.
If the input pruning and dot d pruning work is useable from skylark,
it'd be great to leverage that.