### PR TITLE
Stabilize and assert stability of compiler output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ os:
   - osx
 before_install:
   - sudo gem install cocoapods
-osx_image: xcode9.3
+osx_image: xcode10
 script: make ci

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -64,12 +64,12 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":tvosCase": [
-        "AdSupport"
-      ],
       "//conditions:default": [
         "AdSupport",
         "iAd"
+      ],
+      ":tvosCase": [
+        "AdSupport"
       ]
     }
     ),
@@ -80,12 +80,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -156,12 +156,12 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":tvosCase": [
-        "AdSupport"
-      ],
       "//conditions:default": [
         "AdSupport",
         "iAd"
+      ],
+      ":tvosCase": [
+        "AdSupport"
       ]
     }
     ),
@@ -169,12 +169,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -237,12 +237,12 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":tvosCase": [
-        "AdSupport"
-      ],
       "//conditions:default": [
         "AdSupport",
         "iAd"
+      ],
+      ":tvosCase": [
+        "AdSupport"
       ]
     }
     ),
@@ -253,12 +253,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -321,12 +321,12 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":tvosCase": [
-        "AdSupport"
-      ],
       "//conditions:default": [
         "AdSupport",
         "iAd"
+      ],
+      ":tvosCase": [
+        "AdSupport"
       ]
     }
     ),
@@ -337,12 +337,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -405,12 +405,12 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":tvosCase": [
-        "AdSupport"
-      ],
       "//conditions:default": [
         "AdSupport",
         "iAd"
+      ],
+      ":tvosCase": [
+        "AdSupport"
       ]
     }
     ),
@@ -421,12 +421,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -72,19 +72,19 @@ objc_library(
     "Bolts_module_map"
   ],
   deps = [
-    ":Tasks",
-    ":AppLinks"
+    ":AppLinks",
+    ":Tasks"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -119,13 +119,13 @@ filegroup(
         ],
         exclude_directories = 1
         ),
-      ":watchosCase": glob(
+      ":tvosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
         ),
-      ":tvosCase": glob(
+      ":watchosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
@@ -157,13 +157,13 @@ objc_library(
         ],
         exclude_directories = 1
         ),
-      ":watchosCase": glob(
+      ":tvosCase": glob(
         [
           "Bolts/Common/*.m"
         ],
         exclude_directories = 1
         ),
-      ":tvosCase": glob(
+      ":watchosCase": glob(
         [
           "Bolts/Common/*.m"
         ],
@@ -184,13 +184,13 @@ objc_library(
         ],
         exclude_directories = 1
         ),
-      ":watchosCase": glob(
+      ":tvosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
         ),
-      ":tvosCase": glob(
+      ":watchosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
@@ -215,12 +215,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -297,12 +297,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -48,8 +48,8 @@ objc_library(
     "Braintree_module_map"
   ],
   deps = [
-    ":Core",
     ":Card",
+    ":Core",
     ":PayPal",
     ":UI"
   ],
@@ -354,8 +354,8 @@ objc_library(
     "Braintree_module_map"
   ],
   deps = [
-    ":DataCollector_VendoredLibraries",
-    ":Core"
+    ":Core",
+    ":DataCollector_VendoredLibraries"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -433,8 +433,8 @@ objc_library(
     "Braintree_module_map"
   ],
   deps = [
-    ":PayPalOneTouch",
-    ":Core"
+    ":Core",
+    ":PayPalOneTouch"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -504,8 +504,8 @@ objc_library(
     "Braintree_module_map"
   ],
   deps = [
-    ":PayPalDataCollector",
-    ":Core"
+    ":Core",
+    ":PayPalDataCollector"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -536,19 +536,19 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
   )
 objc_bundle_library(
-  name = "UI_Bundle_Braintree-UI-Localization",
+  name = "UI_Bundle_Braintree-Drop-In-Localization",
   resources = glob(
     [
-      "BraintreeUI/Localization/*.lproj"
+      "BraintreeUI/Drop-In/Localization/*.lproj"
     ],
     exclude_directories = 1
     )
   )
 objc_bundle_library(
-  name = "UI_Bundle_Braintree-Drop-In-Localization",
+  name = "UI_Bundle_Braintree-UI-Localization",
   resources = glob(
     [
-      "BraintreeUI/Drop-In/Localization/*.lproj"
+      "BraintreeUI/Localization/*.lproj"
     ],
     exclude_directories = 1
     )
@@ -617,8 +617,8 @@ objc_library(
     "-fmodule-name=Braintree_pod_module"
   ],
   bundles = [
-    ":UI_Bundle_Braintree-UI-Localization",
-    ":UI_Bundle_Braintree-Drop-In-Localization"
+    ":UI_Bundle_Braintree-Drop-In-Localization",
+    ":UI_Bundle_Braintree-UI-Localization"
   ],
   visibility = [
     "//visibility:public"
@@ -840,9 +840,9 @@ objc_library(
     "SafariServices"
   ],
   deps = [
-    ":PayPalUtils",
+    ":Core",
     ":PayPalDataCollector",
-    ":Core"
+    ":PayPalUtils"
   ],
   copts = [
     "-ObjC",
@@ -925,9 +925,9 @@ objc_library(
     "UIKit"
   ],
   deps = [
+    ":Core",
     ":PayPalDataCollector_VendoredLibraries",
-    ":PayPalUtils",
-    ":Core"
+    ":PayPalUtils"
   ],
   copts = [
     "-Wall -Werror -Wextra"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -55,12 +55,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -132,12 +132,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -208,12 +208,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -84,17 +84,17 @@ objc_library(
     }
     ),
   copts = [
+    ""$(PODS_ROOT)/Calabash/calabash.framework/calabash"",
     "-ObjC",
-    "-force_load",
-    ""$(PODS_ROOT)/Calabash/calabash.framework/calabash""
+    "-force_load"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -69,12 +69,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -76,12 +76,12 @@ objc_library(
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -169,12 +169,12 @@ objc_library(
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -68,12 +68,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -71,12 +71,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -321,8 +321,8 @@ objc_library(
     "//Vendor/SQLCipher:SQLCipher"
   ],
   copts = [
-    "-DSQLITE_HAS_CODEC",
-    "-DHAVE_USLEEP=1"
+    "-DHAVE_USLEEP=1",
+    "-DSQLITE_HAS_CODEC"
   ] + select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -51,24 +51,24 @@ objc_library(
     "z"
   ],
   deps = [
-    "//Vendor/SSZipArchive:SSZipArchive",
-    "//Vendor/MenuItemKit:MenuItemKit",
-    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition",
-    "//Vendor/JSQWebViewController:JSQWebViewController",
     "//Vendor/AEXML:AEXML",
+    "//Vendor/FontBlaster:FontBlaster",
+    "//Vendor/JSQWebViewController:JSQWebViewController",
+    "//Vendor/MenuItemKit:MenuItemKit",
     "//Vendor/RealmSwift:RealmSwift",
-    "//Vendor/FontBlaster:FontBlaster"
+    "//Vendor/SSZipArchive:SSZipArchive",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -93,13 +93,13 @@ objc_library(
 acknowledged_target(
   name = "FolioReaderKit_acknowledgement",
   deps = [
-    "//Vendor/MenuItemKit:MenuItemKit_acknowledgement",
-    "//Vendor/SSZipArchive:SSZipArchive_acknowledgement",
-    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition_acknowledgement",
-    "//Vendor/JSQWebViewController:JSQWebViewController_acknowledgement",
+    "//Vendor/AEXML:AEXML_acknowledgement",
     "//Vendor/FontBlaster:FontBlaster_acknowledgement",
+    "//Vendor/JSQWebViewController:JSQWebViewController_acknowledgement",
+    "//Vendor/MenuItemKit:MenuItemKit_acknowledgement",
     "//Vendor/RealmSwift:RealmSwift_acknowledgement",
-    "//Vendor/AEXML:AEXML_acknowledgement"
+    "//Vendor/SSZipArchive:SSZipArchive_acknowledgement",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition_acknowledgement"
   ],
   value = "//Vendor/FolioReaderKit/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -48,19 +48,19 @@ objc_library(
     "GoogleAppUtilities_module_map"
   ],
   deps = [
-    ":GoogleAppUtilities_VendoredFrameworks",
-    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities"
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleAppUtilities_VendoredFrameworks"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -52,20 +52,20 @@ objc_library(
     "SystemConfiguration"
   ],
   deps = [
-    ":GoogleAuthUtilities_VendoredFrameworks",
+    "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
-    "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities"
+    ":GoogleAuthUtilities_VendoredFrameworks"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -86,8 +86,8 @@ objc_library(
 acknowledged_target(
   name = "GoogleAuthUtilities_acknowledgement",
   deps = [
-    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement",
-    "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities_acknowledgement"
+    "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities_acknowledgement",
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
   ],
   value = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_fragment"
   )

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -51,8 +51,8 @@ objc_library(
     "Security"
   ],
   deps = [
-    ":GoogleNetworkingUtilities_VendoredFrameworks",
-    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities"
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleNetworkingUtilities_VendoredFrameworks"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -53,23 +53,23 @@ objc_library(
     "Security"
   ],
   deps = [
-    ":GoogleSignIn_Bundle_GoogleSignIn",
-    ":GoogleSignIn_VendoredFrameworks",
+    "//Vendor/GTMOAuth2:GTMOAuth2",
     "//Vendor/GTMSessionFetcher:Core",
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments",
-    "//Vendor/GTMOAuth2:GTMOAuth2",
-    "//Vendor/GoogleToolboxForMac:NSString_URLArguments"
+    "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
+    ":GoogleSignIn_Bundle_GoogleSignIn",
+    ":GoogleSignIn_VendoredFrameworks"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -87,9 +87,9 @@ objc_library(
 acknowledged_target(
   name = "GoogleSignIn_acknowledgement",
   deps = [
+    "//Vendor/GTMOAuth2:GTMOAuth2_acknowledgement",
     "//Vendor/GTMSessionFetcher:Core_acknowledgement",
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments_acknowledgement",
-    "//Vendor/GTMOAuth2:GTMOAuth2_acknowledgement",
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments_acknowledgement"
   ],
   value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -55,8 +55,8 @@ objc_library(
     "z"
   ],
   deps = [
-    ":GoogleUtilities_VendoredFrameworks",
-    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities"
+    "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
+    ":GoogleUtilities_VendoredFrameworks"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -65,12 +65,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -67,13 +67,13 @@ objc_library(
   ],
   sdk_frameworks = select(
     {
-      ":tvosCase": [
+      "//conditions:default": [
         "UIKit"
       ],
       ":osxCase": [
         "Cocoa"
       ],
-      "//conditions:default": [
+      ":tvosCase": [
         "UIKit"
       ]
     }
@@ -130,7 +130,7 @@ objc_library(
   enable_modules = 0,
   srcs = select(
     {
-      ":tvosCase": glob(
+      "//conditions:default": glob(
         [
           "Source/Common/**/*.m",
           "Source/Common/**/*.mm"
@@ -141,7 +141,7 @@ objc_library(
         ],
         exclude_directories = 1
         ),
-      "//conditions:default": glob(
+      ":tvosCase": glob(
         [
           "Source/Common/**/*.m",
           "Source/Common/**/*.mm"
@@ -174,13 +174,13 @@ objc_library(
   ],
   sdk_frameworks = select(
     {
-      ":tvosCase": [
+      "//conditions:default": [
         "UIKit"
       ],
       ":osxCase": [
         "Cocoa"
       ],
-      "//conditions:default": [
+      ":tvosCase": [
         "UIKit"
       ]
     }
@@ -221,13 +221,13 @@ filegroup(
   name = "Default_hdrs",
   srcs = select(
     {
-      ":tvosCase": glob(
+      "//conditions:default": glob(
         [
           "Source/**/*.h"
         ],
         exclude_directories = 1
         ),
-      "//conditions:default": glob(
+      ":tvosCase": glob(
         [
           "Source/**/*.h"
         ],
@@ -244,14 +244,14 @@ objc_library(
   enable_modules = 0,
   srcs = select(
     {
-      ":tvosCase": glob(
+      "//conditions:default": glob(
         [
           "Source/**/*.m",
           "Source/**/*.mm"
         ],
         exclude_directories = 1
         ),
-      "//conditions:default": glob(
+      ":tvosCase": glob(
         [
           "Source/**/*.m",
           "Source/**/*.mm"
@@ -261,13 +261,13 @@ objc_library(
     }
     ) + select(
     {
-      ":tvosCase": glob(
+      "//conditions:default": glob(
         [
           "Source/**/*.h"
         ],
         exclude_directories = 1
         ),
-      "//conditions:default": glob(
+      ":tvosCase": glob(
         [
           "Source/**/*.h"
         ],
@@ -290,13 +290,13 @@ objc_library(
   ],
   sdk_frameworks = select(
     {
-      ":tvosCase": [
+      "//conditions:default": [
         "UIKit"
       ],
       ":osxCase": [
         "Cocoa"
       ],
-      "//conditions:default": [
+      ":tvosCase": [
         "UIKit"
       ]
     }

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -86,12 +86,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -64,28 +64,28 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":osxCase": [
-        "AppKit"
-      ],
       "//conditions:default": [
         "UIKit"
+      ],
+      ":osxCase": [
+        "AppKit"
       ]
     }
     ),
   deps = [
-    ":Core",
-    ":Arc-exception-safe"
+    ":Arc-exception-safe",
+    ":Core"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -151,11 +151,11 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":osxCase": [
-        "AppKit"
-      ],
       "//conditions:default": [
         "UIKit"
+      ],
+      ":osxCase": [
+        "AppKit"
       ]
     }
     ),
@@ -166,12 +166,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -228,11 +228,11 @@ objc_library(
   ],
   weak_sdk_frameworks = select(
     {
-      ":osxCase": [
-        "AppKit"
-      ],
       "//conditions:default": [
         "UIKit"
+      ],
+      ":osxCase": [
+        "AppKit"
       ]
     }
     ),
@@ -243,12 +243,12 @@ objc_library(
     "-fobjc-arc-exceptions"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -66,12 +66,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -55,12 +55,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -141,12 +141,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -200,12 +200,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -260,12 +260,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -316,12 +316,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -380,19 +380,19 @@ objc_library(
     "PINRemoteImage_module_map"
   ],
   deps = [
-    ":Core",
-    "//Vendor/FLAnimatedImage:FLAnimatedImage"
+    "//Vendor/FLAnimatedImage:FLAnimatedImage",
+    ":Core"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -437,19 +437,19 @@ objc_library(
     "PINRemoteImage_module_map"
   ],
   deps = [
-    ":Core",
-    "//Vendor/libwebp:libwebp"
+    "//Vendor/libwebp:libwebp",
+    ":Core"
   ],
   copts = [
     "-DPIN_WEBP=1"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -508,19 +508,19 @@ objc_library(
     "PINRemoteImage_module_map"
   ],
   deps = [
-    ":Core",
-    "//Vendor/PINCache:PINCache"
+    "//Vendor/PINCache:PINCache",
+    ":Core"
   ],
   copts = [
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -62,12 +62,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -66,12 +66,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -77,12 +77,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -62,12 +62,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -55,12 +55,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -62,12 +62,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -79,12 +79,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -59,8 +59,8 @@ objc_library(
     ":PINRemoteImage"
   ],
   copts = [
-    "-stdlib=libc++",
-    "-std=c++11"
+    "-std=c++11",
+    "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
@@ -125,8 +125,8 @@ objc_library(
   pch = pch_with_name_hint(
     "Texture",
     [
-      "Source/**/*.pch",
-      "Base/**/*.pch"
+      "Base/**/*.pch",
+      "Source/**/*.pch"
     ]
     ),
   includes = [
@@ -142,9 +142,9 @@ objc_library(
     "c++"
   ],
   copts = [
-    "-stdlib=libc++",
+    "",
     "-std=c++11",
-    ""
+    "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
@@ -206,12 +206,12 @@ objc_library(
   ],
   deps = [
     "//Vendor/PINRemoteImage:PINCache",
-    ":Core",
-    "//Vendor/PINRemoteImage:iOS"
+    "//Vendor/PINRemoteImage:iOS",
+    ":Core"
   ],
   copts = [
-    "-stdlib=libc++",
-    "-std=c++11"
+    "-std=c++11",
+    "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
@@ -277,8 +277,8 @@ objc_library(
     ":Core"
   ],
   copts = [
-    "-stdlib=libc++",
-    "-std=c++11"
+    "-std=c++11",
+    "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
@@ -339,13 +339,13 @@ objc_library(
     "c++"
   ],
   deps = [
-    ":Core",
-    "//Vendor/Yoga:Yoga"
+    "//Vendor/Yoga:Yoga",
+    ":Core"
   ],
   copts = [
-    "-stdlib=libc++",
+    "-DYOGA=1",
     "-std=c++11",
-    "-DYOGA=1"
+    "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -69,12 +69,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -63,12 +63,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -48,20 +48,20 @@ objc_library(
     "googleapis_module_map"
   ],
   deps = [
+    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
     ":Messages",
-    ":Services",
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin"
+    ":Services"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -124,12 +124,12 @@ objc_library(
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [
@@ -188,19 +188,19 @@ objc_library(
     "googleapis_module_map"
   ],
   deps = [
-    ":Messages",
-    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC"
+    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
+    ":Messages"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -65,12 +65,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -66,12 +66,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -137,12 +137,12 @@ objc_library(
 
   ] + select(
     {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
         "-DNS_BLOCK_ASSERTIONS=1"
-      ],
-      "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
       ]
     }
     ) + [

--- a/IntegrationTests/RunTests.sh
+++ b/IntegrationTests/RunTests.sh
@@ -10,13 +10,20 @@ CMD=bin/Compiler
 # Loop through all the examples and compare outputs
 for f in $(find Examples/*); do
     GOLD_MASTER=`cat IntegrationTests/GoldMaster/$(basename $f).goldmaster`
-    OUTPUT=$($CMD $f)
+	TEMP_F=$(mktemp)
+	OUTPUT=$($CMD $f | tee $TEMP_F)
 
     if [[ "$OUTPUT" == "$GOLD_MASTER" ]]; then
         echo "PASS $f"
     else
         echo "EXPECTED $GOLD_MASTER"
-        echo "GOT $OUTPUT"
+        echo "===BEGIN OUTPUT==="
+		echo "$OUTPUT"
+        echo "===END OUTPUT==="
+        echo "===BEGIN DIFF==="
+		echo "$(diff IntegrationTests/GoldMaster/$(basename $f).goldmaster $TEMP_F)"
+        echo "===END DIFF==="
         echo "FAILURE $f"
+		exit 1
     fi
 done

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,10 @@ build-test: SWIFT_TEST_OPTS= --filter BuildTests*
 build-test: init-sandbox 
 build-test: test-impl
 
+# Run the integration tests a few times. We want to make sure output is working
+# and stable.
 integration-test: release
-	./IntegrationTests/RunTests.sh
+	for i in $$(seq 1 10); do ./IntegrationTests/RunTests.sh; done
 
 test: test-impl integration-test
 

--- a/Sources/PodToBUILD/MultiPlatform.swift
+++ b/Sources/PodToBUILD/MultiPlatform.swift
@@ -350,21 +350,43 @@ extension Optional where Wrapped == Array<String> {
         }
     }
 }
+
 extension MultiPlatform where T == [String] {
     public static func == (lhs: MultiPlatform, rhs: MultiPlatform) -> Bool {
         return lhs.ios == rhs.ios && lhs.osx == rhs.osx && lhs.watchos == rhs.watchos && lhs.tvos == rhs.tvos
     }
+
+    func sorted(by areInIncreasingOrder: (String, String) throws -> Bool) rethrows
+-> MultiPlatform<T> {
+        return try MultiPlatform(
+                ios: ios?.sorted(by: areInIncreasingOrder),
+                osx: osx?.sorted(by: areInIncreasingOrder),
+                watchos: watchos?.sorted(by: areInIncreasingOrder),
+                tvos: tvos?.sorted(by: areInIncreasingOrder)
+                )
+    }
 }
+
 extension MultiPlatform where T == Set<String> {
     public static func == (lhs: MultiPlatform, rhs: MultiPlatform) -> Bool {
         return lhs.ios == rhs.ios && lhs.osx == rhs.osx && lhs.watchos == rhs.watchos && lhs.tvos == rhs.tvos
     }   
 }
+
 extension AttrSet where T == [String] {
     public static func == (lhs: AttrSet, rhs: AttrSet) -> Bool {
         return lhs.basic == rhs.basic && lhs.multi == rhs.multi
     }
+
+    func sorted(by areInIncreasingOrder: (String, String) throws -> Bool) rethrows
+-> AttrSet<T> {
+        return try AttrSet(
+                basic: basic?.sorted(by: areInIncreasingOrder),
+                multi: multi.sorted(by: areInIncreasingOrder)
+                )
+    }
 }
+
 extension AttrSet where T == Set<String> {
     public static func == (lhs: AttrSet, rhs: AttrSet) -> Bool {
         return lhs.basic == rhs.basic && lhs.multi == rhs.multi


### PR DESCRIPTION
This commit stabilizes the output of skylark code compilation. In the
compiler, it adds sorting to types that get out of order and the
ordering of such types doesn't sorts types that may be sorted:
dictionaries.

Arrays are stabilized at `toSkylark()` when possible. In general, many
outputs of PodToBUILD are already stable, due to the way that we
construct `SkylarkConvertibles`. At this current juncture, it requires
all inputs to be stable other than dictionaries.

As part of integration tests, we run multiple times.

Intention is that this Fixes #41