### PR TITLE
Alias targets to pod name / cleanups

### DIFF
--- a/Examples/Folly.podspec.json
+++ b/Examples/Folly.podspec.json
@@ -1,0 +1,53 @@
+{
+  "name": "Folly",
+  "version": "2016.10.31.00",
+  "license": {
+    "type": "Apache License, Version 2.0"
+  },
+  "homepage": "https://github.com/facebook/folly",
+  "summary": "An open-source C++ library developed and used at Facebook.",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/folly.git",
+    "tag": "v2016.10.31.00"
+  },
+  "module_name": "folly",
+  "dependencies": {
+    "boost-for-react-native": [
+
+    ],
+    "DoubleConversion": [
+
+    ],
+    "glog": [
+
+    ]
+  },
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+  "source_files": [
+    "folly/Bits.cpp",
+    "folly/Conv.cpp",
+    "folly/Demangle.cpp",
+    "folly/StringBase.cpp",
+    "folly/Unicode.cpp",
+    "folly/dynamic.cpp",
+    "folly/json.cpp",
+    "folly/portability/BitsFunctexcept.cpp",
+    "folly/detail/MallocImpl.cpp"
+  ],
+  "preserve_paths": [
+    "folly/*.h",
+    "folly/detail/*.h",
+    "folly/portability/*.h"
+  ],
+  "libraries": "stdc++",
+  "pod_target_xcconfig": {
+    "USE_HEADERMAP": "NO",
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
+    "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\""
+  },
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  }
+}

--- a/Examples/boost-for-react-native.podspec.json
+++ b/Examples/boost-for-react-native.podspec.json
@@ -1,0 +1,23 @@
+{
+  "name": "boost-for-react-native",
+  "version": "1.63.0",
+  "license": {
+    "type": "Boost Software License",
+    "file": "LICENSE_1_0.txt"
+  },
+  "homepage": "http://www.boost.org",
+  "summary": "Boost provides free peer-reviewed portable C++ source libraries.",
+  "authors": "Rene Rivera",
+  "source": {
+    "git": "https://github.com/react-native-community/boost-for-react-native.git",
+    "tag": "v1.63.0-0"
+  },
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "9.2"
+  },
+  "requires_arc": false,
+  "module_name": "boost",
+  "header_dir": "boost",
+  "preserve_paths": "boost"
+}

--- a/Examples/glog.podspec.json
+++ b/Examples/glog.podspec.json
@@ -1,0 +1,41 @@
+{
+  "name": "glog",
+  "version": "0.3.5",
+  "license": {
+    "type": "Google",
+    "file": "COPYING"
+  },
+  "homepage": "https://github.com/google/glog",
+  "summary": "Google logging module",
+  "authors": "Google",
+  "source": {
+    "git": "https://github.com/google/glog.git",
+    "tag": "v0.3.5"
+  },
+  "module_name": "glog",
+  "header_dir": "glog",
+  "source_files": [
+    "src/glog/*.h",
+    "src/demangle.cc",
+    "src/logging.cc",
+    "src/raw_logging.cc",
+    "src/signalhandler.cc",
+    "src/symbolize.cc",
+    "src/utilities.cc",
+    "src/vlog_is_on.cc"
+  ],
+  "preserve_paths": [
+    "src/*.h",
+    "src/base/*.h"
+  ],
+  "exclude_files": "src/windows/**/*",
+  "libraries": "stdc++",
+  "pod_target_xcconfig": {
+    "USE_HEADERMAP": "NO",
+    "HEADER_SEARCH_PATHS": "$(PODS_TARGET_SRCROOT)/src"
+  },
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  }
+}

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -1,0 +1,114 @@
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'acknowledged_target')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'gen_module_map')
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://bazel.build/versions/master/docs/bazel-user-manual.html
+native.config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+  )
+filegroup(
+  name = "folly_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_module_map(
+  "folly",
+  "folly_module_map",
+  "folly",
+  [
+    "folly_hdrs"
+  ]
+  )
+alias(
+  name = "Folly",
+  actual = "folly",
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+objc_library(
+  name = "folly",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "folly/Bits.cpp",
+      "folly/Conv.cpp",
+      "folly/Demangle.cpp",
+      "folly/StringBase.cpp",
+      "folly/Unicode.cpp",
+      "folly/detail/MallocImpl.cpp",
+      "folly/dynamic.cpp",
+      "folly/json.cpp",
+      "folly/portability/BitsFunctexcept.cpp"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
+  hdrs = [
+    ":folly_hdrs"
+  ],
+  pch = pch_with_name_hint(
+    "Folly",
+    [
+      "folly/**/*.pch"
+    ]
+    ),
+  includes = [
+    "pod_support/Headers/Public/",
+    "folly_module_map"
+  ],
+  sdk_dylibs = [
+    "stdc++"
+  ],
+  deps = [
+    "//Vendor/DoubleConversion:DoubleConversion",
+    "//Vendor/boost-for-react-native:boost-for-react-native",
+    "//Vendor/glog:glog"
+  ],
+  copts = [
+    "-IVendor/DoubleConversion",
+    "-IVendor/Folly",
+    "-IVendor/boost-for-react-native",
+    "-std=c++14",
+    "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+    ) + [
+    "-IVendor/Folly/pod_support/Headers/Public/folly/"
+  ] + [
+    "-fmodule-name=folly_pod_module"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+acknowledged_target(
+  name = "folly_acknowledgement",
+  deps = [
+    "//Vendor/DoubleConversion:DoubleConversion_acknowledgement",
+    "//Vendor/boost-for-react-native:boost-for-react-native_acknowledgement",
+    "//Vendor/glog:glog_acknowledgement"
+  ],
+  value = "//Vendor/Folly/pod_support_buildable:acknowledgement_fragment"
+  )

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -13,22 +13,11 @@ native.config_setting(
   )
 filegroup(
   name = "KakaoOpenSDK_hdrs",
-  srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
-    ),
+  srcs = [
+
+  ],
   visibility = [
     "//visibility:public"
-  ]
-  )
-gen_module_map(
-  "KakaoOpenSDK",
-  "KakaoOpenSDK_module_map",
-  "KakaoOpenSDK",
-  [
-    "KakaoOpenSDK_hdrs"
   ]
   )
 objc_library(
@@ -84,22 +73,11 @@ acknowledged_target(
   )
 filegroup(
   name = "KakaoOpenSDK_hdrs",
-  srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
-    ),
+  srcs = [
+
+  ],
   visibility = [
     "//visibility:public"
-  ]
-  )
-gen_module_map(
-  "KakaoOpenSDK",
-  "KakaoOpenSDK_module_map",
-  "KakaoOpenSDK",
-  [
-    "KakaoOpenSDK_hdrs"
   ]
   )
 objc_library(

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -31,6 +31,13 @@ gen_module_map(
     "OnePasswordExtension_hdrs"
   ]
   )
+alias(
+  name = "1PasswordExtension",
+  actual = "OnePasswordExtension",
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 objc_library(
   name = "OnePasswordExtension",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/React-0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React-0.57.0.podspec.json.goldmaster
@@ -2308,20 +2308,14 @@ filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
     [
-      "pod_support/Headers/Public/**/*"
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
-  ]
-  )
-gen_module_map(
-  "RCTAnimation",
-  "RCTAnimation_module_map",
-  "RCTAnimation",
-  [
-    "RCTAnimation_hdrs"
   ]
   )
 objc_library(
@@ -3305,20 +3299,12 @@ filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
     [
-      "pod_support/Headers/Public/**/*"
+      "Libraries/fishhook/*.h"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
-  ]
-  )
-gen_module_map(
-  "fishhook",
-  "fishhook_module_map",
-  "fishhook",
-  [
-    "fishhook_hdrs"
   ]
   )
 objc_library(

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -31,6 +31,13 @@ gen_module_map(
     "AsyncDisplayKit_hdrs"
   ]
   )
+alias(
+  name = "Texture",
+  actual = "AsyncDisplayKit",
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 objc_library(
   name = "AsyncDisplayKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -1,0 +1,84 @@
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'acknowledged_target')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'gen_module_map')
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://bazel.build/versions/master/docs/bazel-user-manual.html
+native.config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+  )
+filegroup(
+  name = "boost_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_module_map(
+  "boost",
+  "boost_module_map",
+  "boost",
+  [
+    "boost_hdrs"
+  ]
+  )
+alias(
+  name = "boost-for-react-native",
+  actual = "boost",
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+objc_library(
+  name = "boost",
+  enable_modules = 0,
+  hdrs = [
+    ":boost_hdrs"
+  ],
+  pch = pch_with_name_hint(
+    "boost-for-react-native",
+    [
+
+    ]
+    ),
+  includes = [
+    "pod_support/Headers/Public/",
+    "boost_module_map"
+  ],
+  copts = [
+
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+    ) + [
+    "-IVendor/boost-for-react-native/pod_support/Headers/Public/boost/"
+  ] + [
+    "-fmodule-name=boost_pod_module"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+acknowledged_target(
+  name = "boost_acknowledgement",
+  deps = [
+
+  ],
+  value = "//Vendor/boost-for-react-native/pod_support_buildable:acknowledgement_fragment"
+  )

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -1,0 +1,112 @@
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'pch_with_name_hint')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'acknowledged_target')
+load('//Vendor/rules_pods/BazelExtensions:extensions.bzl', 'gen_module_map')
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://bazel.build/versions/master/docs/bazel-user-manual.html
+native.config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+  )
+filegroup(
+  name = "glog_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_module_map(
+  "glog",
+  "glog_module_map",
+  "glog",
+  [
+    "glog_hdrs"
+  ]
+  )
+objc_library(
+  name = "glog",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "src/demangle.cc",
+      "src/logging.cc",
+      "src/raw_logging.cc",
+      "src/signalhandler.cc",
+      "src/symbolize.cc",
+      "src/utilities.cc",
+      "src/vlog_is_on.cc"
+    ],
+    exclude = [
+      "src/windows/**/*.S",
+      "src/windows/**/*.c",
+      "src/windows/**/*.cc",
+      "src/windows/**/*.cpp",
+      "src/windows/**/*.cxx",
+      "src/windows/**/*.m",
+      "src/windows/**/*.mm",
+      "src/windows/**/*.s"
+    ],
+    exclude_directories = 1
+    ) + glob(
+    [
+      "src/glog/*.h"
+    ],
+    exclude = [
+      "src/windows/**/*.h",
+      "src/windows/**/*.hpp",
+      "src/windows/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  hdrs = [
+    ":glog_hdrs"
+  ],
+  pch = pch_with_name_hint(
+    "glog",
+    [
+      "src/**/*.pch"
+    ]
+    ),
+  includes = [
+    "pod_support/Headers/Public/",
+    "glog_module_map"
+  ],
+  sdk_dylibs = [
+    "stdc++"
+  ],
+  copts = [
+    "-IVendor/glog/src"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+    ) + [
+    "-IVendor/glog/pod_support/Headers/Public/glog/"
+  ] + [
+    "-fmodule-name=glog_pod_module"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+acknowledged_target(
+  name = "glog_acknowledgement",
+  deps = [
+
+  ],
+  value = "//Vendor/glog/pod_support_buildable:acknowledgement_fragment"
+  )

--- a/Sources/PodToBUILD/RuleUtils.swift
+++ b/Sources/PodToBUILD/RuleUtils.swift
@@ -10,6 +10,17 @@ public enum BazelSourceLibType {
     case objc
     case swift
     case cpp
+
+    func getLibNameSuffix() -> String {
+        switch self {
+        case .objc:
+            return "_objc"
+        case .cpp:
+            return "_cxx"
+        case .swift:
+            return "_swift"
+        }
+    }
 }
 
 /// Extract files from a source file pattern.
@@ -30,3 +41,15 @@ let ObjcLikeFileTypes = Set([".m", ".c", ".s", ".S"])
 let CppLikeFileTypes  = Set([".mm", ".cpp", ".cxx", ".cc"])
 let SwiftLikeFileTypes  = Set([".swift"])
 let HeaderFileTypes = Set([".h", ".hpp", ".hxx"])
+
+
+public func makeAlias(name: String, actual: String) -> SkylarkNode {
+    return SkylarkNode.functionCall(
+        name: "alias",
+        arguments: [
+            .named(name: "name", value: .string(name)),
+            .named(name: "actual", value: .string(actual)),
+            .named(name: "visibility", value: .list(["//visibility:public"]))
+        ])
+}
+

--- a/Tests/PodToBUILDTests/BuildFileTests.swift
+++ b/Tests/PodToBUILDTests/BuildFileTests.swift
@@ -27,7 +27,8 @@ class BuildFileTests: XCTestCase {
                     resources: GlobNode.empty,
                     publicHeaders: AttrSet.empty,
 			        nonArcSrcs: GlobNode.empty,
-			        requiresArc: .left(true)
+			        requiresArc: .left(true),
+                    isTopLevelTarget: false
         )
     }
 


### PR DESCRIPTION
This aliases the root lib to the pod name if it isn't already using that
name. This gives the user more flexibility in setting up their project.

Additionally add a few examples of react-native pods that triggered edge
cases.