### PR TITLE
Rework header usage / offically support React

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -31,9 +31,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Core_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Adjust_includes",
+  include = [
+    "Vendor/Adjust/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -56,10 +66,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Adjust_module_map"
-  ],
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -76,6 +82,8 @@ objc_library(
     ),
   deps = [
     ":Core"
+  ] + [
+    "Adjust_includes"
   ],
   copts = [
 
@@ -118,6 +126,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "Adjust_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/Adjust/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -132,15 +156,9 @@ objc_library(
       "plugin/Trademob/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Adjust/*.h",
-      "Adjust/ADJAdditions/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Adjust_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Adjust",
@@ -148,10 +166,6 @@ objc_library(
       "Adjust/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Adjust_module_map"
-  ],
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -166,6 +180,11 @@ objc_library(
       ]
     }
     ),
+  deps = [
+
+  ] + [
+    "Core_includes"
+  ],
   copts = [
 
   ] + select(
@@ -206,6 +225,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Sociomantic_union_hdrs",
+  srcs = [
+    "Sociomantic_hdrs",
+    "Adjust_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Sociomantic_includes",
+  include = [
+    "Vendor/Adjust/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Sociomantic",
   enable_modules = 0,
@@ -214,14 +249,9 @@ objc_library(
       "plugin/Sociomantic/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "plugin/Sociomantic/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Adjust_hdrs"
+    ":Sociomantic_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Adjust",
@@ -229,10 +259,6 @@ objc_library(
       "plugin/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Adjust_module_map"
-  ],
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -249,6 +275,8 @@ objc_library(
     ),
   deps = [
     ":Core"
+  ] + [
+    "Sociomantic_includes"
   ],
   copts = [
 
@@ -290,6 +318,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Criteo_union_hdrs",
+  srcs = [
+    "Criteo_hdrs",
+    "Adjust_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Criteo_includes",
+  include = [
+    "Vendor/Adjust/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Criteo",
   enable_modules = 0,
@@ -298,14 +342,9 @@ objc_library(
       "plugin/Criteo/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "plugin/Criteo/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Adjust_hdrs"
+    ":Criteo_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Adjust",
@@ -313,10 +352,6 @@ objc_library(
       "plugin/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Adjust_module_map"
-  ],
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -333,6 +368,8 @@ objc_library(
     ),
   deps = [
     ":Core"
+  ] + [
+    "Criteo_includes"
   ],
   copts = [
 
@@ -374,6 +411,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Trademob_union_hdrs",
+  srcs = [
+    "Trademob_hdrs",
+    "Adjust_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Trademob_includes",
+  include = [
+    "Vendor/Adjust/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Trademob",
   enable_modules = 0,
@@ -382,14 +435,9 @@ objc_library(
       "plugin/Trademob/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "plugin/Trademob/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Adjust_hdrs"
+    ":Trademob_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Adjust",
@@ -397,10 +445,6 @@ objc_library(
       "plugin/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Adjust_module_map"
-  ],
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -417,6 +461,8 @@ objc_library(
     ),
   deps = [
     ":Core"
+  ] + [
+    "Trademob_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -43,9 +43,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Tasks_hdrs",
+    ":AppLinks_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Bolts_includes",
+  include = [
+    "Vendor/Bolts/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -68,13 +79,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Bolts_module_map"
-  ],
   deps = [
     ":AppLinks",
     ":Tasks"
+  ] + [
+    "Bolts_includes"
   ],
   copts = [
 
@@ -138,6 +147,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Tasks_union_hdrs",
+  srcs = [
+    "Tasks_hdrs",
+    "Bolts_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Tasks_includes",
+  include = [
+    "Vendor/Bolts/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Tasks",
   enable_modules = 0,
@@ -171,36 +196,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Bolts/Common/*.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":osxCase": glob(
-        [
-          "Bolts/Common/*.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "Bolts/Common/*.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":watchosCase": glob(
-        [
-          "Bolts/Common/*.h"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":Bolts_hdrs"
+    ":Tasks_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Bolts",
@@ -208,9 +206,10 @@ objc_library(
       "Bolts/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Bolts_module_map"
+  deps = [
+
+  ] + [
+    "Tasks_includes"
   ],
   copts = [
 
@@ -256,6 +255,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "AppLinks_union_hdrs",
+  srcs = [
+    "AppLinks_hdrs",
+    "Bolts_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "AppLinks_includes",
+  include = [
+    "Vendor/Bolts/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "AppLinks",
   enable_modules = 0,
@@ -268,18 +283,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Bolts/iOS/**/*.h"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":Bolts_hdrs"
+    ":AppLinks_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Bolts",
@@ -287,12 +293,10 @@ objc_library(
       "Bolts/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Bolts_module_map"
-  ],
   deps = [
     ":Tasks"
+  ] + [
+    "AppLinks_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Core_hdrs",
+    ":Card_hdrs",
+    ":PayPal_hdrs",
+    ":UI_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Braintree_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,15 +57,13 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   deps = [
     ":Card",
     ":Core",
     ":PayPal",
     ":UI"
+  ] + [
+    "Braintree_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -94,6 +105,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -114,14 +141,9 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeCore/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -129,15 +151,16 @@ objc_library(
       "BraintreeCore/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "AddressBook"
   ],
   weak_sdk_frameworks = [
     "Contacts"
+  ],
+  deps = [
+
+  ] + [
+    "Core_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -179,6 +202,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Apple-Pay_union_hdrs",
+  srcs = [
+    "Apple-Pay_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Apple-Pay_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Apple-Pay",
   enable_modules = 0,
@@ -187,14 +226,9 @@ objc_library(
       "BraintreeApplePay/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeApplePay/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":Apple-Pay_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -202,15 +236,13 @@ objc_library(
       "BraintreeApplePay/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "PassKit"
   ],
   deps = [
     ":Core"
+  ] + [
+    "Apple-Pay_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -252,6 +284,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Card_union_hdrs",
+  srcs = [
+    "Card_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Card_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Card",
   enable_modules = 0,
@@ -265,14 +313,9 @@ objc_library(
       "BraintreeUnionPay/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeCard/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":Card_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -280,12 +323,10 @@ objc_library(
       "BraintreeCard/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "Card_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -327,6 +368,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "DataCollector_union_hdrs",
+  srcs = [
+    "DataCollector_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "DataCollector_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "DataCollector",
   enable_modules = 0,
@@ -335,14 +392,9 @@ objc_library(
       "BraintreeDataCollector/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeDataCollector/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":DataCollector_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -350,13 +402,11 @@ objc_library(
       "BraintreeDataCollector/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   deps = [
     ":Core",
     ":DataCollector_VendoredLibraries"
+  ] + [
+    "DataCollector_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -405,6 +455,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PayPal_union_hdrs",
+  srcs = [
+    "PayPal_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PayPal_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PayPal",
   enable_modules = 0,
@@ -413,15 +479,9 @@ objc_library(
       "BraintreePayPal/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreePayPal/*.h",
-      "BraintreePayPal/Public/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":PayPal_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -429,13 +489,11 @@ objc_library(
       "BraintreePayPal/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   deps = [
     ":Core",
     ":PayPalOneTouch"
+  ] + [
+    "PayPal_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -477,6 +535,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Venmo_union_hdrs",
+  srcs = [
+    "Venmo_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Venmo_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Venmo",
   enable_modules = 0,
@@ -485,14 +559,9 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeVenmo/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":Venmo_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -500,13 +569,11 @@ objc_library(
       "BraintreeVenmo/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   deps = [
     ":Core",
     ":PayPalDataCollector"
+  ] + [
+    "Venmo_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -566,6 +633,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "UI_union_hdrs",
+  srcs = [
+    "UI_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "UI_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "UI",
   enable_modules = 0,
@@ -574,14 +657,9 @@ objc_library(
       "BraintreeUI/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeUI/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":UI_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -589,16 +667,14 @@ objc_library(
       "BraintreeUI/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
     ":Core"
+  ] + [
+    "UI_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -644,6 +720,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "UnionPay_union_hdrs",
+  srcs = [
+    "UnionPay_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "UnionPay_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "UnionPay",
   enable_modules = 0,
@@ -652,14 +744,9 @@ objc_library(
       "BraintreeUnionPay/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreeUnionPay/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":UnionPay_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -667,16 +754,14 @@ objc_library(
       "BraintreeUnionPay/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
     ":Core"
+  ] + [
+    "UnionPay_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -727,6 +812,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "3D-Secure_union_hdrs",
+  srcs = [
+    "3D-Secure_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "3D-Secure_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "3D-Secure",
   enable_modules = 0,
@@ -735,14 +836,9 @@ objc_library(
       "Braintree3DSecure/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Braintree3DSecure/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":3D-Secure_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -750,16 +846,14 @@ objc_library(
       "Braintree3DSecure/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
     ":Core"
+  ] + [
+    "3D-Secure_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -804,6 +898,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PayPalOneTouch_union_hdrs",
+  srcs = [
+    "PayPalOneTouch_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PayPalOneTouch_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PayPalOneTouch",
   enable_modules = 0,
@@ -815,14 +925,9 @@ objc_library(
       "BraintreePayPal/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreePayPal/PayPalOneTouch/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":PayPalOneTouch_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -830,10 +935,6 @@ objc_library(
       "BraintreePayPal/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
@@ -844,6 +945,8 @@ objc_library(
     ":Core",
     ":PayPalDataCollector",
     ":PayPalUtils"
+  ] + [
+    "PayPalOneTouch_includes"
   ],
   copts = [
     "-ObjC",
@@ -887,6 +990,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PayPalDataCollector_union_hdrs",
+  srcs = [
+    "PayPalDataCollector_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PayPalDataCollector_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PayPalDataCollector",
   enable_modules = 0,
@@ -900,14 +1019,9 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreePayPal/PayPalDataCollector/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":PayPalDataCollector_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -915,10 +1029,6 @@ objc_library(
       "BraintreePayPal/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",
@@ -929,6 +1039,8 @@ objc_library(
     ":Core",
     ":PayPalDataCollector_VendoredLibraries",
     ":PayPalUtils"
+  ] + [
+    "PayPalDataCollector_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -976,6 +1088,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PayPalUtils_union_hdrs",
+  srcs = [
+    "PayPalUtils_hdrs",
+    "Braintree_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PayPalUtils_includes",
+  include = [
+    "Vendor/Braintree/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PayPalUtils",
   enable_modules = 0,
@@ -990,14 +1118,9 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "BraintreePayPal/PayPalUtils/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Braintree_hdrs"
+    ":PayPalUtils_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Braintree",
@@ -1005,15 +1128,16 @@ objc_library(
       "BraintreePayPal/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Braintree_module_map"
-  ],
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",
     "CoreLocation",
     "UIKit"
+  ],
+  deps = [
+
+  ] + [
+    "PayPalUtils_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -19,9 +19,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Core_hdrs",
+    ":without-IDFA_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Branch_includes",
+  include = [
+    "Vendor/Branch/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,13 +55,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Branch_module_map"
-  ],
   deps = [
     ":Core",
     ":without-IDFA"
+  ] + [
+    "Branch_includes"
   ],
   copts = [
 
@@ -94,6 +103,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "Branch_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/Branch/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -103,16 +128,9 @@ objc_library(
       "Branch-SDK/Branch-SDK/Requests/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Branch_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Branch",
@@ -120,14 +138,15 @@ objc_library(
       "Branch-SDK/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Branch_module_map"
-  ],
   sdk_frameworks = [
     "AdSupport",
     "CoreTelephony",
     "MobileCoreServices"
+  ],
+  deps = [
+
+  ] + [
+    "Core_includes"
   ],
   copts = [
 
@@ -171,6 +190,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "without-IDFA_union_hdrs",
+  srcs = [
+    "without-IDFA_hdrs",
+    "Branch_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "without-IDFA_includes",
+  include = [
+    "Vendor/Branch/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "without-IDFA",
   enable_modules = 0,
@@ -180,16 +215,9 @@ objc_library(
       "Branch-SDK/Branch-SDK/Requests/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":Branch_hdrs"
+    ":without-IDFA_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Branch",
@@ -197,13 +225,14 @@ objc_library(
       "Branch-SDK/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Branch_module_map"
-  ],
   sdk_frameworks = [
     "CoreTelephony",
     "MobileCoreServices"
+  ],
+  deps = [
+
+  ] + [
+    "without-IDFA_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -32,6 +32,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Calabash_cxx_union_hdrs",
+  srcs = [
+    "Calabash_cxx_hdrs",
+    "Calabash_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Calabash_cxx_includes",
+  include = [
+    "Vendor/Calabash/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Calabash_cxx",
   enable_modules = 0,
@@ -48,13 +64,6 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   non_arc_srcs = glob(
     [
@@ -66,7 +75,7 @@ objc_library(
     exclude_directories = 1
     ),
   hdrs = [
-    ":Calabash_hdrs"
+    ":Calabash_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Calabash",
@@ -74,10 +83,6 @@ objc_library(
       "calabash.framework/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Calabash_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -85,6 +90,11 @@ objc_library(
       ]
     }
     ),
+  deps = [
+
+  ] + [
+    "Calabash_cxx_includes"
+  ],
   copts = [
     ""Vendor/Calabash/calabash.framework/calabash"",
     "-ObjC",
@@ -122,9 +132,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":Calabash_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Calabash_includes",
+  include = [
+    "Vendor/Calabash/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -145,13 +170,6 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   non_arc_srcs = glob(
     [
@@ -168,10 +186,6 @@ objc_library(
       "calabash.framework/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Calabash_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -181,6 +195,8 @@ objc_library(
     ),
   deps = [
     ":Calabash_cxx"
+  ] + [
+    "Calabash_includes"
   ],
   copts = [
     ""Vendor/Calabash/calabash.framework/calabash"",

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "CardIO/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "CardIO_includes",
+  include = [
+    "Vendor/CardIO/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +57,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "CardIO_module_map"
-  ],
   sdk_frameworks = [
     "Accelerate",
     "AVFoundation",
@@ -65,6 +74,8 @@ objc_library(
   ],
   deps = [
     ":CardIO_VendoredLibraries"
+  ] + [
+    "CardIO_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "ColorCube/ColorCube/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "ColorCube_includes",
+  include = [
+    "Vendor/ColorCube/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "ColorCube/ColorCube/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ColorCube/ColorCube/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":ColorCube_hdrs"
@@ -55,9 +63,10 @@ objc_library(
       "ColorCube/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "ColorCube_module_map"
+  deps = [
+
+  ] + [
+    "ColorCube_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -25,9 +25,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "EarlGrey_includes",
+  include = [
+    "Vendor/EarlGrey/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -50,10 +60,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "EarlGrey_module_map"
-  ],
   sdk_frameworks = [
     "CoreData",
     "CoreFoundation",
@@ -66,6 +72,8 @@ objc_library(
   ],
   deps = [
     ":EarlGrey_VendoredFrameworks"
+  ] + [
+    "EarlGrey_includes"
   ],
   copts = [
     "-fobjc-arc-exceptions"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -31,9 +31,68 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + select(
+    {
+      "//conditions:default": glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
+        ],
+        exclude_directories = 1
+        ),
+      ":tvosCase": glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
+          "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+        ],
+        exclude_directories = 1
+        )
+    }
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FBSDKCoreKit_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -127,57 +186,6 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
-        ],
-        exclude = [
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
-        ],
-        exclude = [
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
-          "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hxx",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hxx",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   non_arc_srcs = select(
     {
@@ -241,10 +249,6 @@ objc_library(
       "FBSDKCoreKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FBSDKCoreKit_module_map"
-  ],
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -277,7 +281,9 @@ objc_library(
         "//Vendor/Bolts:Bolts"
       ]
     }
-    ),
+    ) + [
+    "FBSDKCoreKit_includes"
+  ],
   copts = [
 
   ] + select(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FBSDKLoginKit_includes",
+  include = [
+    "Vendor/FBSDKLoginKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "FBSDKLoginKit/FBSDKLoginKit/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":FBSDKLoginKit_hdrs"
@@ -55,10 +63,6 @@ objc_library(
       "FBSDKLoginKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FBSDKLoginKit_module_map"
-  ],
   weak_sdk_frameworks = [
     "Accounts",
     "CoreLocation",
@@ -72,6 +76,8 @@ objc_library(
   ],
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
+  ] + [
+    "FBSDKLoginKit_includes"
   ],
   copts = [
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -19,9 +19,25 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "FBSDKMessengerShareKit/**/*.h",
+      "FBSDKMessengerShareKit/**/*.hpp",
+      "FBSDKMessengerShareKit/**/*.hxx",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FBSDKMessengerShareKit_includes",
+  include = [
+    "Vendor/FBSDKMessengerShareKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +56,6 @@ objc_library(
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"
@@ -55,9 +66,10 @@ objc_library(
       "FBSDKMessengerShareKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FBSDKMessengerShareKit_module_map"
+  deps = [
+
+  ] + [
+    "FBSDKMessengerShareKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -31,9 +31,65 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + select(
+    {
+      "//conditions:default": glob(
+        [
+          "FBSDKShareKit/**/*.h",
+          "FBSDKShareKit/**/*.hpp",
+          "FBSDKShareKit/**/*.hxx",
+          "FBSDKShareKit/FBSDKShareKit/**/*.h"
+        ],
+        exclude = [
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
+        ],
+        exclude_directories = 1
+        ),
+      ":tvosCase": glob(
+        [
+          "FBSDKShareKit/**/*.h",
+          "FBSDKShareKit/**/*.hpp",
+          "FBSDKShareKit/**/*.hxx",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ],
+        exclude_directories = 1
+        )
+    }
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FBSDKShareKit_includes",
+  include = [
+    "Vendor/FBSDKShareKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -83,48 +139,6 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "FBSDKShareKit/FBSDKShareKit/**/*.h"
-        ],
-        exclude = [
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
     ":FBSDKShareKit_hdrs"
@@ -135,10 +149,6 @@ objc_library(
       "FBSDKShareKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FBSDKShareKit_module_map"
-  ],
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -165,6 +175,8 @@ objc_library(
     ),
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
+  ] + [
+    "FBSDKShareKit_includes"
   ],
   copts = [
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "FLAnimatedImage/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FLAnimatedImage_includes",
+  include = [
+    "Vendor/FLAnimatedImage/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "FLAnimatedImage/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "FLAnimatedImage/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
@@ -55,15 +63,16 @@ objc_library(
       "FLAnimatedImage/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FLAnimatedImage_module_map"
-  ],
   sdk_frameworks = [
     "QuartzCore",
     "ImageIO",
     "MobileCoreServices",
     "CoreGraphics"
+  ],
+  deps = [
+
+  ] + [
+    "FLAnimatedImage_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Classes/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FLEX_includes",
+  include = [
+    "Vendor/FLEX/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "Classes/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Classes/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":FLEX_hdrs"
@@ -55,10 +63,6 @@ objc_library(
       "Classes/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FLEX_module_map"
-  ],
   sdk_frameworks = [
     "Foundation",
     "UIKit",
@@ -67,6 +71,11 @@ objc_library(
   sdk_dylibs = [
     "z",
     "sqlite3"
+  ],
+  deps = [
+
+  ] + [
+    "FLEX_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":standard_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FMDB_includes",
+  include = [
+    "Vendor/FMDB/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,12 +54,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FMDB_module_map"
-  ],
   deps = [
     ":standard"
+  ] + [
+    "FMDB_includes"
   ],
   copts = [
 
@@ -91,6 +99,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "standard_union_hdrs",
+  srcs = [
+    "standard_hdrs",
+    "FMDB_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "standard_includes",
+  include = [
+    "Vendor/FMDB/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "standard",
   enable_modules = 0,
@@ -103,14 +127,9 @@ objc_library(
       "src/fmdb.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":FMDB_hdrs"
+    ":standard_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "FMDB",
@@ -118,12 +137,13 @@ objc_library(
       "src/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FMDB_module_map"
-  ],
   sdk_dylibs = [
     "sqlite3"
+  ],
+  deps = [
+
+  ] + [
+    "standard_includes"
   ],
   copts = [
 
@@ -165,6 +185,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "FTS_union_hdrs",
+  srcs = [
+    "FTS_hdrs",
+    "FMDB_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FTS_includes",
+  include = [
+    "Vendor/FMDB/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "FTS",
   enable_modules = 0,
@@ -173,14 +209,9 @@ objc_library(
       "src/extra/fts3/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "src/extra/fts3/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":FMDB_hdrs"
+    ":FTS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "FMDB",
@@ -188,12 +219,10 @@ objc_library(
       "src/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FMDB_module_map"
-  ],
   deps = [
     ":standard"
+  ] + [
+    "FTS_includes"
   ],
   copts = [
 
@@ -232,11 +261,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "standalone_union_hdrs",
+  srcs = [
+    "standalone_hdrs",
+    "FMDB_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "standalone_includes",
+  include = [
+    "Vendor/FMDB/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "standalone",
   enable_modules = 0,
   hdrs = [
-    ":FMDB_hdrs"
+    ":standalone_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "FMDB",
@@ -244,9 +289,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FMDB_module_map"
+  deps = [
+
+  ] + [
+    "standalone_includes"
   ],
   copts = [
     "-DFMDB_SQLITE_STANDALONE"
@@ -288,6 +334,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "SQLCipher_union_hdrs",
+  srcs = [
+    "SQLCipher_hdrs",
+    "FMDB_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "SQLCipher_includes",
+  include = [
+    "Vendor/FMDB/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "SQLCipher",
   enable_modules = 0,
@@ -299,14 +361,9 @@ objc_library(
       "src/fmdb.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":FMDB_hdrs"
+    ":SQLCipher_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "FMDB",
@@ -314,12 +371,10 @@ objc_library(
       "src/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "FMDB_module_map"
-  ],
   deps = [
     "//Vendor/SQLCipher:SQLCipher"
+  ] + [
+    "SQLCipher_includes"
   ],
   copts = [
     "-DHAVE_USLEEP=1",

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -13,13 +13,22 @@ native.config_setting(
   }
   )
 filegroup(
-  name = "folly_hdrs",
+  name = "Folly_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "folly/*.h",
+      "folly/detail/*.h",
+      "folly/portability/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -34,10 +43,10 @@ gen_includes(
   )
 gen_module_map(
   "folly",
-  "folly_module_map",
+  "Folly_module_map",
   "folly",
   [
-    "folly_hdrs"
+    "Folly_hdrs"
   ]
   )
 alias(
@@ -63,11 +72,9 @@ objc_library(
       "folly/portability/BitsFunctexcept.cpp"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+    ),
   hdrs = [
-    ":folly_hdrs"
+    ":Folly_hdrs"
   ],
   pch = pch_with_name_hint(
     "Folly",
@@ -75,10 +82,6 @@ objc_library(
       "folly/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "folly_module_map"
-  ],
   sdk_dylibs = [
     "stdc++"
   ],
@@ -103,7 +106,7 @@ objc_library(
       ]
     }
     ) + [
-    "-IVendor/Folly/pod_support/Headers/Public/folly/"
+
   ] + [
     "-fmodule-name=folly_pod_module"
   ],

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -19,9 +19,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Changelog/**/*.h",
+      "Changelog/**/*.hpp",
+      "Changelog/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleAppIndexing_includes",
+  include = [
+    "Vendor/GoogleAppIndexing/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +59,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleAppIndexing_module_map"
-  ],
   sdk_frameworks = [
     "CoreText",
     "SafariServices"
@@ -55,6 +66,8 @@ objc_library(
   deps = [
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
     ":GoogleAppIndexing_VendoredFrameworks"
+  ] + [
+    "GoogleAppIndexing_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleAppUtilities_includes",
+  include = [
+    "Vendor/GoogleAppUtilities/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,13 +54,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleAppUtilities_module_map"
-  ],
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleAppUtilities_VendoredFrameworks"
+  ] + [
+    "GoogleAppUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleAuthUtilities_includes",
+  include = [
+    "Vendor/GoogleAuthUtilities/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +54,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleAuthUtilities_module_map"
-  ],
   sdk_frameworks = [
     "Security",
     "SystemConfiguration"
@@ -56,6 +62,8 @@ objc_library(
     "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleAuthUtilities_VendoredFrameworks"
+  ] + [
+    "GoogleAuthUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleNetworkingUtilities_includes",
+  include = [
+    "Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,16 +54,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleNetworkingUtilities_module_map"
-  ],
   sdk_frameworks = [
     "Security"
   ],
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleNetworkingUtilities_VendoredFrameworks"
+  ] + [
+    "GoogleNetworkingUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleSignIn_includes",
+  include = [
+    "Vendor/GoogleSignIn/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +54,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleSignIn_module_map"
-  ],
   sdk_frameworks = [
     "CoreText",
     "SafariServices",
@@ -60,6 +66,8 @@ objc_library(
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
     ":GoogleSignIn_Bundle_GoogleSignIn",
     ":GoogleSignIn_VendoredFrameworks"
+  ] + [
+    "GoogleSignIn_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleSymbolUtilities_includes",
+  include = [
+    "Vendor/GoogleSymbolUtilities/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,12 +54,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleSymbolUtilities_module_map"
-  ],
   deps = [
     ":GoogleSymbolUtilities_VendoredFrameworks"
+  ] + [
+    "GoogleSymbolUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -19,9 +19,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "GoogleUtilities_includes",
+  include = [
+    "Vendor/GoogleUtilities/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +54,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "GoogleUtilities_module_map"
-  ],
   sdk_frameworks = [
     "AddressBook",
     "CoreGraphics"
@@ -58,6 +64,8 @@ objc_library(
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleUtilities_VendoredFrameworks"
+  ] + [
+    "GoogleUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "IBActionSheet_includes",
+  include = [
+    "Vendor/IBActionSheet/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":IBActionSheet_hdrs"
@@ -55,12 +63,13 @@ objc_library(
       "IBActionSheetSample/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IBActionSheet_module_map"
-  ],
   sdk_frameworks = [
     "QuartzCore"
+  ],
+  deps = [
+
+  ] + [
+    "IBActionSheet_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -37,9 +37,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Default_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "IGListKit_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -62,10 +72,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IGListKit_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -84,6 +90,8 @@ objc_library(
   ],
   deps = [
     ":Default"
+  ] + [
+    "IGListKit_includes"
   ],
   copts = [
 
@@ -117,12 +125,29 @@ filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
     [
-      "Source/Common/**/*.h"
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Diffing_cxx_union_hdrs",
+  srcs = [
+    "Diffing_cxx_hdrs",
+    "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Diffing_cxx_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -153,14 +178,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + glob(
-    [
-      "Source/Common/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":IGListKit_hdrs"
+    ":Diffing_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "IGListKit",
@@ -168,10 +188,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IGListKit_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -187,6 +203,11 @@ objc_library(
     ),
   sdk_dylibs = [
     "c++"
+  ],
+  deps = [
+
+  ] + [
+    "Diffing_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -221,12 +242,29 @@ filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
     [
-      "Source/Common/**/*.h"
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Diffing_union_hdrs",
+  srcs = [
+    "Diffing_hdrs",
+    "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Diffing_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -255,14 +293,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + glob(
-    [
-      "Source/Common/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":IGListKit_hdrs"
+    ":Diffing_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "IGListKit",
@@ -270,10 +303,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IGListKit_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -292,6 +321,8 @@ objc_library(
   ],
   deps = [
     ":Diffing_cxx"
+  ] + [
+    "Diffing_includes"
   ],
   copts = [
 
@@ -327,13 +358,17 @@ filegroup(
     {
       "//conditions:default": glob(
         [
-          "Source/**/*.h"
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
         ],
         exclude_directories = 1
         ),
       ":tvosCase": glob(
         [
-          "Source/**/*.h"
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
         ],
         exclude_directories = 1
         )
@@ -341,6 +376,22 @@ filegroup(
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Default_cxx_union_hdrs",
+  srcs = [
+    "Default_cxx_hdrs",
+    "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Default_cxx_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -367,24 +418,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Source/**/*.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "Source/**/*.h"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":IGListKit_hdrs"
+    ":Default_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "IGListKit",
@@ -392,10 +428,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IGListKit_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -414,6 +446,8 @@ objc_library(
   ],
   deps = [
     ":Diffing"
+  ] + [
+    "Default_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -450,13 +484,17 @@ filegroup(
     {
       "//conditions:default": glob(
         [
-          "Source/**/*.h"
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
         ],
         exclude_directories = 1
         ),
       ":tvosCase": glob(
         [
-          "Source/**/*.h"
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
         ],
         exclude_directories = 1
         )
@@ -464,6 +502,22 @@ filegroup(
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Default_union_hdrs",
+  srcs = [
+    "Default_hdrs",
+    "IGListKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Default_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -484,24 +538,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Source/**/*.h"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "Source/**/*.h"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":IGListKit_hdrs"
+    ":Default_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "IGListKit",
@@ -509,10 +548,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "IGListKit_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -532,6 +567,8 @@ objc_library(
   deps = [
     ":Default_cxx",
     ":Diffing"
+  ] + [
+    "Default_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "FBKVOController/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KVOController_includes",
+  include = [
+    "Vendor/KVOController/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "FBKVOController/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "FBKVOController/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":KVOController_hdrs"
@@ -55,9 +63,10 @@ objc_library(
       "FBKVOController/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KVOController_module_map"
+  deps = [
+
+  ] + [
+    "KVOController_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -21,11 +21,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "KakaoOpenSDK_union_hdrs",
+  srcs = [
+    "KakaoOpenSDK_hdrs",
+    "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KakaoOpenSDK_includes",
+  include = [
+    "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "KakaoOpenSDK",
   enable_modules = 0,
   hdrs = [
-    ":KakaoOpenSDK_hdrs"
+    ":KakaoOpenSDK_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
@@ -33,16 +49,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KakaoOpenSDK_module_map"
-  ],
   sdk_frameworks = [
     "UIKit",
     "WebKit"
   ],
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks"
+  ] + [
+    "KakaoOpenSDK_includes"
   ],
   copts = [
 
@@ -81,11 +95,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "KakaoOpenSDK_union_hdrs",
+  srcs = [
+    "KakaoOpenSDK_hdrs",
+    "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KakaoOpenSDK_includes",
+  include = [
+    "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "KakaoOpenSDK",
   enable_modules = 0,
   hdrs = [
-    ":KakaoOpenSDK_hdrs"
+    ":KakaoOpenSDK_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
@@ -93,16 +123,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KakaoOpenSDK_module_map"
-  ],
   sdk_frameworks = [
     "UIKit",
     "WebKit"
   ],
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks"
+  ] + [
+    "KakaoOpenSDK_includes"
   ],
   copts = [
 
@@ -154,11 +182,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "KakaoNavi_union_hdrs",
+  srcs = [
+    "KakaoNavi_hdrs",
+    "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KakaoNavi_includes",
+  include = [
+    "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "KakaoNavi",
   enable_modules = 0,
   hdrs = [
-    ":KakaoOpenSDK_hdrs"
+    ":KakaoNavi_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
@@ -166,15 +210,13 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KakaoOpenSDK_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":KakaoNavi_VendoredFrameworks"
+  ] + [
+    "KakaoNavi_includes"
   ],
   copts = [
 
@@ -226,11 +268,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "KakaoLink_union_hdrs",
+  srcs = [
+    "KakaoLink_hdrs",
+    "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KakaoLink_includes",
+  include = [
+    "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "KakaoLink",
   enable_modules = 0,
   hdrs = [
-    ":KakaoOpenSDK_hdrs"
+    ":KakaoLink_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
@@ -238,15 +296,13 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KakaoOpenSDK_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":KakaoLink_VendoredFrameworks"
+  ] + [
+    "KakaoLink_includes"
   ],
   copts = [
 
@@ -298,11 +354,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "KakaoS2_union_hdrs",
+  srcs = [
+    "KakaoS2_hdrs",
+    "KakaoOpenSDK_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "KakaoS2_includes",
+  include = [
+    "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "KakaoS2",
   enable_modules = 0,
   hdrs = [
-    ":KakaoOpenSDK_hdrs"
+    ":KakaoS2_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
@@ -310,15 +382,13 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "KakaoOpenSDK_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
   ],
   deps = [
     ":KakaoS2_VendoredFrameworks"
+  ] + [
+    "KakaoS2_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -37,9 +37,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Masonry/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Masonry_includes",
+  include = [
+    "Vendor/Masonry/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -58,11 +71,6 @@ objc_library(
       "Masonry/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Masonry/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":Masonry_hdrs"
@@ -73,10 +81,6 @@ objc_library(
       "Masonry/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Masonry_module_map"
-  ],
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -93,6 +97,11 @@ objc_library(
       ]
     }
     ),
+  deps = [
+
+  ] + [
+    "Masonry_includes"
+  ],
   copts = [
 
   ] + select(

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -13,23 +13,41 @@ native.config_setting(
   }
   )
 filegroup(
-  name = "OnePasswordExtension_hdrs",
+  name = "1PasswordExtension_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "*.h"
+    ],
+    exclude = [
+      "Demos/**/*.h",
+      "Demos/**/*.hpp",
+      "Demos/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
   ]
   )
+gen_includes(
+  name = "OnePasswordExtension_includes",
+  include = [
+    "Vendor/OnePasswordExtension/pod_support/Headers/Public/"
+  ]
+  )
 gen_module_map(
   "OnePasswordExtension",
-  "OnePasswordExtension_module_map",
+  "1PasswordExtension_module_map",
   "OnePasswordExtension",
   [
-    "OnePasswordExtension_hdrs"
+    "1PasswordExtension_hdrs"
   ]
   )
 alias(
@@ -57,19 +75,9 @@ objc_library(
       "Demos/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "*.h"
-    ],
-    exclude = [
-      "Demos/**/*.h",
-      "Demos/**/*.hpp",
-      "Demos/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":OnePasswordExtension_hdrs"
+    ":1PasswordExtension_hdrs"
   ],
   pch = pch_with_name_hint(
     "1PasswordExtension",
@@ -77,10 +85,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "OnePasswordExtension_module_map"
-  ],
   sdk_frameworks = [
     "Foundation",
     "MobileCoreServices",
@@ -91,6 +95,8 @@ objc_library(
   ],
   deps = [
     ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
+  ] + [
+    "OnePasswordExtension_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -31,9 +31,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Core_hdrs",
+    ":Arc-exception-safe_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINCache_includes",
+  include = [
+    "Vendor/PINCache/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -56,10 +67,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINCache_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
   ],
@@ -76,6 +83,8 @@ objc_library(
   deps = [
     ":Arc-exception-safe",
     ":Core"
+  ] + [
+    "PINCache_includes"
   ],
   copts = [
 
@@ -117,6 +126,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "PINCache_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/PINCache/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -128,14 +153,9 @@ objc_library(
       "Source/PINDiskCache.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":PINCache_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINCache",
@@ -143,10 +163,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINCache_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
   ],
@@ -162,6 +178,8 @@ objc_library(
     ),
   deps = [
     "//Vendor/PINOperation:PINOperation"
+  ] + [
+    "Core_includes"
   ],
   copts = [
 
@@ -200,6 +218,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Arc-exception-safe_union_hdrs",
+  srcs = [
+    "Arc-exception-safe_hdrs",
+    "PINCache_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Arc-exception-safe_includes",
+  include = [
+    "Vendor/PINCache/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Arc-exception-safe",
   enable_modules = 0,
@@ -208,11 +242,9 @@ objc_library(
       "Source/PINDiskCache.m"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+    ),
   hdrs = [
-    ":PINCache_hdrs"
+    ":Arc-exception-safe_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINCache",
@@ -220,10 +252,6 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINCache_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
   ],
@@ -239,6 +267,8 @@ objc_library(
     ),
   deps = [
     ":Core"
+  ] + [
+    "Arc-exception-safe_includes"
   ],
   copts = [
     "-fobjc-arc-exceptions"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -24,6 +24,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PINOperation_cxx_union_hdrs",
+  srcs = [
+    "PINOperation_cxx_hdrs",
+    "PINOperation_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINOperation_cxx_includes",
+  include = [
+    "Vendor/PINOperation/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PINOperation_cxx",
   enable_modules = 0,
@@ -35,14 +51,9 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":PINOperation_hdrs"
+    ":PINOperation_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINOperation",
@@ -50,12 +61,13 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINOperation_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
+  ],
+  deps = [
+
+  ] + [
+    "PINOperation_cxx_includes"
   ],
   copts = [
 
@@ -92,9 +104,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Source/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":PINOperation_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINOperation_includes",
+  include = [
+    "Vendor/PINOperation/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -113,11 +138,6 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":PINOperation_hdrs"
@@ -128,15 +148,13 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINOperation_module_map"
-  ],
   sdk_frameworks = [
     "Foundation"
   ],
   deps = [
     ":PINOperation_cxx"
+  ] + [
+    "PINOperation_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -19,9 +19,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":FLAnimatedImage_hdrs",
+    ":PINCache_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINRemoteImage_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,13 +55,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   deps = [
     ":FLAnimatedImage",
     ":PINCache"
+  ] + [
+    "PINRemoteImage_includes"
   ],
   copts = [
 
@@ -96,6 +105,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -108,18 +133,9 @@ objc_library(
       "Source/Classes/PINCache/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/Classes/**/*.h"
-    ],
-    exclude = [
-      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
-      "Source/Classes/PINCache/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -127,16 +143,14 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   sdk_frameworks = [
     "ImageIO",
     "Accelerate"
   ],
   deps = [
     "//Vendor/PINOperation:PINOperation"
+  ] + [
+    "Core_includes"
   ],
   copts = [
 
@@ -175,11 +189,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "iOS_union_hdrs",
+  srcs = [
+    "iOS_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "iOS_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "iOS",
   enable_modules = 0,
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":iOS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -187,15 +217,13 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Core"
+  ] + [
+    "iOS_includes"
   ],
   copts = [
 
@@ -234,11 +262,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "OSX_union_hdrs",
+  srcs = [
+    "OSX_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "OSX_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "OSX",
   enable_modules = 0,
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":OSX_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -246,16 +290,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   sdk_frameworks = [
     "Cocoa",
     "CoreServices"
   ],
   deps = [
     ":Core"
+  ] + [
+    "OSX_includes"
   ],
   copts = [
 
@@ -294,11 +336,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "tvOS_union_hdrs",
+  srcs = [
+    "tvOS_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "tvOS_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "tvOS",
   enable_modules = 0,
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":tvOS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -306,12 +364,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   deps = [
     ":iOS"
+  ] + [
+    "tvOS_includes"
   ],
   copts = [
 
@@ -353,6 +409,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "FLAnimatedImage_union_hdrs",
+  srcs = [
+    "FLAnimatedImage_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "FLAnimatedImage_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "FLAnimatedImage",
   enable_modules = 0,
@@ -361,14 +433,9 @@ objc_library(
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":FLAnimatedImage_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -376,13 +443,11 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   deps = [
     "//Vendor/FLAnimatedImage:FLAnimatedImage",
     ":Core"
+  ] + [
+    "FLAnimatedImage_includes"
   ],
   copts = [
 
@@ -421,11 +486,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "WebP_union_hdrs",
+  srcs = [
+    "WebP_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "WebP_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "WebP",
   enable_modules = 0,
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":WebP_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -433,13 +514,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   deps = [
     "//Vendor/libwebp:libwebp",
     ":Core"
+  ] + [
+    "WebP_includes"
   ],
   copts = [
     "-DPIN_WEBP=1"
@@ -481,6 +560,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PINCache_union_hdrs",
+  srcs = [
+    "PINCache_hdrs",
+    "PINRemoteImage_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINCache_includes",
+  include = [
+    "Vendor/PINRemoteImage/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "PINCache",
   enable_modules = 0,
@@ -489,14 +584,9 @@ objc_library(
       "Source/Classes/PINCache/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/Classes/PINCache/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":PINRemoteImage_hdrs"
+    ":PINCache_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
@@ -504,13 +594,11 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PINRemoteImage_module_map"
-  ],
   deps = [
     "//Vendor/PINCache:PINCache",
     ":Core"
+  ] + [
+    "PINCache_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "PaymentKit/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PaymentKit_includes",
+  include = [
+    "Vendor/PaymentKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "PaymentKit/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "PaymentKit/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":PaymentKit_hdrs"
@@ -55,9 +63,10 @@ objc_library(
       "PaymentKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "PaymentKit_module_map"
+  deps = [
+
+  ] + [
+    "PaymentKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "RadarKit/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RadarKit_includes",
+  include = [
+    "Vendor/RadarKit/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "RadarKit/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "RadarKit/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":RadarKit_hdrs"
@@ -55,13 +63,14 @@ objc_library(
       "RadarKit/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "RadarKit_module_map"
-  ],
   sdk_frameworks = [
     "Foundation",
     "SystemConfiguration"
+  ],
+  deps = [
+
+  ] + [
+    "RadarKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/React-0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React-0.57.0.podspec.json.goldmaster
@@ -31,9 +31,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Core_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "React_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -56,12 +66,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "React_includes"
   ],
   copts = [
 
@@ -97,7 +105,9 @@ filegroup(
     {
       "//conditions:default": glob(
         [
-          "React/**/*.h"
+          "React/**/*.h",
+          "React/**/*.hpp",
+          "React/**/*.hxx"
         ],
         exclude = [
           "**/__tests__/*.h",
@@ -129,7 +139,9 @@ filegroup(
         ),
       ":tvosCase": glob(
         [
-          "React/**/*.h"
+          "React/**/*.h",
+          "React/**/*.hpp",
+          "React/**/*.hxx"
         ],
         exclude = [
           "**/__tests__/*.h",
@@ -183,10 +195,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_cxx_union_hdrs",
+  srcs = [
+    "Core_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "Core_cxx_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -450,94 +473,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "React/**/*.h"
-        ],
-        exclude = [
-          "**/__tests__/*.h",
-          "**/__tests__/*.hpp",
-          "**/__tests__/*.hxx",
-          "IntegrationTests/*.h",
-          "IntegrationTests/*.hpp",
-          "IntegrationTests/*.hxx",
-          "React/**/RCTTV*.h",
-          "React/**/RCTTV*.hpp",
-          "React/**/RCTTV*.hxx",
-          "React/Cxx*/*.h",
-          "React/Cxx*/*.hpp",
-          "React/Cxx*/*.hxx",
-          "React/DevSupport/*.h",
-          "React/DevSupport/*.hpp",
-          "React/DevSupport/*.hxx",
-          "React/Fabric/**/*.h",
-          "React/Fabric/**/*.hpp",
-          "React/Fabric/**/*.hxx",
-          "React/Inspector/*.h",
-          "React/Inspector/*.hpp",
-          "React/Inspector/*.hxx",
-          "ReactCommon/yoga/*.h",
-          "ReactCommon/yoga/*.hpp",
-          "ReactCommon/yoga/*.hxx"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "React/**/*.h"
-        ],
-        exclude = [
-          "**/__tests__/*.h",
-          "**/__tests__/*.hpp",
-          "**/__tests__/*.hxx",
-          "IntegrationTests/*.h",
-          "IntegrationTests/*.hpp",
-          "IntegrationTests/*.hxx",
-          "React/Cxx*/*.h",
-          "React/Cxx*/*.hpp",
-          "React/Cxx*/*.hxx",
-          "React/DevSupport/*.h",
-          "React/DevSupport/*.hpp",
-          "React/DevSupport/*.hxx",
-          "React/Fabric/**/*.h",
-          "React/Fabric/**/*.hpp",
-          "React/Fabric/**/*.hxx",
-          "React/Inspector/*.h",
-          "React/Inspector/*.hpp",
-          "React/Inspector/*.hxx",
-          "React/Modules/RCTClipboard*.h",
-          "React/Modules/RCTClipboard*.hpp",
-          "React/Modules/RCTClipboard*.hxx",
-          "React/Views/RCTDatePicker*.h",
-          "React/Views/RCTDatePicker*.hpp",
-          "React/Views/RCTDatePicker*.hxx",
-          "React/Views/RCTPicker*.h",
-          "React/Views/RCTPicker*.hpp",
-          "React/Views/RCTPicker*.hxx",
-          "React/Views/RCTRefreshControl*.h",
-          "React/Views/RCTRefreshControl*.hpp",
-          "React/Views/RCTRefreshControl*.hxx",
-          "React/Views/RCTSlider*.h",
-          "React/Views/RCTSlider*.hpp",
-          "React/Views/RCTSlider*.hxx",
-          "React/Views/RCTSwitch*.h",
-          "React/Views/RCTSwitch*.hpp",
-          "React/Views/RCTSwitch*.hxx",
-          "React/Views/RCTWebView*.h",
-          "React/Views/RCTWebView*.hpp",
-          "React/Views/RCTWebView*.hxx",
-          "ReactCommon/yoga/*.h",
-          "ReactCommon/yoga/*.hpp",
-          "ReactCommon/yoga/*.hxx"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":React_hdrs"
+    ":Core_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -545,10 +483,6 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -594,7 +528,9 @@ filegroup(
     {
       "//conditions:default": glob(
         [
-          "React/**/*.h"
+          "React/**/*.h",
+          "React/**/*.hpp",
+          "React/**/*.hxx"
         ],
         exclude = [
           "**/__tests__/*.h",
@@ -626,7 +562,9 @@ filegroup(
         ),
       ":tvosCase": glob(
         [
-          "React/**/*.h"
+          "React/**/*.h",
+          "React/**/*.hpp",
+          "React/**/*.hxx"
         ],
         exclude = [
           "**/__tests__/*.h",
@@ -680,10 +618,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "Core_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -943,94 +892,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "React/**/*.h"
-        ],
-        exclude = [
-          "**/__tests__/*.h",
-          "**/__tests__/*.hpp",
-          "**/__tests__/*.hxx",
-          "IntegrationTests/*.h",
-          "IntegrationTests/*.hpp",
-          "IntegrationTests/*.hxx",
-          "React/**/RCTTV*.h",
-          "React/**/RCTTV*.hpp",
-          "React/**/RCTTV*.hxx",
-          "React/Cxx*/*.h",
-          "React/Cxx*/*.hpp",
-          "React/Cxx*/*.hxx",
-          "React/DevSupport/*.h",
-          "React/DevSupport/*.hpp",
-          "React/DevSupport/*.hxx",
-          "React/Fabric/**/*.h",
-          "React/Fabric/**/*.hpp",
-          "React/Fabric/**/*.hxx",
-          "React/Inspector/*.h",
-          "React/Inspector/*.hpp",
-          "React/Inspector/*.hxx",
-          "ReactCommon/yoga/*.h",
-          "ReactCommon/yoga/*.hpp",
-          "ReactCommon/yoga/*.hxx"
-        ],
-        exclude_directories = 1
-        ),
-      ":tvosCase": glob(
-        [
-          "React/**/*.h"
-        ],
-        exclude = [
-          "**/__tests__/*.h",
-          "**/__tests__/*.hpp",
-          "**/__tests__/*.hxx",
-          "IntegrationTests/*.h",
-          "IntegrationTests/*.hpp",
-          "IntegrationTests/*.hxx",
-          "React/Cxx*/*.h",
-          "React/Cxx*/*.hpp",
-          "React/Cxx*/*.hxx",
-          "React/DevSupport/*.h",
-          "React/DevSupport/*.hpp",
-          "React/DevSupport/*.hxx",
-          "React/Fabric/**/*.h",
-          "React/Fabric/**/*.hpp",
-          "React/Fabric/**/*.hxx",
-          "React/Inspector/*.h",
-          "React/Inspector/*.hpp",
-          "React/Inspector/*.hxx",
-          "React/Modules/RCTClipboard*.h",
-          "React/Modules/RCTClipboard*.hpp",
-          "React/Modules/RCTClipboard*.hxx",
-          "React/Views/RCTDatePicker*.h",
-          "React/Views/RCTDatePicker*.hpp",
-          "React/Views/RCTDatePicker*.hxx",
-          "React/Views/RCTPicker*.h",
-          "React/Views/RCTPicker*.hpp",
-          "React/Views/RCTPicker*.hxx",
-          "React/Views/RCTRefreshControl*.h",
-          "React/Views/RCTRefreshControl*.hpp",
-          "React/Views/RCTRefreshControl*.hxx",
-          "React/Views/RCTSlider*.h",
-          "React/Views/RCTSlider*.hpp",
-          "React/Views/RCTSlider*.hxx",
-          "React/Views/RCTSwitch*.h",
-          "React/Views/RCTSwitch*.hpp",
-          "React/Views/RCTSwitch*.hxx",
-          "React/Views/RCTWebView*.h",
-          "React/Views/RCTWebView*.hpp",
-          "React/Views/RCTWebView*.hxx",
-          "ReactCommon/yoga/*.h",
-          "ReactCommon/yoga/*.hpp",
-          "ReactCommon/yoga/*.hxx"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":React_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1038,10 +902,6 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -1094,6 +954,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "CxxBridge_cxx_union_hdrs",
+  srcs = [
+    "CxxBridge_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "CxxBridge_cxx_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "CxxBridge_cxx",
   enable_modules = 0,
@@ -1105,14 +981,9 @@ objc_library(
       "React/Cxx*/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/Cxx*/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":CxxBridge_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1120,14 +991,12 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
     ":cxxreact"
+  ] + [
+    "CxxBridge_cxx_includes"
   ],
   copts = [
     "-std=c++14",
@@ -1170,6 +1039,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "CxxBridge_union_hdrs",
+  srcs = [
+    "CxxBridge_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "CxxBridge_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "CxxBridge",
   enable_modules = 0,
@@ -1178,14 +1063,9 @@ objc_library(
       "React/Cxx*/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/Cxx*/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":CxxBridge_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1193,15 +1073,13 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
     ":CxxBridge_cxx",
     ":cxxreact"
+  ] + [
+    "CxxBridge_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -1248,6 +1126,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "DevSupport_cxx_union_hdrs",
+  srcs = [
+    "DevSupport_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "DevSupport_cxx_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "DevSupport_cxx",
   enable_modules = 0,
@@ -1273,19 +1167,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":DevSupport_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1293,13 +1177,11 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTWebSocket"
+  ] + [
+    "DevSupport_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -1346,6 +1228,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "DevSupport_union_hdrs",
+  srcs = [
+    "DevSupport_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "DevSupport_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "DevSupport",
   enable_modules = 0,
@@ -1361,19 +1259,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":DevSupport_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1381,14 +1269,12 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":DevSupport_cxx",
     ":RCTWebSocket"
+  ] + [
+    "DevSupport_includes"
   ],
   copts = [
 
@@ -1422,6 +1308,9 @@ filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
     [
+      "React/**/*.h",
+      "React/**/*.hpp",
+      "React/**/*.hxx",
       "React/Fabric/**/*.h"
     ],
     exclude = [
@@ -1435,10 +1324,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTFabric_cxx_union_hdrs",
+  srcs = [
+    "RCTFabric_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "RCTFabric_cxx_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -1463,19 +1363,9 @@ objc_library(
       "React/Fabric/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/Fabric/**/*.h"
-    ],
-    exclude = [
-      "**/tests/*.h",
-      "**/tests/*.hpp",
-      "**/tests/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTFabric_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1483,10 +1373,6 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -1529,6 +1415,9 @@ filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
     [
+      "React/**/*.h",
+      "React/**/*.hpp",
+      "React/**/*.hxx",
       "React/Fabric/**/*.h"
     ],
     exclude = [
@@ -1542,10 +1431,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTFabric_union_hdrs",
+  srcs = [
+    "RCTFabric_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "RCTFabric_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -1568,19 +1468,9 @@ objc_library(
       "**/tests/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/Fabric/**/*.h"
-    ],
-    exclude = [
-      "**/tests/*.h",
-      "**/tests/*.hpp",
-      "**/tests/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTFabric_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1588,10 +1478,6 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -1643,6 +1529,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "tvOS_union_hdrs",
+  srcs = [
+    "tvOS_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "tvOS_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "tvOS",
   enable_modules = 0,
@@ -1651,14 +1553,9 @@ objc_library(
       "React/**/RCTTV*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/**/RCTTV*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":tvOS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1666,12 +1563,10 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "tvOS_includes"
   ],
   copts = [
 
@@ -1713,10 +1608,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "jschelpers_union_hdrs",
+  srcs = [
+    "jschelpers_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "jschelpers_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -1740,14 +1646,9 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ReactCommon/jschelpers/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":jschelpers_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1755,10 +1656,6 @@ objc_library(
       "ReactCommon/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -1808,10 +1705,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "jsinspector_union_hdrs",
+  srcs = [
+    "jsinspector_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "jsinspector_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -1835,14 +1743,9 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ReactCommon/jsinspector/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":jsinspector_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1850,10 +1753,6 @@ objc_library(
       "ReactCommon/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
 
   ] + [
@@ -1899,10 +1798,21 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "PrivateDatabase_union_hdrs",
+  srcs = [
+    "PrivateDatabase_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "PrivateDatabase_includes",
   include = [
-    "Vendor/React/ReactCommon"
+    "Vendor/React/ReactCommon",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -1927,14 +1837,9 @@ objc_library(
       "ReactCommon/jschelpers/*.cpp"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ReactCommon/privatedata/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":PrivateDatabase_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1942,10 +1847,6 @@ objc_library(
       "ReactCommon/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
 
   ] + [
@@ -1996,13 +1897,24 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "cxxreact_union_hdrs",
+  srcs = [
+    "cxxreact_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "cxxreact_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/boost-for-react-native",
     "Vendor/DoubleConversion",
-    "Vendor/Folly"
+    "Vendor/Folly",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -2025,19 +1937,9 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ReactCommon/cxxreact/*.h"
-    ],
-    exclude = [
-      "ReactCommon/cxxreact/SampleCxxModule.h",
-      "ReactCommon/cxxreact/SampleCxxModule.hpp",
-      "ReactCommon/cxxreact/SampleCxxModule.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":cxxreact_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2045,10 +1947,6 @@ objc_library(
       "ReactCommon/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     "//Vendor/Folly:Folly",
     "//Vendor/boost-for-react-native:boost-for-react-native",
@@ -2095,11 +1993,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "fabric_union_hdrs",
+  srcs = [
+    "fabric_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "fabric_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "fabric",
   enable_modules = 0,
   hdrs = [
-    ":React_hdrs"
+    ":fabric_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2107,9 +2021,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
+  deps = [
+
+  ] + [
+    "fabric_includes"
   ],
   copts = [
 
@@ -2143,7 +2058,10 @@ filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
     [
-      "ReactCommon/fabric/sample/**/*.h"
+      "ReactCommon/fabric/sample/**/*.h",
+      "fabric/sample/**/*.h",
+      "fabric/sample/**/*.hpp",
+      "fabric/sample/**/*.hxx"
     ],
     exclude = [
       "**/tests/*.h",
@@ -2156,11 +2074,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTFabricSample_union_hdrs",
+  srcs = [
+    "RCTFabricSample_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
 gen_includes(
   name = "RCTFabricSample_includes",
   include = [
     "Vendor/React/ReactCommon",
-    "Vendor/Folly"
+    "Vendor/Folly",
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -2181,19 +2110,9 @@ objc_library(
       "**/tests/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "ReactCommon/fabric/sample/**/*.h"
-    ],
-    exclude = [
-      "**/tests/*.h",
-      "**/tests/*.hpp",
-      "**/tests/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":fabric/sample_hdrs"
+    ":RCTFabricSample_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2201,10 +2120,6 @@ objc_library(
       "ReactCommon/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "fabric/sample_module_map"
-  ],
   deps = [
     "//Vendor/Folly:Folly"
   ] + [
@@ -2250,6 +2165,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "ART_union_hdrs",
+  srcs = [
+    "ART_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "ART_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "ART",
   enable_modules = 0,
@@ -2258,14 +2189,9 @@ objc_library(
       "Libraries/ART/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":ART_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2273,12 +2199,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "ART_includes"
   ],
   copts = [
 
@@ -2320,6 +2244,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTActionSheet_union_hdrs",
+  srcs = [
+    "RCTActionSheet_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTActionSheet_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTActionSheet",
   enable_modules = 0,
@@ -2328,14 +2268,9 @@ objc_library(
       "Libraries/ActionSheetIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTActionSheet_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2343,12 +2278,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTActionSheet_includes"
   ],
   copts = [
 
@@ -2384,12 +2317,31 @@ filegroup(
     [
       "Libraries/NativeAnimation/*.h",
       "Libraries/NativeAnimation/Drivers/*.h",
-      "Libraries/NativeAnimation/Nodes/*.h"
+      "Libraries/NativeAnimation/Nodes/*.h",
+      "RCTAnimation/**/*.h",
+      "RCTAnimation/**/*.hpp",
+      "RCTAnimation/**/*.hxx"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "RCTAnimation_union_hdrs",
+  srcs = [
+    "RCTAnimation_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTAnimation_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -2402,16 +2354,9 @@ objc_library(
       "Libraries/NativeAnimation/Nodes/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/NativeAnimation/*.h",
-      "Libraries/NativeAnimation/Drivers/*.h",
-      "Libraries/NativeAnimation/Nodes/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":RCTAnimation_hdrs"
+    ":RCTAnimation_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2419,12 +2364,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "RCTAnimation_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTAnimation_includes"
   ],
   copts = [
 
@@ -2466,6 +2409,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTBlob_cxx_union_hdrs",
+  srcs = [
+    "RCTBlob_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTBlob_cxx_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTBlob_cxx",
   enable_modules = 0,
@@ -2494,14 +2453,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTBlob_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2509,12 +2463,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTBlob_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -2556,6 +2508,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTBlob_union_hdrs",
+  srcs = [
+    "RCTBlob_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTBlob_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTBlob",
   enable_modules = 0,
@@ -2583,14 +2551,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTBlob_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2598,13 +2561,11 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTBlob_cxx"
+  ] + [
+    "RCTBlob_includes"
   ],
   copts = [
 
@@ -2646,6 +2607,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTCameraRoll_union_hdrs",
+  srcs = [
+    "RCTCameraRoll_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTCameraRoll_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTCameraRoll",
   enable_modules = 0,
@@ -2654,14 +2631,9 @@ objc_library(
       "Libraries/CameraRoll/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/CameraRoll/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTCameraRoll_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2669,13 +2641,11 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTImage"
+  ] + [
+    "RCTCameraRoll_includes"
   ],
   copts = [
 
@@ -2717,6 +2687,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTGeolocation_union_hdrs",
+  srcs = [
+    "RCTGeolocation_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTGeolocation_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTGeolocation",
   enable_modules = 0,
@@ -2725,14 +2711,9 @@ objc_library(
       "Libraries/Geolocation/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTGeolocation_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2740,12 +2721,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTGeolocation_includes"
   ],
   copts = [
 
@@ -2787,6 +2766,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTImage_union_hdrs",
+  srcs = [
+    "RCTImage_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTImage_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTImage",
   enable_modules = 0,
@@ -2798,14 +2793,9 @@ objc_library(
       "Libraries/CameraRoll/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTImage_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2813,13 +2803,11 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTNetwork"
+  ] + [
+    "RCTImage_includes"
   ],
   copts = [
 
@@ -2861,6 +2849,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTNetwork_cxx_union_hdrs",
+  srcs = [
+    "RCTNetwork_cxx_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTNetwork_cxx_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTNetwork_cxx",
   enable_modules = 0,
@@ -2874,14 +2878,9 @@ objc_library(
       "Libraries/Network/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTNetwork_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2889,12 +2888,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTNetwork_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -2936,6 +2933,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTNetwork_union_hdrs",
+  srcs = [
+    "RCTNetwork_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTNetwork_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTNetwork",
   enable_modules = 0,
@@ -2948,14 +2961,9 @@ objc_library(
       "Libraries/Image/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTNetwork_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -2963,13 +2971,11 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTNetwork_cxx"
+  ] + [
+    "RCTNetwork_includes"
   ],
   copts = [
 
@@ -3011,6 +3017,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTPushNotification_union_hdrs",
+  srcs = [
+    "RCTPushNotification_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTPushNotification_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTPushNotification",
   enable_modules = 0,
@@ -3019,14 +3041,9 @@ objc_library(
       "Libraries/PushNotificationIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTPushNotification_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3034,12 +3051,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTPushNotification_includes"
   ],
   copts = [
 
@@ -3081,6 +3096,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTSettings_union_hdrs",
+  srcs = [
+    "RCTSettings_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTSettings_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTSettings",
   enable_modules = 0,
@@ -3089,14 +3120,9 @@ objc_library(
       "Libraries/Settings/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTSettings_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3104,12 +3130,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTSettings_includes"
   ],
   copts = [
 
@@ -3151,6 +3175,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTText_union_hdrs",
+  srcs = [
+    "RCTText_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTText_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTText",
   enable_modules = 0,
@@ -3159,14 +3199,9 @@ objc_library(
       "Libraries/Text/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Text/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTText_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3174,12 +3209,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTText_includes"
   ],
   copts = [
 
@@ -3221,6 +3254,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTVibration_union_hdrs",
+  srcs = [
+    "RCTVibration_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTVibration_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTVibration",
   enable_modules = 0,
@@ -3229,14 +3278,9 @@ objc_library(
       "Libraries/Vibration/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTVibration_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3244,12 +3288,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTVibration_includes"
   ],
   copts = [
 
@@ -3291,6 +3333,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTWebSocket_union_hdrs",
+  srcs = [
+    "RCTWebSocket_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTWebSocket_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTWebSocket",
   enable_modules = 0,
@@ -3317,14 +3375,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTWebSocket_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3332,14 +3385,12 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":RCTBlob",
     ":fishhook"
+  ] + [
+    "RCTWebSocket_includes"
   ],
   copts = [
 
@@ -3373,12 +3424,31 @@ filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
     [
-      "Libraries/fishhook/*.h"
+      "Libraries/fishhook/*.h",
+      "fishhook/**/*.h",
+      "fishhook/**/*.hpp",
+      "fishhook/**/*.hxx"
     ],
     exclude_directories = 1
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "fishhook_union_hdrs",
+  srcs = [
+    "fishhook_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "fishhook_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -3408,14 +3478,9 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/fishhook/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":fishhook_hdrs"
+    ":fishhook_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3423,9 +3488,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "fishhook_module_map"
+  deps = [
+
+  ] + [
+    "fishhook_includes"
   ],
   copts = [
 
@@ -3467,6 +3533,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTLinkingIOS_union_hdrs",
+  srcs = [
+    "RCTLinkingIOS_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTLinkingIOS_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTLinkingIOS",
   enable_modules = 0,
@@ -3475,14 +3557,9 @@ objc_library(
       "Libraries/LinkingIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTLinkingIOS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3490,12 +3567,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTLinkingIOS_includes"
   ],
   copts = [
 
@@ -3537,6 +3612,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTTest_union_hdrs",
+  srcs = [
+    "RCTTest_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTTest_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTTest",
   enable_modules = 0,
@@ -3545,14 +3636,9 @@ objc_library(
       "Libraries/RCTTest/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/RCTTest/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTTest_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3560,15 +3646,13 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "XCTest"
   ],
   deps = [
     ":Core"
+  ] + [
+    "RCTTest_includes"
   ],
   copts = [
 
@@ -3607,11 +3691,27 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "_ignore_me_subspec_for_linting__union_hdrs",
+  srcs = [
+    "_ignore_me_subspec_for_linting__hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "_ignore_me_subspec_for_linting__includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "_ignore_me_subspec_for_linting_",
   enable_modules = 0,
   hdrs = [
-    ":React_hdrs"
+    ":_ignore_me_subspec_for_linting__union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -3619,13 +3719,11 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core",
     ":CxxBridge"
+  ] + [
+    "_ignore_me_subspec_for_linting__includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/React-0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React-0.9.0.podspec.json.goldmaster
@@ -19,9 +19,36 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":Core_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "React_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,12 +71,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "React_includes"
   ],
   copts = [
 
@@ -83,7 +108,22 @@ filegroup(
   name = "Core_hdrs",
   srcs = glob(
     [
-      "React/**/*.h"
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "React/**/*.h",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
     ],
     exclude = [
       "**/__tests__/*.h",
@@ -97,6 +137,22 @@ filegroup(
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -138,22 +194,9 @@ objc_library(
       "Libraries/WebSocket/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "React/**/*.h"
-    ],
-    exclude = [
-      "**/__tests__/*.h",
-      "**/__tests__/*.hpp",
-      "**/__tests__/*.hxx",
-      "IntegrationTests/*.h",
-      "IntegrationTests/*.hpp",
-      "IntegrationTests/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -161,12 +204,13 @@ objc_library(
       "React/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   sdk_frameworks = [
     "JavaScriptCore"
+  ],
+  deps = [
+
+  ] + [
+    "Core_includes"
   ],
   copts = [
 
@@ -208,6 +252,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "ART_union_hdrs",
+  srcs = [
+    "ART_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "ART_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "ART",
   enable_modules = 0,
@@ -216,14 +276,9 @@ objc_library(
       "Libraries/ART/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":ART_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -231,12 +286,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "ART_includes"
   ],
   copts = [
 
@@ -278,6 +331,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTActionSheet_union_hdrs",
+  srcs = [
+    "RCTActionSheet_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTActionSheet_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTActionSheet",
   enable_modules = 0,
@@ -286,14 +355,9 @@ objc_library(
       "Libraries/ActionSheetIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTActionSheet_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -301,12 +365,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTActionSheet_includes"
   ],
   copts = [
 
@@ -348,6 +410,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTAdSupport_union_hdrs",
+  srcs = [
+    "RCTAdSupport_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTAdSupport_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTAdSupport",
   enable_modules = 0,
@@ -356,14 +434,9 @@ objc_library(
       "Libraries/AdSupport/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/AdSupport/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTAdSupport_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -371,12 +444,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTAdSupport_includes"
   ],
   copts = [
 
@@ -418,6 +489,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTGeolocation_union_hdrs",
+  srcs = [
+    "RCTGeolocation_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTGeolocation_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTGeolocation",
   enable_modules = 0,
@@ -426,14 +513,9 @@ objc_library(
       "Libraries/Geolocation/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTGeolocation_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -441,12 +523,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTGeolocation_includes"
   ],
   copts = [
 
@@ -488,6 +568,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTImage_union_hdrs",
+  srcs = [
+    "RCTImage_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTImage_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTImage",
   enable_modules = 0,
@@ -496,14 +592,9 @@ objc_library(
       "Libraries/Image/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTImage_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -511,12 +602,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTImage_includes"
   ],
   copts = [
 
@@ -558,6 +647,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTNetwork_union_hdrs",
+  srcs = [
+    "RCTNetwork_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTNetwork_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTNetwork",
   enable_modules = 0,
@@ -566,14 +671,9 @@ objc_library(
       "Libraries/Network/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTNetwork_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -581,12 +681,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTNetwork_includes"
   ],
   copts = [
 
@@ -628,6 +726,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTPushNotification_union_hdrs",
+  srcs = [
+    "RCTPushNotification_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTPushNotification_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTPushNotification",
   enable_modules = 0,
@@ -636,14 +750,9 @@ objc_library(
       "Libraries/PushNotificationIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTPushNotification_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -651,12 +760,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTPushNotification_includes"
   ],
   copts = [
 
@@ -698,6 +805,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTSettings_union_hdrs",
+  srcs = [
+    "RCTSettings_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTSettings_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTSettings",
   enable_modules = 0,
@@ -706,14 +829,9 @@ objc_library(
       "Libraries/Settings/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTSettings_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -721,12 +839,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTSettings_includes"
   ],
   copts = [
 
@@ -768,6 +884,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTText_union_hdrs",
+  srcs = [
+    "RCTText_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTText_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTText",
   enable_modules = 0,
@@ -776,14 +908,9 @@ objc_library(
       "Libraries/Text/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Text/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTText_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -791,12 +918,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTText_includes"
   ],
   copts = [
 
@@ -838,6 +963,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTVibration_union_hdrs",
+  srcs = [
+    "RCTVibration_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTVibration_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTVibration",
   enable_modules = 0,
@@ -846,14 +987,9 @@ objc_library(
       "Libraries/Vibration/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTVibration_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -861,12 +997,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTVibration_includes"
   ],
   copts = [
 
@@ -908,6 +1042,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTWebSocket_union_hdrs",
+  srcs = [
+    "RCTWebSocket_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTWebSocket_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTWebSocket",
   enable_modules = 0,
@@ -916,14 +1066,9 @@ objc_library(
       "Libraries/WebSocket/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTWebSocket_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -931,12 +1076,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTWebSocket_includes"
   ],
   copts = [
 
@@ -978,6 +1121,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "RCTLinkingIOS_union_hdrs",
+  srcs = [
+    "RCTLinkingIOS_hdrs",
+    "React_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "RCTLinkingIOS_includes",
+  include = [
+    "Vendor/React-0/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "RCTLinkingIOS",
   enable_modules = 0,
@@ -986,14 +1145,9 @@ objc_library(
       "Libraries/LinkingIOS/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":React_hdrs"
+    ":RCTLinkingIOS_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "React",
@@ -1001,12 +1155,10 @@ objc_library(
       "Libraries/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "React_module_map"
-  ],
   deps = [
     ":Core"
+  ] + [
+    "RCTLinkingIOS_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -26,6 +26,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "SFHFKeychainUtils_cxx_union_hdrs",
+  srcs = [
+    "SFHFKeychainUtils_cxx_hdrs",
+    "SFHFKeychainUtils_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "SFHFKeychainUtils_cxx_includes",
+  include = [
+    "Vendor/SFHFKeychainUtils/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "SFHFKeychainUtils_cxx",
   enable_modules = 0,
@@ -42,13 +58,6 @@ objc_library(
       "security/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   non_arc_srcs = glob(
     [
@@ -60,7 +69,7 @@ objc_library(
     exclude_directories = 1
     ),
   hdrs = [
-    ":SFHFKeychainUtils_hdrs"
+    ":SFHFKeychainUtils_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "SFHFKeychainUtils",
@@ -68,12 +77,13 @@ objc_library(
       "security/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "SFHFKeychainUtils_module_map"
-  ],
   sdk_frameworks = [
     "Security"
+  ],
+  deps = [
+
+  ] + [
+    "SFHFKeychainUtils_cxx_includes"
   ],
   copts = [
 
@@ -110,9 +120,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":SFHFKeychainUtils_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "SFHFKeychainUtils_includes",
+  include = [
+    "Vendor/SFHFKeychainUtils/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -133,13 +158,6 @@ objc_library(
       "security/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   non_arc_srcs = glob(
     [
@@ -156,15 +174,13 @@ objc_library(
       "security/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "SFHFKeychainUtils_module_map"
-  ],
   sdk_frameworks = [
     "Security"
   ],
   deps = [
     ":SFHFKeychainUtils_cxx"
+  ] + [
+    "SFHFKeychainUtils_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "SPUserResizableView/SPUserResizableView.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "SPUserResizableView+Pion_includes",
+  include = [
+    "Vendor/SPUserResizableView+Pion/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "SPUserResizableView/SPUserResizableView.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "SPUserResizableView/SPUserResizableView.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"
@@ -55,9 +63,10 @@ objc_library(
       "SPUserResizableView/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "SPUserResizableView+Pion_module_map"
+  deps = [
+
+  ] + [
+    "SPUserResizableView+Pion_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Source/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "SlackTextViewController_includes",
+  include = [
+    "Vendor/SlackTextViewController/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Source/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":SlackTextViewController_hdrs"
@@ -55,9 +63,10 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "SlackTextViewController_module_map"
+  deps = [
+
+  ] + [
+    "SlackTextViewController_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Smartling_includes",
+  include = [
+    "Vendor/Smartling/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,15 +57,16 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Smartling_module_map"
-  ],
   sdk_frameworks = [
     "UIKit"
   ],
   sdk_dylibs = [
     "Smartling"
+  ],
+  deps = [
+
+  ] + [
+    "Smartling_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -25,9 +25,23 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "Stripe/*.h",
+      "Stripe/PublicHeaders/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Stripe_includes",
+  include = [
+    "Vendor/Stripe/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -46,12 +60,6 @@ objc_library(
       "Stripe/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Stripe/*.h",
-      "Stripe/PublicHeaders/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":Stripe_hdrs"
@@ -62,10 +70,6 @@ objc_library(
       "Stripe/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Stripe_module_map"
-  ],
   sdk_frameworks = [
     "Foundation",
     "Security",
@@ -75,6 +79,8 @@ objc_library(
   ],
   deps = [
     ":Stripe_Bundle_Stripe"
+  ] + [
+    "Stripe_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -13,23 +13,41 @@ native.config_setting(
   }
   )
 filegroup(
-  name = "AsyncDisplayKit_hdrs",
+  name = "Texture_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":PINRemoteImage_hdrs",
+    ":MapKit_hdrs",
+    ":Photos_hdrs",
+    ":AssetsLibrary_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
   )
+gen_includes(
+  name = "AsyncDisplayKit_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
+  ]
+  )
 gen_module_map(
   "AsyncDisplayKit",
-  "AsyncDisplayKit_module_map",
+  "Texture_module_map",
   "AsyncDisplayKit",
   [
-    "AsyncDisplayKit_hdrs"
+    "Texture_hdrs"
   ]
   )
 alias(
@@ -43,7 +61,7 @@ objc_library(
   name = "AsyncDisplayKit",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":Texture_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -51,10 +69,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
@@ -63,6 +77,8 @@ objc_library(
     ":MapKit",
     ":PINRemoteImage",
     ":Photos"
+  ] + [
+    "AsyncDisplayKit_includes"
   ],
   copts = [
 
@@ -96,6 +112,9 @@ filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
     [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx",
       "Base/*.h",
       "Source/**/*.h",
       "Source/TextKit/*.h"
@@ -104,6 +123,22 @@ filegroup(
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Core_cxx_union_hdrs",
+  srcs = [
+    "Core_cxx_hdrs",
+    "Texture_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_cxx_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -118,16 +153,9 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/TextKit/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":Core_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -135,12 +163,13 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
+  ],
+  deps = [
+
+  ] + [
+    "Core_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -176,6 +205,9 @@ filegroup(
   name = "Core_hdrs",
   srcs = glob(
     [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx",
       "Base/*.h",
       "Source/**/*.h",
       "Source/TextKit/*.h"
@@ -184,6 +216,22 @@ filegroup(
     ),
   visibility = [
     "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "Texture_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
@@ -195,16 +243,9 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/TextKit/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":Core_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -213,15 +254,13 @@ objc_library(
       "Source/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     ":Core_cxx"
+  ] + [
+    "Core_includes"
   ],
   copts = [
     "-fno-exceptions -fno-objc-arc-exceptions"
@@ -253,18 +292,39 @@ acknowledged_target(
   )
 filegroup(
   name = "PINRemoteImage_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "PINRemoteImage_union_hdrs",
   srcs = [
-
+    "PINRemoteImage_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "PINRemoteImage_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "PINRemoteImage",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":PINRemoteImage_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -272,10 +332,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
@@ -283,6 +339,8 @@ objc_library(
     "//Vendor/PINRemoteImage:PINCache",
     "//Vendor/PINRemoteImage:iOS",
     ":Core"
+  ] + [
+    "PINRemoteImage_includes"
   ],
   copts = [
 
@@ -315,18 +373,39 @@ acknowledged_target(
   )
 filegroup(
   name = "IGListKit_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "IGListKit_union_hdrs",
   srcs = [
-
+    "IGListKit_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "IGListKit_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "IGListKit",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":IGListKit_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -334,16 +413,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     "//Vendor/IGListKit:IGListKit",
     ":Core"
+  ] + [
+    "IGListKit_includes"
   ],
   copts = [
 
@@ -375,18 +452,39 @@ acknowledged_target(
   )
 filegroup(
   name = "Yoga_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Yoga_union_hdrs",
   srcs = [
-
+    "Yoga_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Yoga_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "Yoga",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":Yoga_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -394,16 +492,14 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     "//Vendor/Yoga:Yoga",
     ":Core"
+  ] + [
+    "Yoga_includes"
   ],
   copts = [
     "-DYOGA=1"
@@ -435,18 +531,39 @@ acknowledged_target(
   )
 filegroup(
   name = "MapKit_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "MapKit_union_hdrs",
   srcs = [
-
+    "MapKit_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "MapKit_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "MapKit",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":MapKit_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -454,10 +571,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_frameworks = [
     "MapKit"
   ],
@@ -466,6 +579,8 @@ objc_library(
   ],
   deps = [
     ":Core"
+  ] + [
+    "MapKit_includes"
   ],
   copts = [
     "-DAS_USE_MAPKIT=1"
@@ -497,18 +612,39 @@ acknowledged_target(
   )
 filegroup(
   name = "Photos_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "Photos_union_hdrs",
   srcs = [
-
+    "Photos_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Photos_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "Photos",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":Photos_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -516,10 +652,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_frameworks = [
     "Photos"
   ],
@@ -528,6 +660,8 @@ objc_library(
   ],
   deps = [
     ":Core"
+  ] + [
+    "Photos_includes"
   ],
   copts = [
     "-DAS_USE_PHOTOS=1"
@@ -559,18 +693,39 @@ acknowledged_target(
   )
 filegroup(
   name = "AssetsLibrary_hdrs",
+  srcs = glob(
+    [
+      "AsyncDisplayKit/**/*.h",
+      "AsyncDisplayKit/**/*.hpp",
+      "AsyncDisplayKit/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ),
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+filegroup(
+  name = "AssetsLibrary_union_hdrs",
   srcs = [
-
+    "AssetsLibrary_hdrs",
+    "Texture_hdrs"
   ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "AssetsLibrary_includes",
+  include = [
+    "Vendor/Texture/pod_support/Headers/Public/"
   ]
   )
 objc_library(
   name = "AssetsLibrary",
   enable_modules = 0,
   hdrs = [
-    ":AsyncDisplayKit_hdrs"
+    ":AssetsLibrary_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "Texture",
@@ -578,10 +733,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "AsyncDisplayKit_module_map"
-  ],
   sdk_frameworks = [
     "AssetsLibrary"
   ],
@@ -590,6 +741,8 @@ objc_library(
   ],
   deps = [
     ":Core"
+  ] + [
+    "AssetsLibrary_includes"
   ],
   copts = [
     "-DAS_USE_ASSETS_LIBRARY=1"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -26,6 +26,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "UICollectionViewLeftAlignedLayout_cxx_union_hdrs",
+  srcs = [
+    "UICollectionViewLeftAlignedLayout_cxx_hdrs",
+    "UICollectionViewLeftAlignedLayout_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "UICollectionViewLeftAlignedLayout_cxx_includes",
+  include = [
+    "Vendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "UICollectionViewLeftAlignedLayout_cxx",
   enable_modules = 0,
@@ -43,16 +59,9 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":UICollectionViewLeftAlignedLayout_hdrs"
+    ":UICollectionViewLeftAlignedLayout_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "UICollectionViewLeftAlignedLayout",
@@ -60,9 +69,10 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "UICollectionViewLeftAlignedLayout_module_map"
+  deps = [
+
+  ] + [
+    "UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
   copts = [
 
@@ -99,9 +109,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "UICollectionViewLeftAlignedLayout_includes",
+  include = [
+    "Vendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -123,13 +148,6 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_hdrs"
@@ -140,12 +158,10 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "UICollectionViewLeftAlignedLayout_module_map"
-  ],
   deps = [
     ":UICollectionViewLeftAlignedLayout_cxx"
+  ] + [
+    "UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "SDK1.6.2/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Weixin_includes",
+  include = [
+    "Vendor/Weixin/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,10 +57,6 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "Weixin_module_map"
-  ],
   sdk_frameworks = [
     "CoreTelephony",
     "SystemConfiguration"
@@ -59,6 +68,8 @@ objc_library(
   ],
   deps = [
     ":Weixin_VendoredLibraries"
+  ] + [
+    "Weixin_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -19,9 +19,27 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "*.h",
+      "minizip/crypt.h",
+      "minizip/ioapi.h",
+      "minizip/mztools.h",
+      "minizip/unzip.h",
+      "minizip/zip.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "ZipArchive_includes",
+  include = [
+    "Vendor/ZipArchive/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,16 +62,6 @@ objc_library(
       "minizip/zip.c"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "*.h",
-      "minizip/crypt.h",
-      "minizip/ioapi.h",
-      "minizip/mztools.h",
-      "minizip/unzip.h",
-      "minizip/zip.h"
-    ],
-    exclude_directories = 1
     ),
   non_arc_srcs = glob(
     [
@@ -70,12 +78,13 @@ objc_library(
       "minizip/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "ZipArchive_module_map"
-  ],
   sdk_dylibs = [
     "z"
+  ],
+  deps = [
+
+  ] + [
+    "ZipArchive_includes"
   ],
   copts = [
     "-Dunix"

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -13,23 +13,38 @@ native.config_setting(
   }
   )
 filegroup(
-  name = "boost_hdrs",
+  name = "boost-for-react-native_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "boost/**/*.h",
+      "boost/**/*.hpp",
+      "boost/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
   ]
   )
+gen_includes(
+  name = "boost_includes",
+  include = [
+    "Vendor/boost-for-react-native/pod_support/Headers/Public/"
+  ]
+  )
 gen_module_map(
   "boost",
-  "boost_module_map",
+  "boost-for-react-native_module_map",
   "boost",
   [
-    "boost_hdrs"
+    "boost-for-react-native_hdrs"
   ]
   )
 alias(
@@ -43,7 +58,7 @@ objc_library(
   name = "boost",
   enable_modules = 0,
   hdrs = [
-    ":boost_hdrs"
+    ":boost-for-react-native_hdrs"
   ],
   pch = pch_with_name_hint(
     "boost-for-react-native",
@@ -51,9 +66,10 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "boost_module_map"
+  deps = [
+
+  ] + [
+    "boost_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -19,7 +19,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "glog/**/*.h",
+      "glog/**/*.hpp",
+      "glog/**/*.hxx",
+      "src/*.h",
+      "src/base/*.h",
+      "src/glog/*.h"
+    ],
+    exclude = [
+      "src/windows/**/*.h",
+      "src/windows/**/*.hpp",
+      "src/windows/**/*.hxx"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -62,16 +79,6 @@ objc_library(
       "src/windows/**/*.s"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "src/glog/*.h"
-    ],
-    exclude = [
-      "src/windows/**/*.h",
-      "src/windows/**/*.hpp",
-      "src/windows/**/*.hxx"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":glog_hdrs"
@@ -82,10 +89,6 @@ objc_library(
       "src/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "glog_module_map"
-  ],
   sdk_dylibs = [
     "stdc++"
   ],
@@ -107,7 +110,7 @@ objc_library(
       ]
     }
     ) + [
-    "-IVendor/glog/pod_support/Headers/Public/glog/"
+
   ] + [
     "-fmodule-name=glog_pod_module"
   ],

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -19,9 +19,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + [
+
+  ] + [
+    ":Messages_hdrs",
+    ":Services_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "googleapis_includes",
+  include = [
+    "Vendor/googleapis/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -44,14 +55,12 @@ objc_library(
 
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "googleapis_module_map"
-  ],
   deps = [
     "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
     ":Messages",
     ":Services"
+  ] + [
+    "googleapis_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
@@ -93,6 +102,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Messages_union_hdrs",
+  srcs = [
+    "Messages_hdrs",
+    "googleapis_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Messages_includes",
+  include = [
+    "Vendor/googleapis/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Messages",
   enable_modules = 0,
@@ -106,7 +131,7 @@ objc_library(
     exclude_directories = 1
     ),
   hdrs = [
-    ":googleapis_hdrs"
+    ":Messages_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "googleapis",
@@ -114,12 +139,10 @@ objc_library(
       "google/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "googleapis_module_map"
-  ],
   deps = [
     "//Vendor/Protobuf:Protobuf"
+  ] + [
+    "Messages_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
@@ -161,6 +184,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "Services_union_hdrs",
+  srcs = [
+    "Services_hdrs",
+    "googleapis_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "Services_includes",
+  include = [
+    "Vendor/googleapis/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "Services",
   enable_modules = 0,
@@ -169,14 +208,9 @@ objc_library(
       "google/**/*.pbrpc.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "google/**/*.pbrpc.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":googleapis_hdrs"
+    ":Services_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "googleapis",
@@ -184,13 +218,11 @@ objc_library(
       "google/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "googleapis_module_map"
-  ],
   deps = [
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
     ":Messages"
+  ] + [
+    "Services_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "iRate/iRate.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "iRate_includes",
+  include = [
+    "Vendor/iRate/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "iRate/iRate.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "iRate/iRate.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":iRate_hdrs"
@@ -55,12 +63,10 @@ objc_library(
       "iRate/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "iRate_module_map"
-  ],
   deps = [
     ":iRate_Bundle_iRate"
+  ] + [
+    "iRate_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -19,9 +19,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "kingpin/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "kingpin_includes",
+  include = [
+    "Vendor/kingpin/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -40,11 +53,6 @@ objc_library(
       "kingpin/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "kingpin/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":kingpin_hdrs"
@@ -55,13 +63,14 @@ objc_library(
       "kingpin/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "kingpin_module_map"
-  ],
   sdk_frameworks = [
     "MapKit",
     "CoreLocation"
+  ],
+  deps = [
+
+  ] + [
+    "kingpin_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -24,6 +24,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "pop_cxx_union_hdrs",
+  srcs = [
+    "pop_cxx_hdrs",
+    "pop_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "pop_cxx_includes",
+  include = [
+    "Vendor/pop/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "pop_cxx",
   enable_modules = 0,
@@ -36,14 +52,9 @@ objc_library(
       "pop/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "pop/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
-    ":pop_hdrs"
+    ":pop_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "pop",
@@ -51,12 +62,13 @@ objc_library(
       "pop/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "pop_module_map"
-  ],
   sdk_dylibs = [
     "c++"
+  ],
+  deps = [
+
+  ] + [
+    "pop_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -94,9 +106,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + glob(
+    [
+      "pop/**/*.h"
+    ],
+    exclude_directories = 1
+    ) + [
+    ":pop_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "pop_includes",
+  include = [
+    "Vendor/pop/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -115,11 +140,6 @@ objc_library(
       "pop/**/*.m"
     ],
     exclude_directories = 1
-    ) + glob(
-    [
-      "pop/**/*.h"
-    ],
-    exclude_directories = 1
     ),
   hdrs = [
     ":pop_hdrs"
@@ -130,15 +150,13 @@ objc_library(
       "pop/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "pop_module_map"
-  ],
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     ":pop_cxx"
+  ] + [
+    "pop_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -60,6 +60,22 @@ filegroup(
     "//visibility:public"
   ]
   )
+filegroup(
+  name = "youtube-ios-player-helper_cxx_union_hdrs",
+  srcs = [
+    "youtube-ios-player-helper_cxx_hdrs",
+    "youtube-ios-player-helper_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "youtube-ios-player-helper_cxx_includes",
+  include = [
+    "Vendor/youtube-ios-player-helper/pod_support/Headers/Public/"
+  ]
+  )
 objc_library(
   name = "youtube-ios-player-helper_cxx",
   enable_modules = 0,
@@ -112,38 +128,9 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ],
-        exclude = [
-          "Classes/osx/**/*.h",
-          "Classes/osx/**/*.hpp",
-          "Classes/osx/**/*.hxx"
-        ],
-        exclude_directories = 1
-        ),
-      ":osxCase": glob(
-        [
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ],
-        exclude = [
-          "Classes/ios/**/*.h",
-          "Classes/ios/**/*.hpp",
-          "Classes/ios/**/*.hxx"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
-    ":youtube-ios-player-helper_hdrs"
+    ":youtube-ios-player-helper_cxx_union_hdrs"
   ],
   pch = pch_with_name_hint(
     "youtube-ios-player-helper",
@@ -151,12 +138,10 @@ objc_library(
       "Classes/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "youtube-ios-player-helper_module_map"
-  ],
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets"
+  ] + [
+    "youtube-ios-player-helper_cxx_includes"
   ],
   copts = [
 
@@ -196,9 +181,46 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ),
+    ) + select(
+    {
+      "//conditions:default": glob(
+        [
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ],
+        exclude = [
+          "Classes/osx/**/*.h",
+          "Classes/osx/**/*.hpp",
+          "Classes/osx/**/*.hxx"
+        ],
+        exclude_directories = 1
+        ),
+      ":osxCase": glob(
+        [
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ],
+        exclude = [
+          "Classes/ios/**/*.h",
+          "Classes/ios/**/*.hpp",
+          "Classes/ios/**/*.hxx"
+        ],
+        exclude_directories = 1
+        )
+    }
+    ) + [
+    ":youtube-ios-player-helper_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
+  ]
+  )
+gen_includes(
+  name = "youtube-ios-player-helper_includes",
+  include = [
+    "Vendor/youtube-ios-player-helper/pod_support/Headers/Public/"
   ]
   )
 gen_module_map(
@@ -253,35 +275,6 @@ objc_library(
         exclude_directories = 1
         )
     }
-    ) + select(
-    {
-      "//conditions:default": glob(
-        [
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ],
-        exclude = [
-          "Classes/osx/**/*.h",
-          "Classes/osx/**/*.hpp",
-          "Classes/osx/**/*.hxx"
-        ],
-        exclude_directories = 1
-        ),
-      ":osxCase": glob(
-        [
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ],
-        exclude = [
-          "Classes/ios/**/*.h",
-          "Classes/ios/**/*.hpp",
-          "Classes/ios/**/*.hxx"
-        ],
-        exclude_directories = 1
-        )
-    }
     ),
   hdrs = [
     ":youtube-ios-player-helper_hdrs"
@@ -292,13 +285,11 @@ objc_library(
       "Classes/**/*.pch"
     ]
     ),
-  includes = [
-    "pod_support/Headers/Public/",
-    "youtube-ios-player-helper_module_map"
-  ],
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx"
+  ] + [
+    "youtube-ios-player-helper_includes"
   ],
   copts = [
 

--- a/Sources/PodToBUILD/PodSpec.swift
+++ b/Sources/PodToBUILD/PodSpec.swift
@@ -99,7 +99,9 @@ public enum PodSpecField: String {
     case weakFrameworks = "weak_frameworks"
     case excludeFiles = "exclude_files"
     case sourceFiles = "source_files"
-    case publicHeaders = "public_headers"
+    case publicHeaders = "public_header_files"
+    case privateHeaders = "private_header_files"
+    case preservePaths = "preserve_paths"
     case compilerFlags = "compiler_flags"
     case libraries
     case dependencies
@@ -145,6 +147,8 @@ public protocol PodSpecRepresentable {
     var moduleName: String? { get }
     var requiresArc: Either<Bool, [String]>? { get }
     var publicHeaders: [String] { get }
+    var privateHeaders: [String] { get }
+    var preservePaths: [String] { get }
     var defaultSubspecs: [String] { get }
 }
 
@@ -170,6 +174,8 @@ public struct PodSpec: PodSpecRepresentable {
     public let requiresArc: Either<Bool, [String]>?
 
     public let publicHeaders: [String]
+    public let privateHeaders: [String]
+    public let preservePaths: [String]
 
     public let vendoredFrameworks: [String]
     public let vendoredLibraries: [String]
@@ -210,6 +216,8 @@ public struct PodSpec: PodSpecRepresentable {
         excludeFiles = strings(fromJSON: fieldMap[.excludeFiles])
         sourceFiles = strings(fromJSON: fieldMap[.sourceFiles])
         publicHeaders = strings(fromJSON: fieldMap[.publicHeaders])
+        privateHeaders = strings(fromJSON: fieldMap[.privateHeaders])
+        preservePaths = strings(fromJSON: fieldMap[.preservePaths])
         compilerFlags = strings(fromJSON: fieldMap[.compilerFlags])
         libraries = strings(fromJSON: fieldMap[.libraries])
 
@@ -365,6 +373,12 @@ extension PodSpec {
         public static let publicHeaders: Lens<PodSpecRepresentable, [String]> = {
             ReadonlyLens { $0.publicHeaders }
         }()
+        public static let privateHeaders: Lens<PodSpecRepresentable, [String]> = {
+            ReadonlyLens { $0.privateHeaders }
+        }()
+        public static let preservePaths: Lens<PodSpecRepresentable, [String]> = {
+            ReadonlyLens { $0.preservePaths }
+        }()
         public static let requiresArc: Lens<PodSpecRepresentable, Either<Bool, [String]>?> = {
             ReadonlyLens { $0.requiresArc }
         }()
@@ -372,7 +386,6 @@ extension PodSpec {
         public static let resources: Lens<PodSpecRepresentable, [String]> = {
             ReadonlyLens { $0.resources }
         }()
-
         public static let ios: Lens<PodSpec, PodSpecRepresentable?> = {
             ReadonlyLens { $0.ios }
         }()

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -297,9 +297,10 @@ public enum RepoActions {
         // - Put them into the public header directory
         let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions: buildOptions)
         let globResultsArr = buildFile.skylarkConvertibles.compactMap { $0 as? ObjcLibrary }
-            .compactMap { $0.headers }
-            .flatMap { globNode in
-                globNode.include.fold(basic: { (patterns: Set<String>?) -> Set<String> in
+            .flatMap {
+                objcLibrary -> Set<String> in
+                let headers: GlobNode = objcLibrary.headers
+                return headers.include.fold(basic: { (patterns: Set<String>?) -> Set<String> in
                     let s: Set<String> = Set(patterns.map { $0.flatMap(podGlob) } ?? [])
                     return s
                 }, multi: { (set: Set<String>, multi: MultiPlatform<Set<String>>) -> Set<String> in

--- a/Tests/BuildTests/BuildTest.swift
+++ b/Tests/BuildTests/BuildTest.swift
@@ -33,11 +33,12 @@ class BuildTests: XCTestCase {
         let podSandbox = sandbox + "/Vendor/\(pod)"
         shell.dir(podSandbox)
         shell.shellOut("ditto $PWD \(sandbox)/Vendor/rules_pods")
-        shell.shellOut("ditto \(rootDir)/Tests/BuildTests/Examples/\(pod)/Pods.WORKSPACE \(sandbox)/Pods.WORKSPACE")
+        shell.shellOut("ditto \(rootDir)/Tests/BuildTests/Examples/\(pod)/* \(sandbox)/")
+        shell.shellOut("ditto \(rootDir)/Tests/BuildTests/Examples/PodSpecs \(sandbox)/Vendor/PodSpecs")
         let task = ShellTask(command: "/bin/bash", arguments: [
-                "-c", sandbox +
-                "/Vendor/rules_pods/bin/update_pods.py --src_root \(sandbox)"
-                ], timeout: 1200.0)
+                "-c",
+                "Vendor/rules_pods/bin/update_pods.py"
+                ], timeout: 1200.0, cwd: sandbox)
         let result = task.launch()
         XCTAssertEqual(result.terminationStatus, 0)
         print("PodUpdate Result:", result.standardOutputAsString)
@@ -71,6 +72,19 @@ class BuildTests: XCTestCase {
 
     func testPINRemoteImage() {
         build(pod: "PINRemoteImage", specs: ["Core"])
+    }
+
+    func testRN() {
+        build(pod: "React", specs: [
+             "Core",
+             "RCTAnimation",
+             "CxxBridge",
+             "DevSupport",
+             "RCTImage",
+             "RCTNetwork",
+             "RCTText",
+             "RCTWebSocket",
+             ])
     }
 
     func testTexture() {

--- a/Tests/BuildTests/Examples/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost-for-react-native'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+end

--- a/Tests/BuildTests/Examples/PodSpecs/glog-0.3.4/ios-configure-glog.sh
+++ b/Tests/BuildTests/Examples/PodSpecs/glog-0.3.4/ios-configure-glog.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+CURRENT_ARCH="${CURRENT_ARCH:-armv7}"
+
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+
+# Remove automake symlink if it exists
+if [ -h "test-driver" ]; then
+    rm test-driver
+fi
+
+# source ../PodSpecs/react-native-third-party-0.51.0/Env.sh
+
+echo  "set -o xtrace" > config2
+chmod +x config2
+cat configure >> config2
+
+./config2 --host arm-apple-darwin
+
+# Fix build for tvOS
+cat << EOF >> src/config.h
+
+/* Add in so we have Apple Target Conditionals */
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <Availability.h>
+#endif
+
+/* Special configuration for AppleTVOS */
+#if TARGET_OS_TV
+#undef HAVE_SYSCALL_H
+#undef HAVE_SYS_SYSCALL_H
+#undef OS_MACOSX
+#endif
+
+/* Special configuration for ucontext */
+#undef HAVE_UCONTEXT_H
+#undef PC_FROM_UCONTEXT
+#if defined(__x86_64__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip
+#elif defined(__i386__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip
+#endif
+EOF

--- a/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name = 'DoubleConversion'
+  spec.version = '1.1.6'
+  spec.license = { :type => 'MIT' }
+  spec.homepage = 'https://github.com/google/double-conversion'
+  spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
+  spec.authors = 'Google'
+  spec.prepare_command = 'mv src double-conversion'
+  spec.source = { :git => 'https://github.com/google/double-conversion.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'DoubleConversion'
+  spec.source_files = 'double-conversion/*.{h,cc}'
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |spec|
+  spec.name = 'Folly'
+  spec.version = '2016.10.31.00'
+  spec.license = { :type => 'Apache License, Version 2.0' }
+  spec.homepage = 'https://github.com/facebook/folly'
+  spec.summary = 'An open-source C++ library developed and used at Facebook.'
+  spec.authors = 'Facebook'
+  spec.source = { :git => 'https://github.com/facebook/folly.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'folly'
+  spec.dependency 'boost-for-react-native'
+  spec.dependency 'DoubleConversion'
+  spec.dependency 'glog'
+  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+  spec.source_files = 'folly/Bits.cpp',
+                      'folly/Conv.cpp',
+                      'folly/Demangle.cpp',
+                      'folly/StringBase.cpp',
+                      'folly/Unicode.cpp',
+                      'folly/dynamic.cpp',
+                      'folly/json.cpp',
+                      'folly/portability/BitsFunctexcept.cpp',
+                      'folly/detail/MallocImpl.cpp'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'folly/*.h',
+                        'folly/detail/*.h',
+                        'folly/portability/*.h'
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\"" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+end

--- a/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/glog.podspec
+++ b/Tests/BuildTests/Examples/PodSpecs/react-0.57/third-party-podspecs/glog.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |spec|
+  spec.name = 'glog'
+  spec.version = '0.3.5'
+  spec.license = { :type => 'Google', :file => 'COPYING' }
+  spec.homepage = 'https://github.com/google/glog'
+  spec.summary = 'Google logging module'
+  spec.authors = 'Google'
+
+  # spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
+  spec.source = { :git => 'https://github.com/google/glog.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'glog'
+  spec.header_dir = 'glog'
+  spec.source_files = 'src/glog/*.h',
+                      'src/demangle.cc',
+                      'src/logging.cc',
+                      'src/raw_logging.cc',
+                      'src/signalhandler.cc',
+                      'src/symbolize.cc',
+                      'src/utilities.cc',
+                      'src/vlog_is_on.cc'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'src/*.h',
+                        'src/base/*.h'
+  spec.exclude_files       = "src/windows/**/*"
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/Tests/BuildTests/Examples/React/Pods.WORKSPACE
+++ b/Tests/BuildTests/Examples/React/Pods.WORKSPACE
@@ -1,0 +1,82 @@
+new_pod_repository(
+  name = "boost-for-react-native",
+  url = 'https://github.com/react-native-community/boost-for-react-native/archive/v1.63.0-0.zip',
+  # This podspec isn't included in the http archives of boost.
+  podspec_url = 'Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec',
+  generate_module_map = False,
+  install_script = """
+    __INIT_REPO__
+    # TODO: We need to add the ability to not generate this dir.
+    rm -rf pod_support/Headers/Public/boost
+  """,
+)
+
+new_pod_repository(
+  name = "Folly",
+  podspec_url = "Vendor/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec",
+  url = "https://github.com/facebook/folly/archive/v2016.09.26.00.zip",
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "DoubleConversion",
+  url = 'https://github.com/google/double-conversion/archive/v1.1.5.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec',
+  install_script = """
+    # prepare_command
+    mv src double-conversion
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "glog",
+  url = 'https://github.com/google/glog/archive/v0.3.4.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.57/third-party-podspecs/GLog.podspec',
+  install_script = """
+    # prepare_command
+  	sh ../PodSpecs/glog-0.3.4/ios-configure-glog.sh || exit 1
+  	__INIT_REPO__
+  """,
+  generate_module_map = False
+)
+
+# Prior, required manual changes
+# - Copy over third-party-podspecs to Vendor/Podspecs
+# - Comment out busted prepare commands
+new_pod_repository(
+  name = "React",
+  url = 'https://github.com/facebook/react-native/archive/v0.57.0.zip',
+  user_options = [
+    # TODO: https://github.com/pinterest/PodToBUILD/issues/51
+    "jsinspector.copts += -std=c++14",
+  ],
+
+  # Module map doesn't work because it seems to be expecting the folly library
+  generate_module_map = False,
+  inhibit_warnings = True,
+)
+
+new_pod_repository(
+  name = "Yoga",
+  url = 'https://github.com/facebook/react-native/archive/v0.55.4.zip',
+  strip_prefix = 'react-native-0.55.4/ReactCommon/yoga',
+  install_script = """
+    # We need to fix the package parameter here (even though we don't use in pod2build)
+    # because the evaluation of the podspec in Ruby will fail. The package parameter
+    # points to a JSON.parse of a file outside the yoga sandbox.
+    /usr/bin/sed -i "" "s,^package.*,package = { 'version' => '0.46.3' },g" Yoga.podspec
+
+    
+    # The canonical version of Yoga uses the Podspec.name, 'Yoga'
+    # React uses the name of 'yoga'. To use this with Texture, we need to
+    # uppercase the name. This is an issue with React <-> Texture integration in
+    # Pods.
+    /usr/bin/sed -i "" "s,spec.module_name.*yoga,spec.module_name = 'Yoga,g" Yoga.podspec
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)


### PR DESCRIPTION
This commit simplifies header propagation, by moving all headers to the
rule level file group.

It propagate headers from header_dir, private_header_files, preserve_paths.

private_header_files should be added to srcs eventually - and perhaps be
an exclude clause on headers.

Includes that were previously added are skipped when the user disables
the HEADERMAP_ENABLED flag.

Additionally, a BuildTest is added for React.