### PR TITLE
BuildFileContext / fix fragile header logic

### DIFF
--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -26,7 +26,7 @@ filegroup(
     ) + [
 
   ] + [
-    ":SwiftSupport_hdrs"
+
   ],
   visibility = [
     "//visibility:public"

--- a/Sources/PodToBUILD/BazelTarget.swift
+++ b/Sources/PodToBUILD/BazelTarget.swift
@@ -1,0 +1,25 @@
+//
+//  BazelTarget.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 10/17/2018.
+//  Copyright © 2018 Pinterest Inc. All rights reserved.
+//
+
+/// Law: Names must be valid bazel names; see the spec
+protocol BazelTarget: SkylarkConvertible {
+    var name: String { get }
+    var acknowledgedDeps: [String]? { get }
+    var acknowledged: Bool { get }
+}
+
+extension BazelTarget {
+    var acknowledgedDeps: [String]? {
+        return nil
+    }
+
+    var acknowledged: Bool {
+        return false
+    }
+}
+

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -181,7 +181,9 @@ public struct PodBuildFile: SkylarkConvertible {
 
     /// Return the skylark representation of the entire BUILD file
     public func toSkylark() -> SkylarkNode {
+        BuildFileContext.set(BuildFileContext(convertibles: skylarkConvertibles))
         let convertibleNodes: [SkylarkNode] = skylarkConvertibles.compactMap { $0.toSkylark() }
+        BuildFileContext.set(nil)
         let hasSwift = skylarkConvertibles.first(where: { $0 is SwiftLibrary }) != nil
         return .lines([makePrefixNodes(includeSwift: hasSwift)] + convertibleNodes)
     }

--- a/Sources/PodToBUILD/BuildFileContext.swift
+++ b/Sources/PodToBUILD/BuildFileContext.swift
@@ -1,0 +1,42 @@
+//
+//  BuildFileContext.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 10/17/2018.
+//  Copyright © 2018 Pinterest Inc. All rights reserved.
+//
+
+fileprivate var shared: BuildFileContext? = nil
+
+/// BuildFileContext
+/// Usage:
+/// During Skylark generation of a BuildFile the BuildFile context
+/// exposes all BazelTargets inside of the BuildFile.
+struct BuildFileContext {
+    private let bazelTargetByName: [String: BazelTarget]
+
+    init(convertibles: [SkylarkConvertible]) {
+        var bazelTargetByName: [String: BazelTarget] = [:]
+        convertibles.forEach { convertible in
+            guard let target = convertible as? BazelTarget else {
+                return
+            }
+            bazelTargetByName[target.name] = target
+        }
+        self.bazelTargetByName = bazelTargetByName
+    }
+
+    public func getBazelTarget(name: String) -> BazelTarget? {
+        return bazelTargetByName[name]
+    }
+
+    public static func set(_ context: BuildFileContext?) {
+        shared = context
+    }
+
+    public static func get() -> BuildFileContext? {
+        return shared
+    }
+}
+
+


### PR DESCRIPTION
Previously, we introspected label names to determine if they would emit
headers. This pattern is brittle and doesn't scale. Instead, expose all
BazelTargets during skylark generation of a BuildFile.

Originally it seemed possible to topologically sort all of the deps and
_allocate_ in reverse order. This pattern will won't work, because
transforms/simplifications can change the original inputs. Additionally.
it is less code and simpler to have access to the *entire* graph at code
gen time.