### PR TITLE
Docs for bazel run, FAQ, repository_rule, installs

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,9 +1,9 @@
 # PodToBUILD Examples
 
-CI tested, usage examples of using PodToBUILD.
+CI tested, usage examples of using CocoaPods with Bazel via `PodToBUILD`.
 
-_Note, that the installation of `PodToBUILD` is non-normal and setup for testing
-conditions - see the README.md for installation and usage._
+_Note, that the installation of `rules_pods` is non-normal and setup for testing
+conditions - see the README.md for more info._
 
 Each example directory contains:
 - a `BUILD` file. Under tests, Bazel builds the targets defined here

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-impl-spm:
 	@mkdir -p .build
 	swift build $(SWIFT_OPTS) \
 	    -Xswiftc -target -Xswiftc x86_64-apple-macosx10.13 \
-		| tee .build/last_build.log \
+		| tee .build/last_build.log; \
 		exit $${PIPESTATUS[0]}
 
 # Tee the error to a log file
@@ -106,7 +106,7 @@ github_release:
 	@echo "creating release: $(TESTED_BAZEL_VERSION)-($(shell git rev-parse --short HEAD)"
 	$(MAKE) archive
 	@hub release create -p -a PodToBUILD.zip \
-   		-m "PodToBUILD  $(TESTED_BAZEL_VERSION)-$(shell git rev-parse --sort HEAD)" \
+   		-m "PodToBUILD  $(TESTED_BAZEL_VERSION)-$(shell git rev-parse --short HEAD)" \
 		$(TESTED_BAZEL_VERSION)-$(shell git rev-parse --short HEAD)
 
 # Create an archive of `rules_pods`.


### PR DESCRIPTION
This PR defaults the docs to the `repository_rule` as that is the
idiomatic way to install pods in Bazel. It adds notes about using
`repository_rule`s, why `PodToBUILD` supports out of band dependency
installation, and how to `bazel run` the pod updates.

Generally, it isn't ideal to do source builds of programs like
`PodToBUILD` on a users machine for performance and build environment
coupling. This PR defaults documentation to point at binary releases.

Fixes #36