### PR TITLE
Bazel, rules_swift, and rules_apple updates

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
 
 objc_library(

--- a/Sources/PodToBUILD/ShellContext.swift
+++ b/Sources/PodToBUILD/ShellContext.swift
@@ -93,7 +93,7 @@ class ShellTask : NSObject {
     /// By default, it runs under bash for the current path.
     public static func with(script: String, timeout: Double, cwd: String? = nil) -> ShellTask {
         let path = ProcessInfo.processInfo.environment["PATH"]!
-        let script = "PATH=\(path) /bin/sh -c '\(script)'"
+        let script = "PATH=\"\(path)\" /bin/sh -c '\(script)'"
         return ShellTask(command: "/bin/bash", arguments: ["-c", script],
                 timeout: timeout, cwd: cwd)
     }

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.6.0",
+    tag = "0.13.0",
 )
 
 load(
@@ -16,7 +16,7 @@ apple_rules_dependencies()
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.0",
+    tag = "0.6.0",
 )
 
 load(

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.22.0"
+BAZEL_VERSION_SHA="adae5bbc3bf2b9b60d460d8ea2c65da1a6edd75b242439dfc49d001272548d13"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
@@ -107,7 +107,7 @@ if [[ -x "${BAZEL}" ]]; then
   done
 
   # Exec in a subshell in order to trap
-  (exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}")
+  (exec -a "$0" /usr/bin/env - TERM="${TERM}" SHELL="${SHELL}" PATH="${PATH}" HOME="${HOME}" "${BAZEL}" "${ARGS[@]}")
 else
   echo "WARNING: Missing installation of bazel" >&2;
   exit 1


### PR DESCRIPTION
I had some trouble getting `PodToBUILD` working on my local setup running the latest versions of Bazel, `rules_swift`, and `rules_apple`, so I'm PR'ing the changes I made to get everything copacetic.
 - `@build_bazel_rules_apple//apple:swift.bzl` no longer exists
 - Throughout the tooling, some shell variables aren't appropriately quoted. I have some spaces in my `$PATH`, so I addressed all the places this was causing a problem.
 - ~(optional) The README suggested loading `rules_pods` with `http_archive` instead of `git_repository`…this is fairly unusual, so I changed it to the more common `git_repository`.~  < (I realized we can't recommend this because the repository doesn't version the compiled Swift binaries…)