### PR TITLE
Updates for rules_apple resource rules

### DIFF
--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -696,7 +697,7 @@ objc_library(
   ] + [
     "-fmodule-name=Braintree_pod_module"
   ],
-  bundles = [
+  data = [
     ":UI_Bundle_Braintree-Drop-In-Localization",
     ":UI_Bundle_Braintree-UI-Localization"
   ],
@@ -875,7 +876,7 @@ objc_library(
   ] + [
     "-fmodule-name=Braintree_pod_module"
   ],
-  bundles = [
+  data = [
     ":3D-Secure_Bundle_Braintree-3D-Secure-Localization"
   ],
   visibility = [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 config_setting(
   name = "iosCase",
   values = {

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -304,7 +305,7 @@ objc_library(
   ] + [
     "-fmodule-name=FBSDKCoreKit_pod_module"
   ],
-  bundles = [
+  data = [
     ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
   ],
   visibility = [
@@ -318,7 +319,7 @@ acknowledged_target(
   ],
   value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
   )
-objc_bundle(
+apple_bundle_import(
   name = "FBSDKCoreKit_Bundle_FacebookSDKStrings",
   bundle_imports = glob(
     [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 swift_library(
   name = "FolioReaderKit",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -89,7 +90,7 @@ objc_library(
   ] + [
     "-fmodule-name=GoogleAppIndexing_pod_module"
   ],
-  bundles = [
+  data = [
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources"
   ],
   visibility = [
@@ -103,7 +104,7 @@ acknowledged_target(
   ],
   value = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_fragment"
   )
-objc_bundle(
+apple_bundle_import(
   name = "GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
   bundle_imports = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -85,7 +85,7 @@ objc_library(
   ] + [
     "-fmodule-name=GoogleAuthUtilities_pod_module"
   ],
-  resources = glob(
+  data = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/Resources/GTMOAuth2ViewTouch.xib"
     ],

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -89,7 +90,7 @@ objc_library(
   ] + [
     "-fmodule-name=GoogleSignIn_pod_module"
   ],
-  bundles = [
+  data = [
     ":GoogleSignIn_Bundle_GoogleSignIn"
   ],
   visibility = [
@@ -106,7 +107,7 @@ acknowledged_target(
   ],
   value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"
   )
-objc_bundle(
+apple_bundle_import(
   name = "GoogleSignIn_Bundle_GoogleSignIn",
   bundle_imports = glob(
     [

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -118,7 +119,7 @@ objc_library(
   ] + [
     "-fmodule-name=OnePasswordExtension_pod_module"
   ],
-  bundles = [
+  data = [
     ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
   ],
   visibility = [

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -88,7 +88,7 @@ objc_library(
   ] + [
     "-fmodule-name=PaymentKit_pod_module"
   ],
-  resources = glob(
+  data = glob(
     [
       "PaymentKit/Resources/*.png",
       "PaymentKit/Resources/Cards/*.png"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 config_setting(
   name = "iosCase",
   values = {

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 swift_library(
   name = "SevenSwitch",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -102,7 +103,7 @@ objc_library(
   ] + [
     "-fmodule-name=Stripe_pod_module"
   ],
-  bundles = select(
+  data = select(
     {
       "//conditions:default": [
         ":Stripe_Bundle_Stripe"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +16,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 filegroup(
   name = "iOSSnapshotTestCase_hdrs",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -88,7 +89,7 @@ objc_library(
   ] + [
     "-fmodule-name=iRate_pod_module"
   ],
-  bundles = [
+  data = [
     ":iRate_Bundle_iRate"
   ],
   visibility = [
@@ -102,7 +103,7 @@ acknowledged_target(
   ],
   value = "//Vendor/iRate/pod_support_buildable:acknowledgement_fragment"
   )
-objc_bundle(
+apple_bundle_import(
   name = "iRate_Bundle_iRate",
   bundle_imports = glob(
     [

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -1,3 +1,5 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "pch_with_name_hint",
@@ -15,7 +17,6 @@ native.config_setting(
     "compilation_mode": "opt"
   }
   )
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 config_setting(
   name = "iosCase",
   values = {
@@ -164,7 +165,7 @@ objc_library(
   ] + [
     "-fmodule-name=youtube-ios-player-helper_pod_module"
   ],
-  bundles = [
+  data = [
     ":youtube-ios-player-helper_Bundle_Assets"
   ],
   visibility = [
@@ -344,7 +345,7 @@ objc_library(
   ] + [
     "-fmodule-name=youtube-ios-player-helper_pod_module"
   ],
-  bundles = [
+  data = [
     ":youtube-ios-player-helper_Bundle_Assets"
   ],
   visibility = [
@@ -358,7 +359,7 @@ acknowledged_target(
   ],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
   )
-objc_bundle(
+apple_bundle_import(
   name = "youtube-ios-player-helper_Bundle_Assets",
   bundle_imports = glob(
     [

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -7,7 +7,7 @@
 //
 
 // Represent a swift_library in Bazel
-// https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-swift.md
+// https://github.com/bazelbuild/rules_swift/blob/master/doc/rules.md#swift_library
 // Note: Swift support is currently in progress
 // TODO:
 // - XCConfig / compiler flags


### PR DESCRIPTION
### Main Changes
- objc_bundle is now apple_bundle_import
- Bundles and resources are passed through the `data` value of
objc_library
- Added function to optionally add load statements based on the types of
skylark nodes in the build files (swift, apple resource bundles, etc)

### Remaining work 
- Verify app bundles still copy resources to the same locations
- Make sure bundles are passed to SwiftLibrary correctly as well