### PR TITLE
The `gen_includes` target should be prepended with `:` 

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -86,7 +86,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Adjust_includes"
+    ":Adjust_includes"
   ],
   copts = [
 
@@ -186,7 +186,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -279,7 +279,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Sociomantic_includes"
+    ":Sociomantic_includes"
   ],
   copts = [
 
@@ -372,7 +372,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Criteo_includes"
+    ":Criteo_includes"
   ],
   copts = [
 
@@ -465,7 +465,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Trademob_includes"
+    ":Trademob_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -86,7 +86,7 @@ objc_library(
     ":AppLinks",
     ":Tasks"
   ] + [
-    "Bolts_includes"
+    ":Bolts_includes"
   ],
   copts = [
 
@@ -212,7 +212,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Tasks_includes"
+    ":Tasks_includes"
   ],
   copts = [
 
@@ -299,7 +299,7 @@ objc_library(
   deps = [
     ":Tasks"
   ] + [
-    "AppLinks_includes"
+    ":AppLinks_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -66,7 +66,7 @@ objc_library(
     ":PayPal",
     ":UI"
   ] + [
-    "Braintree_includes"
+    ":Braintree_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -163,7 +163,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -245,7 +245,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Apple-Pay_includes"
+    ":Apple-Pay_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -329,7 +329,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Card_includes"
+    ":Card_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -409,7 +409,7 @@ objc_library(
     ":Core",
     ":DataCollector_VendoredLibraries"
   ] + [
-    "DataCollector_includes"
+    ":DataCollector_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -496,7 +496,7 @@ objc_library(
     ":Core",
     ":PayPalOneTouch"
   ] + [
-    "PayPal_includes"
+    ":PayPal_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -576,7 +576,7 @@ objc_library(
     ":Core",
     ":PayPalDataCollector"
   ] + [
-    "Venmo_includes"
+    ":Venmo_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -677,7 +677,7 @@ objc_library(
     ":Card",
     ":Core"
   ] + [
-    "UI_includes"
+    ":UI_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -764,7 +764,7 @@ objc_library(
     ":Card",
     ":Core"
   ] + [
-    "UnionPay_includes"
+    ":UnionPay_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -856,7 +856,7 @@ objc_library(
     ":Card",
     ":Core"
   ] + [
-    "3D-Secure_includes"
+    ":3D-Secure_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -949,7 +949,7 @@ objc_library(
     ":PayPalDataCollector",
     ":PayPalUtils"
   ] + [
-    "PayPalOneTouch_includes"
+    ":PayPalOneTouch_includes"
   ],
   copts = [
     "-ObjC",
@@ -1043,7 +1043,7 @@ objc_library(
     ":PayPalDataCollector_VendoredLibraries",
     ":PayPalUtils"
   ] + [
-    "PayPalDataCollector_includes"
+    ":PayPalDataCollector_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"
@@ -1140,7 +1140,7 @@ objc_library(
   deps = [
 
   ] + [
-    "PayPalUtils_includes"
+    ":PayPalUtils_includes"
   ],
   copts = [
     "-Wall -Werror -Wextra"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -62,7 +62,7 @@ objc_library(
     ":Core",
     ":without-IDFA"
   ] + [
-    "Branch_includes"
+    ":Branch_includes"
   ],
   copts = [
 
@@ -149,7 +149,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -235,7 +235,7 @@ objc_library(
   deps = [
 
   ] + [
-    "without-IDFA_includes"
+    ":without-IDFA_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -97,7 +97,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Calabash_cxx_includes"
+    ":Calabash_cxx_includes"
   ],
   copts = [
     ""Vendor/Calabash/calabash.framework/calabash"",
@@ -216,7 +216,7 @@ objc_library(
     ":Calabash_cxx",
     ":Calabash_swift"
   ] + [
-    "Calabash_includes"
+    ":Calabash_includes"
   ],
   copts = [
     ""Vendor/Calabash/calabash.framework/calabash"",

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -78,7 +78,7 @@ objc_library(
   deps = [
     ":CardIO_VendoredLibraries"
   ] + [
-    "CardIO_includes"
+    ":CardIO_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "ColorCube_includes"
+    ":ColorCube_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -76,7 +76,7 @@ objc_library(
   deps = [
     ":EarlGrey_VendoredFrameworks"
   ] + [
-    "EarlGrey_includes"
+    ":EarlGrey_includes"
   ],
   copts = [
     "-fobjc-arc-exceptions"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -285,7 +285,7 @@ objc_library(
       ]
     }
     ) + [
-    "FBSDKCoreKit_includes"
+    ":FBSDKCoreKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -80,7 +80,7 @@ objc_library(
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
   ] + [
-    "FBSDKLoginKit_includes"
+    ":FBSDKLoginKit_includes"
   ],
   copts = [
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -72,7 +72,7 @@ objc_library(
   deps = [
 
   ] + [
-    "FBSDKMessengerShareKit_includes"
+    ":FBSDKMessengerShareKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -179,7 +179,7 @@ objc_library(
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
   ] + [
-    "FBSDKShareKit_includes"
+    ":FBSDKShareKit_includes"
   ],
   copts = [
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -75,7 +75,7 @@ objc_library(
   deps = [
 
   ] + [
-    "FLAnimatedImage_includes"
+    ":FLAnimatedImage_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -78,7 +78,7 @@ objc_library(
   deps = [
 
   ] + [
-    "FLEX_includes"
+    ":FLEX_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -60,7 +60,7 @@ objc_library(
   deps = [
     ":standard"
   ] + [
-    "FMDB_includes"
+    ":FMDB_includes"
   ],
   copts = [
 
@@ -146,7 +146,7 @@ objc_library(
   deps = [
 
   ] + [
-    "standard_includes"
+    ":standard_includes"
   ],
   copts = [
 
@@ -225,7 +225,7 @@ objc_library(
   deps = [
     ":standard"
   ] + [
-    "FTS_includes"
+    ":FTS_includes"
   ],
   copts = [
 
@@ -295,7 +295,7 @@ objc_library(
   deps = [
 
   ] + [
-    "standalone_includes"
+    ":standalone_includes"
   ],
   copts = [
     "-DFMDB_SQLITE_STANDALONE"
@@ -377,7 +377,7 @@ objc_library(
   deps = [
     "//Vendor/SQLCipher:SQLCipher"
   ] + [
-    "SQLCipher_includes"
+    ":SQLCipher_includes"
   ],
   copts = [
     "-DHAVE_USLEEP=1",

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -86,7 +86,7 @@ objc_library(
     "//Vendor/boost-for-react-native:boost-for-react-native",
     "//Vendor/glog:glog"
   ] + [
-    "Folly_includes"
+    ":Folly_includes"
   ],
   copts = [
     "-std=c++14",

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -70,7 +70,7 @@ objc_library(
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
     ":GoogleAppIndexing_VendoredFrameworks"
   ] + [
-    "GoogleAppIndexing_includes"
+    ":GoogleAppIndexing_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -61,7 +61,7 @@ objc_library(
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleAppUtilities_VendoredFrameworks"
   ] + [
-    "GoogleAppUtilities_includes"
+    ":GoogleAppUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -66,7 +66,7 @@ objc_library(
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleAuthUtilities_VendoredFrameworks"
   ] + [
-    "GoogleAuthUtilities_includes"
+    ":GoogleAuthUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -64,7 +64,7 @@ objc_library(
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleNetworkingUtilities_VendoredFrameworks"
   ] + [
-    "GoogleNetworkingUtilities_includes"
+    ":GoogleNetworkingUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -70,7 +70,7 @@ objc_library(
     ":GoogleSignIn_Bundle_GoogleSignIn",
     ":GoogleSignIn_VendoredFrameworks"
   ] + [
-    "GoogleSignIn_includes"
+    ":GoogleSignIn_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -60,7 +60,7 @@ objc_library(
   deps = [
     ":GoogleSymbolUtilities_VendoredFrameworks"
   ] + [
-    "GoogleSymbolUtilities_includes"
+    ":GoogleSymbolUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -68,7 +68,7 @@ objc_library(
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleUtilities_VendoredFrameworks"
   ] + [
-    "GoogleUtilities_includes"
+    ":GoogleUtilities_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -72,7 +72,7 @@ objc_library(
   deps = [
 
   ] + [
-    "IBActionSheet_includes"
+    ":IBActionSheet_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -94,7 +94,7 @@ objc_library(
   deps = [
     ":Default"
   ] + [
-    "IGListKit_includes"
+    ":IGListKit_includes"
   ],
   copts = [
 
@@ -210,7 +210,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Diffing_cxx_includes"
+    ":Diffing_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -325,7 +325,7 @@ objc_library(
   deps = [
     ":Diffing_cxx"
   ] + [
-    "Diffing_includes"
+    ":Diffing_includes"
   ],
   copts = [
 
@@ -450,7 +450,7 @@ objc_library(
   deps = [
     ":Diffing"
   ] + [
-    "Default_cxx_includes"
+    ":Default_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -571,7 +571,7 @@ objc_library(
     ":Default_cxx",
     ":Diffing"
   ] + [
-    "Default_includes"
+    ":Default_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "KVOController_includes"
+    ":KVOController_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -59,7 +59,7 @@ objc_library(
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks"
   ] + [
-    "KakaoOpenSDK_includes"
+    ":KakaoOpenSDK_includes"
   ],
   copts = [
 
@@ -133,7 +133,7 @@ objc_library(
   deps = [
     ":KakaoOpenSDK_VendoredFrameworks"
   ] + [
-    "KakaoOpenSDK_includes"
+    ":KakaoOpenSDK_includes"
   ],
   copts = [
 
@@ -219,7 +219,7 @@ objc_library(
   deps = [
     ":KakaoNavi_VendoredFrameworks"
   ] + [
-    "KakaoNavi_includes"
+    ":KakaoNavi_includes"
   ],
   copts = [
 
@@ -305,7 +305,7 @@ objc_library(
   deps = [
     ":KakaoLink_VendoredFrameworks"
   ] + [
-    "KakaoLink_includes"
+    ":KakaoLink_includes"
   ],
   copts = [
 
@@ -391,7 +391,7 @@ objc_library(
   deps = [
     ":KakaoS2_VendoredFrameworks"
   ] + [
-    "KakaoS2_includes"
+    ":KakaoS2_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -103,7 +103,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Masonry_includes"
+    ":Masonry_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -99,7 +99,7 @@ objc_library(
   deps = [
     ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
   ] + [
-    "OnePasswordExtension_includes"
+    ":OnePasswordExtension_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -87,7 +87,7 @@ objc_library(
     ":Arc-exception-safe",
     ":Core"
   ] + [
-    "PINCache_includes"
+    ":PINCache_includes"
   ],
   copts = [
 
@@ -182,7 +182,7 @@ objc_library(
   deps = [
     "//Vendor/PINOperation:PINOperation"
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -271,7 +271,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Arc-exception-safe_includes"
+    ":Arc-exception-safe_includes"
   ],
   copts = [
     "-fobjc-arc-exceptions"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -70,7 +70,7 @@ objc_library(
   deps = [
 
   ] + [
-    "PINOperation_cxx_includes"
+    ":PINOperation_cxx_includes"
   ],
   copts = [
 
@@ -157,7 +157,7 @@ objc_library(
   deps = [
     ":PINOperation_cxx"
   ] + [
-    "PINOperation_includes"
+    ":PINOperation_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -62,7 +62,7 @@ objc_library(
     ":FLAnimatedImage",
     ":PINCache"
   ] + [
-    "PINRemoteImage_includes"
+    ":PINRemoteImage_includes"
   ],
   copts = [
 
@@ -153,7 +153,7 @@ objc_library(
   deps = [
     "//Vendor/PINOperation:PINOperation"
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -226,7 +226,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "iOS_includes"
+    ":iOS_includes"
   ],
   copts = [
 
@@ -300,7 +300,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "OSX_includes"
+    ":OSX_includes"
   ],
   copts = [
 
@@ -370,7 +370,7 @@ objc_library(
   deps = [
     ":iOS"
   ] + [
-    "tvOS_includes"
+    ":tvOS_includes"
   ],
   copts = [
 
@@ -450,7 +450,7 @@ objc_library(
     "//Vendor/FLAnimatedImage:FLAnimatedImage",
     ":Core"
   ] + [
-    "FLAnimatedImage_includes"
+    ":FLAnimatedImage_includes"
   ],
   copts = [
 
@@ -521,7 +521,7 @@ objc_library(
     "//Vendor/libwebp:libwebp",
     ":Core"
   ] + [
-    "WebP_includes"
+    ":WebP_includes"
   ],
   copts = [
     "-DPIN_WEBP=1"
@@ -601,7 +601,7 @@ objc_library(
     "//Vendor/PINCache:PINCache",
     ":Core"
   ] + [
-    "PINCache_includes"
+    ":PINCache_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "PaymentKit_includes"
+    ":PaymentKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -73,7 +73,7 @@ objc_library(
   deps = [
 
   ] + [
-    "RadarKit_includes"
+    ":RadarKit_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -73,7 +73,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "React_includes"
+    ":React_includes"
   ],
   copts = [
 
@@ -496,7 +496,7 @@ objc_library(
   deps = [
     "//Vendor/Yoga:Yoga"
   ] + [
-    "Core_cxx_includes"
+    ":Core_cxx_includes"
   ],
   copts = [
 
@@ -916,7 +916,7 @@ objc_library(
     "//Vendor/Yoga:Yoga",
     ":Core_cxx"
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -1000,7 +1000,7 @@ objc_library(
     ":Core",
     ":cxxreact"
   ] + [
-    "CxxBridge_cxx_includes"
+    ":CxxBridge_cxx_includes"
   ],
   copts = [
     "-std=c++14",
@@ -1083,7 +1083,7 @@ objc_library(
     ":CxxBridge_cxx",
     ":cxxreact"
   ] + [
-    "CxxBridge_includes"
+    ":CxxBridge_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -1185,7 +1185,7 @@ objc_library(
     ":Core",
     ":RCTWebSocket"
   ] + [
-    "DevSupport_cxx_includes"
+    ":DevSupport_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -1296,7 +1296,7 @@ objc_library(
     ":DevSupport_swift",
     ":RCTWebSocket"
   ] + [
-    "DevSupport_includes"
+    ":DevSupport_includes"
   ],
   copts = [
 
@@ -1403,7 +1403,7 @@ objc_library(
     ":Core",
     ":fabric"
   ] + [
-    "RCTFabric_cxx_includes"
+    ":RCTFabric_cxx_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -1509,7 +1509,7 @@ objc_library(
     ":RCTFabric_cxx",
     ":fabric"
   ] + [
-    "RCTFabric_includes"
+    ":RCTFabric_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -1588,7 +1588,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "tvOS_includes"
+    ":tvOS_includes"
   ],
   copts = [
 
@@ -1685,7 +1685,7 @@ objc_library(
     "//Vendor/Folly:Folly",
     ":PrivateDatabase"
   ] + [
-    "jschelpers_includes"
+    ":jschelpers_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -1778,7 +1778,7 @@ objc_library(
   deps = [
 
   ] + [
-    "jsinspector_includes"
+    ":jsinspector_includes"
   ],
   copts = [
 
@@ -1872,7 +1872,7 @@ objc_library(
   deps = [
 
   ] + [
-    "PrivateDatabase_includes"
+    ":PrivateDatabase_includes"
   ],
   copts = [
 
@@ -1975,7 +1975,7 @@ objc_library(
     ":jschelpers",
     ":jsinspector"
   ] + [
-    "cxxreact_includes"
+    ":cxxreact_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -2046,7 +2046,7 @@ objc_library(
   deps = [
 
   ] + [
-    "fabric_includes"
+    ":fabric_includes"
   ],
   copts = [
 
@@ -2145,7 +2145,7 @@ objc_library(
   deps = [
     "//Vendor/Folly:Folly"
   ] + [
-    "RCTFabricSample_includes"
+    ":RCTFabricSample_includes"
   ],
   copts = [
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -2224,7 +2224,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "ART_includes"
+    ":ART_includes"
   ],
   copts = [
 
@@ -2303,7 +2303,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTActionSheet_includes"
+    ":RCTActionSheet_includes"
   ],
   copts = [
 
@@ -2389,7 +2389,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTAnimation_includes"
+    ":RCTAnimation_includes"
   ],
   copts = [
 
@@ -2488,7 +2488,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTBlob_cxx_includes"
+    ":RCTBlob_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -2587,7 +2587,7 @@ objc_library(
     ":Core",
     ":RCTBlob_cxx"
   ] + [
-    "RCTBlob_includes"
+    ":RCTBlob_includes"
   ],
   copts = [
 
@@ -2667,7 +2667,7 @@ objc_library(
     ":Core",
     ":RCTImage"
   ] + [
-    "RCTCameraRoll_includes"
+    ":RCTCameraRoll_includes"
   ],
   copts = [
 
@@ -2746,7 +2746,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTGeolocation_includes"
+    ":RCTGeolocation_includes"
   ],
   copts = [
 
@@ -2829,7 +2829,7 @@ objc_library(
     ":Core",
     ":RCTNetwork"
   ] + [
-    "RCTImage_includes"
+    ":RCTImage_includes"
   ],
   copts = [
 
@@ -2913,7 +2913,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTNetwork_cxx_includes"
+    ":RCTNetwork_cxx_includes"
   ],
   copts = [
     "-std=c++14"
@@ -2997,7 +2997,7 @@ objc_library(
     ":Core",
     ":RCTNetwork_cxx"
   ] + [
-    "RCTNetwork_includes"
+    ":RCTNetwork_includes"
   ],
   copts = [
 
@@ -3076,7 +3076,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTPushNotification_includes"
+    ":RCTPushNotification_includes"
   ],
   copts = [
 
@@ -3155,7 +3155,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTSettings_includes"
+    ":RCTSettings_includes"
   ],
   copts = [
 
@@ -3234,7 +3234,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTText_includes"
+    ":RCTText_includes"
   ],
   copts = [
 
@@ -3313,7 +3313,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTVibration_includes"
+    ":RCTVibration_includes"
   ],
   copts = [
 
@@ -3412,7 +3412,7 @@ objc_library(
     ":RCTBlob",
     ":fishhook"
   ] + [
-    "RCTWebSocket_includes"
+    ":RCTWebSocket_includes"
   ],
   copts = [
 
@@ -3513,7 +3513,7 @@ objc_library(
   deps = [
 
   ] + [
-    "fishhook_includes"
+    ":fishhook_includes"
   ],
   copts = [
 
@@ -3592,7 +3592,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTLinkingIOS_includes"
+    ":RCTLinkingIOS_includes"
   ],
   copts = [
 
@@ -3674,7 +3674,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTTest_includes"
+    ":RCTTest_includes"
   ],
   copts = [
 
@@ -3745,7 +3745,7 @@ objc_library(
     ":Core",
     ":CxxBridge"
   ] + [
-    "_ignore_me_subspec_for_linting__includes"
+    ":_ignore_me_subspec_for_linting__includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -77,7 +77,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "React_includes"
+    ":React_includes"
   ],
   copts = [
 
@@ -213,7 +213,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 
@@ -292,7 +292,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "ART_includes"
+    ":ART_includes"
   ],
   copts = [
 
@@ -371,7 +371,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTActionSheet_includes"
+    ":RCTActionSheet_includes"
   ],
   copts = [
 
@@ -450,7 +450,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTAdSupport_includes"
+    ":RCTAdSupport_includes"
   ],
   copts = [
 
@@ -529,7 +529,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTGeolocation_includes"
+    ":RCTGeolocation_includes"
   ],
   copts = [
 
@@ -608,7 +608,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTImage_includes"
+    ":RCTImage_includes"
   ],
   copts = [
 
@@ -687,7 +687,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTNetwork_includes"
+    ":RCTNetwork_includes"
   ],
   copts = [
 
@@ -766,7 +766,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTPushNotification_includes"
+    ":RCTPushNotification_includes"
   ],
   copts = [
 
@@ -845,7 +845,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTSettings_includes"
+    ":RCTSettings_includes"
   ],
   copts = [
 
@@ -924,7 +924,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTText_includes"
+    ":RCTText_includes"
   ],
   copts = [
 
@@ -1003,7 +1003,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTVibration_includes"
+    ":RCTVibration_includes"
   ],
   copts = [
 
@@ -1082,7 +1082,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTWebSocket_includes"
+    ":RCTWebSocket_includes"
   ],
   copts = [
 
@@ -1161,7 +1161,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "RCTLinkingIOS_includes"
+    ":RCTLinkingIOS_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -87,7 +87,7 @@ objc_library(
   deps = [
 
   ] + [
-    "SFHFKeychainUtils_cxx_includes"
+    ":SFHFKeychainUtils_cxx_includes"
   ],
   copts = [
 
@@ -200,7 +200,7 @@ objc_library(
     ":SFHFKeychainUtils_cxx",
     ":SFHFKeychainUtils_swift"
   ] + [
-    "SFHFKeychainUtils_includes"
+    ":SFHFKeychainUtils_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "SPUserResizableView+Pion_includes"
+    ":SPUserResizableView+Pion_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "SlackTextViewController_includes"
+    ":SlackTextViewController_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Smartling_includes"
+    ":Smartling_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -83,7 +83,7 @@ objc_library(
   deps = [
     ":Stripe_Bundle_Stripe"
   ] + [
-    "Stripe_includes"
+    ":Stripe_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -74,7 +74,7 @@ objc_library(
     ":PINRemoteImage",
     ":Photos"
   ] + [
-    "Texture_includes"
+    ":Texture_includes"
   ],
   copts = [
 
@@ -165,7 +165,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_cxx_includes"
+    ":Core_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -256,7 +256,7 @@ objc_library(
   deps = [
     ":Core_cxx"
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
     "-fno-exceptions -fno-objc-arc-exceptions"
@@ -336,7 +336,7 @@ objc_library(
     "//Vendor/PINRemoteImage:iOS",
     ":Core"
   ] + [
-    "PINRemoteImage_includes"
+    ":PINRemoteImage_includes"
   ],
   copts = [
 
@@ -416,7 +416,7 @@ objc_library(
     "//Vendor/IGListKit:IGListKit",
     ":Core"
   ] + [
-    "IGListKit_includes"
+    ":IGListKit_includes"
   ],
   copts = [
 
@@ -495,7 +495,7 @@ objc_library(
     "//Vendor/Yoga:Yoga",
     ":Core"
   ] + [
-    "Yoga_includes"
+    ":Yoga_includes"
   ],
   copts = [
     "-DYOGA=1"
@@ -576,7 +576,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "MapKit_includes"
+    ":MapKit_includes"
   ],
   copts = [
     "-DAS_USE_MAPKIT=1"
@@ -657,7 +657,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "Photos_includes"
+    ":Photos_includes"
   ],
   copts = [
     "-DAS_USE_PHOTOS=1"
@@ -738,7 +738,7 @@ objc_library(
   deps = [
     ":Core"
   ] + [
-    "AssetsLibrary_includes"
+    ":AssetsLibrary_includes"
   ],
   copts = [
     "-DAS_USE_ASSETS_LIBRARY=1"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -76,7 +76,7 @@ objc_library(
   deps = [
 
   ] + [
-    "UICollectionViewLeftAlignedLayout_cxx_includes"
+    ":UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
   copts = [
 
@@ -181,7 +181,7 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_cxx",
     ":UICollectionViewLeftAlignedLayout_swift"
   ] + [
-    "UICollectionViewLeftAlignedLayout_includes"
+    ":UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -72,7 +72,7 @@ objc_library(
   deps = [
     ":Weixin_VendoredLibraries"
   ] + [
-    "Weixin_includes"
+    ":Weixin_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -87,7 +87,7 @@ objc_library(
   deps = [
 
   ] + [
-    "ZipArchive_includes"
+    ":ZipArchive_includes"
   ],
   copts = [
     "-Dunix"

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -65,7 +65,7 @@ objc_library(
   deps = [
 
   ] + [
-    "boost-for-react-native_includes"
+    ":boost-for-react-native_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -98,7 +98,7 @@ objc_library(
   deps = [
 
   ] + [
-    "glog_includes"
+    ":glog_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -63,7 +63,7 @@ objc_library(
     ":Messages",
     ":Services"
   ] + [
-    "googleapis_includes"
+    ":googleapis_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
@@ -145,7 +145,7 @@ objc_library(
   deps = [
     "//Vendor/Protobuf:Protobuf"
   ] + [
-    "Messages_includes"
+    ":Messages_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
@@ -225,7 +225,7 @@ objc_library(
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
     ":Messages"
   ] + [
-    "Services_includes"
+    ":Services_includes"
   ],
   copts = [
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -67,7 +67,7 @@ objc_library(
   deps = [
     ":SwiftSupport"
   ] + [
-    "iOSSnapshotTestCase_includes"
+    ":iOSSnapshotTestCase_includes"
   ],
   copts = [
 
@@ -157,7 +157,7 @@ objc_library(
   deps = [
 
   ] + [
-    "Core_includes"
+    ":Core_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -69,7 +69,7 @@ objc_library(
   deps = [
     ":iRate_Bundle_iRate"
   ] + [
-    "iRate_includes"
+    ":iRate_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -73,7 +73,7 @@ objc_library(
   deps = [
 
   ] + [
-    "kingpin_includes"
+    ":kingpin_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -71,7 +71,7 @@ objc_library(
   deps = [
 
   ] + [
-    "pop_cxx_includes"
+    ":pop_cxx_includes"
   ],
   copts = [
     "-std=c++11",
@@ -159,7 +159,7 @@ objc_library(
   deps = [
     ":pop_cxx"
   ] + [
-    "pop_includes"
+    ":pop_includes"
   ],
   copts = [
 

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -145,7 +145,7 @@ objc_library(
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets"
   ] + [
-    "youtube-ios-player-helper_cxx_includes"
+    ":youtube-ios-player-helper_cxx_includes"
   ],
   copts = [
 
@@ -325,7 +325,7 @@ objc_library(
     ":youtube-ios-player-helper_cxx",
     ":youtube-ios-player-helper_swift"
   ] + [
-    "youtube-ios-player-helper_includes"
+    ":youtube-ios-player-helper_includes"
   ],
   copts = [
 

--- a/MakeGoldMaster.sh
+++ b/MakeGoldMaster.sh
@@ -6,8 +6,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 cd $SCRIPTPATH
 
 mkdir -p IntegrationTests/GoldMaster
-
-for f in $(find Examples/*); do
+for f in $(find Examples/PodSpecs/*); do
     echo "Writing goldmaster for $f"
     bin/Compiler $f --always_split_rules \
         > IntegrationTests/GoldMaster/$(basename $f).goldmaster

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -630,7 +630,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
             allDeps = lib.deps.sorted(by: (<)).toSkylark() 
         }
         if lib.includes.count > 0 {
-            allDeps = allDeps .+. [(name + "_includes")].toSkylark()
+            allDeps = allDeps .+. [":\(name)_includes"].toSkylark()
         }
 
         if allDeps.isEmpty == false { 


### PR DESCRIPTION
Currently this is missing a `:` when its passed in the list of `deps` for `ObjcLibrary`. I'm not sure how or if this worked before