### PR TITLE
Build for release before archiving for Github Releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ github_release:
 	@git checkout master
 	@git pull --rebase origin master
 	@echo "creating release: $(TESTED_BAZEL_VERSION)-($(shell git rev-parse --short HEAD)"
+	$(MAKE) release
 	$(MAKE) archive
 	@hub release create -p -a PodToBUILD.zip \
    		-m "PodToBUILD  $(TESTED_BAZEL_VERSION)-$(shell git rev-parse --short HEAD)" \


### PR DESCRIPTION
- Without this we could create a broken release if the binaries are not
already created or if the binaries are from an older commit.