### PR TITLE
Suppress stderr when untarring

### DIFF
--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -500,7 +500,7 @@ public enum RepoActions {
         return "mkdir -p " + rootDir + " && " +
             "cd " + rootDir + " && " +
             "mkdir -p OUT && " +
-            "tar -xzvf " + fileName + " -C OUT > /dev/null && " +
+            "tar -xzvf " + fileName + " -C OUT > /dev/null 2>&1 && " +
             "rm -rf " + fileName
     }
 }


### PR DESCRIPTION
At least on macOS 10.14.4, this `tar` invocation prints each of the files it is unpacking to stderr. It seems that nothing is actually reading the stderr pipe from this subprocess, and it therefore deadlocks and never finishes when untarring a repo with many files. This can be reproduced with the latest stable PodToBUILD and both Bazel 0.24.1 and 0.25.2 via the following WORKSPACE file (and, say, running `bazel query @React//...`):

```bzl
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "rules_pods",
    urls = ["https://github.com/pinterest/PodToBUILD/releases/download/0.22.0-ee8466e/PodToBUILD.zip"],
)

load("@rules_pods//BazelExtensions:workspace.bzl", "new_pod_repository")

new_pod_repository(
    name = "React",
    url = "https://github.com/facebook/react-native/tarball/4105450c7e15d6b46f88e2dad8a92cb28c3e882b/react-native.tar.gz",
    strip_prefix = "facebook-react-native-4105450/",
)
```

This change updates the command to also redirect the `tar`'s stderr to `/dev/null`, thereby allowing PodToBUILD to untar repos with many files.