### PR TITLE
Update Apple/Swift/Bazel versions to allow building with Xcode 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ cache:
     - $HOME/.bazelenv
     - $HOME/Library/Caches/Bazel
     - $HOME/.bazel_pod_store
-osx_image: xcode10
+osx_image: xcode10.2
 script: make ci

--- a/Examples/BasiciOS/WORKSPACE
+++ b/Examples/BasiciOS/WORKSPACE
@@ -16,7 +16,7 @@ git_repository(
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.6.0",
+    tag = "0.16.1",
 )
 
 load(
@@ -26,18 +26,19 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
 
 load("@rules_pods//BazelExtensions:workspace.bzl", "new_pod_repository")
 

--- a/Examples/Example.Makefile
+++ b/Examples/Example.Makefile
@@ -6,12 +6,12 @@ BAZEL_WRAPPER=$(RULES_PODS_DIR)/tools/bazelwrapper
 
 # Workaround for symlink weirdness.
 # Currently `bazelwrapper` relies on pwd, which causes issues here
-BAZEL=~/.bazelenv/versions/0.18.0/bin/bazel
+BAZEL=~/.bazelenv/versions/0.25.2/bin/bazel
 
 # Override the repository to point at the source. It does a source build of the
 # current code.
 BAZEL_OPTS=--override_repository=rules_pods=$(RULES_PODS_DIR) \
-		--disk_cache=$(HOME)/Library/Caches/Bazel
+		--disk_cache=$(HOME)/Library/Caches/Bazel  --apple_platform_type=ios
 
 all: fetch build
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ compile_commands.json:
 
 
 
-TESTED_BAZEL_VERSION=0.18.0
+TESTED_BAZEL_VERSION=0.25.2
 
 # Make a binary archive of PodToBUILD with the official github cli `hub`
 github_release:

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
         "state": {
           "branch": null,
-          "revision": "e5871587ddf85c0bcf84f773925655f2f83ef336",
-          "version": "0.0.7"
+          "revision": "bd9cb30ceee1f21c02f51a7168f58471449807d8",
+          "version": "0.1.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/typelift/SwiftCheck.git",
         "state": {
           "branch": null,
-          "revision": "43ffe7ab48366c36a697c54bcdd257876edd6fc6",
-          "version": "0.10.0"
+          "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",
+          "version": "0.12.0"
         }
       }
     ]

--- a/Tests/BuildTests/BuildTest.swift
+++ b/Tests/BuildTests/BuildTest.swift
@@ -32,7 +32,12 @@ class BuildTests: XCTestCase {
             let fetchResult = fetchTask.launch()
             XCTAssertEqual(fetchResult.terminationStatus, 0)
             guard fetchResult.terminationStatus == 0 else {
-                fatalError("Can't setup test root")
+                fatalError(
+                        "Can't setup test root."
+                                + "\nCMD:\n\(fetchTask.debugDescription)"
+                                + "\nSTDOUT:\n\(fetchResult.standardOutputAsString)"
+                                + "\nSTDERR:\n\(fetchResult.standardErrorAsString)"
+                )
             }
             let bazelScript = "make -C \(rootDir)/Examples/\(example)"
             print("running bazel:", bazelScript)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.13.0",
+    tag = "0.16.1",
 )
 
 load(
@@ -13,15 +13,16 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.6.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.22.0"
-BAZEL_VERSION_SHA="adae5bbc3bf2b9b60d460d8ea2c65da1a6edd75b242439dfc49d001272548d13"
+BAZEL_VERSION="0.25.2"
+BAZEL_VERSION_SHA="10ff77f7cdf29385d80770b1608dc39aa247610ee6cae627684a979e086cca13"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"


### PR DESCRIPTION
The goal with this is to update the dependencies to include  This updates the `rules_apple` dependency to latest in order to pull in https://github.com/bazelbuild/rules_swift/commit/19db162c614af9c9db354e14d68965c8eb58e348 and allow compiling with Xcode 10.2. This also switches to using the version of `rules_swift` included by `rules_apple`, rather than manually specifying it.

Finally, this upgrades the version of Bazel being used to be compatible with the newer versions of `rules_apple` and `rules_swift`.

This seems like it partially addresses https://github.com/pinterest/PodToBUILD/issues/74, but that also mentions other tasks like updating other projects and CI.