### PR TITLE
Use fresh temporary directories

### DIFF
--- a/Sources/PodToBUILD/ShellContext.swift
+++ b/Sources/PodToBUILD/ShellContext.swift
@@ -271,11 +271,14 @@ public struct SystemShellContext : ShellContext {
     
     public func tmpdir() -> String {
         log("CREATE TMPDIR")
-        let result = NSTemporaryDirectory() as String
-        guard !result.isEmpty else {
+        // Taken from https://stackoverflow.com/a/46701313/3000133
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        } catch {
             fatalError("Can't create temp dir")
         }
-        return result
+        return url.path
     }
 
     // MARK: - Private

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -167,7 +167,7 @@ def _load_repo_if_needed(repository_ctx, repo_tool_bin_path):
     if not url:
         # We allow putting source code in the Vendor/PodName and then initing
         # the repo with that code.
-	return
+        return
 
     # Note: the pod is not cleaned out if the sourcecode is loaded from the
     # current directory


### PR DESCRIPTION
The current implementation of `tmpdir` just returns the root of the
user's global temp dir (as returned by `NSTemporaryDirectory()`). This
changes that to create a unique subdirectory within it. This means that
each invocation of `tmpdir` will now return a new, empty directory.

This helps avoid issues with output from one repository affecting
another repository. In particular when unzipping an archive from GitHub
I was seeing issues where `unzip` was asking whether `.gitignore` should
be overwritten and immediately failing with an EOF. This should provide
better isolation between repositories.

While I'm here, this also changes a rouge tab to spaces in a Python file.