### PR TITLE
Allow better support and control of archive extraction

### DIFF
--- a/BazelExtensions/workspace.bzl
+++ b/BazelExtensions/workspace.bzl
@@ -41,7 +41,9 @@ def _fetch_remote_repo(repository_ctx, repo_tool_bin, target_name, url):
         "--sub_dir",
         repository_ctx.attr.strip_prefix,
         "--trace",
-        "true" if repository_ctx.attr.trace else "false"
+        "true" if repository_ctx.attr.trace else "false",
+        "--handler",
+        repository_ctx.attr.extraction_handler
     ]
 
     fetch_output = _exec(repository_ctx, fetch_cmd)
@@ -180,6 +182,8 @@ pod_repo_ = repository_rule(
         "enable_modules": attr.bool(default=True, mandatory=True),
         "generate_module_map": attr.bool(default=True, mandatory=True),
         "header_visibility": attr.string(),
+        "extraction_handler": attr.string(values=["zip", "tar", "default"],
+                                          default="default"),
     }
 )
 
@@ -198,6 +202,7 @@ def new_pod_repository(name,
                        enable_modules=True,
                        generate_module_map=None,
                        header_visibility="pod_support",
+                       extraction_handler="default",
                        ):
     """Declare a repository for a Pod
     Args:
@@ -258,6 +263,10 @@ def new_pod_repository(name,
 
          header_visibility: DEPRECATED: This is replaced by headermaps:
          https://github.com/bazelbuild/bazel/pull/3712
+
+         extraction_handler: override for how the target file from `url` is
+         extracted as, can be either `tar` or `zip`.  The default is `default`
+         which will try and infer from the file extension of the target file.
     """
     if generate_module_map == None:
         generate_module_map = enable_modules
@@ -279,5 +288,6 @@ def new_pod_repository(name,
         trace=trace,
         enable_modules=enable_modules,
         generate_module_map=generate_module_map,
-        header_visibility=header_visibility
+        header_visibility=header_visibility,
+        extraction_handler=extraction_handler
     )

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ there is no need to add an entry for them.
 
 `header_visibility`: DEPRECATED: This is replaced by headermaps: https://github.com/Bazelbuild/Bazel/pull/3712
 
+`extraction_handler`: explicitly define what filetype to treat the remote 
+target as.  Supports `tar` and `zip`.  If unset, will try and infer from the
+file extension.
+
 ### Known Complications
 
 ### Incompatible file paths

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -401,7 +401,7 @@ public enum RepoActions {
         // Extract the downloaded archive
         let extractDir = shell.tmpdir()
         func extract() -> CommandOutput {
-            var extractionHandler = fetchOptions.extractionHandler.isEmpty ? "default" : fetchOpts.extractionHandler;
+            var extractionHandler = fetchOptions.extractionHandler.isEmpty ? "default" : fetchOptions.extractionHandler;
             if extractionHandler == "default" {
                 let lowercasedFileName = fileName.lowercased()
                 if lowercasedFileName.hasSuffix("zip") {

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -433,7 +433,8 @@ public enum RepoActions {
                     ),
                 ])
             } else {
-                fatalError("The extraction handler value is invalid: \(extractionHandler ?? 'default')")
+                let handler = extractionHandler ?? "default"
+                fatalError("The extraction handler value is invalid: \(handler)")
             }
         }
 

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -433,7 +433,7 @@ public enum RepoActions {
                     ),
                 ])
             } else {
-                fatalError("The extraction handler value is invalid: \(extractionHandler)")
+                fatalError("The extraction handler value is invalid: \(extractionHandler ?? 'default')")
             }
         }
 

--- a/Tests/PodToBUILDTests/PodStoreTests.swift
+++ b/Tests/PodToBUILDTests/PodStoreTests.swift
@@ -15,22 +15,23 @@ let testPodName = "Foo"
 let fetchOpts = FetchOptions(podName: testPodName,
                     url: "http://pinner.com/foo.zip",
                     trace: false,
-                    subDir: nil)
+                    subDir: nil,
+                    extractionHandler: "default")
 
 class PodStoreTests: XCTestCase {
 
     var downloads: String {
         return "%TMP%"
     }
-    
+
     var extractDir: String {
         return "%TMP%"
     }
-    
+
 	var downloadPath: String {
         return downloads + "/" + testPodName + "-" + "foo.zip"
-    }   
-        
+    }
+
     var hasDir: ShellInvocation {
         return MakeShellInvocation("/bin/[", arguments: ["-e", cacheRoot(forPod:
                 testPodName, url: "http://pinner.com/foo.zip"), "]"], exitCode: 1)
@@ -51,13 +52,13 @@ class PodStoreTests: XCTestCase {
             )
         )
     }
-    
+
     func testZipExtraction() {
         let hasDir =  MakeShellInvocation("/bin/[", arguments: ["-e",
                 cacheRoot(forPod: testPodName, url: "http://pinner.com/foo.zip"),
                 "]"], exitCode: 1)
 
-        
+
         let extract = MakeShellInvocation("/bin/sh",
                                           arguments: ["-c", RepoActions.unzipTransaction(
                                             rootDir: escape(extractDir),
@@ -81,7 +82,7 @@ class PodStoreTests: XCTestCase {
         let shell = LogicalShellContext(commandInvocations: [
             hasDir,
             ])
-        
+
         RepoActions.fetch(shell: shell, fetchOptions: fetchOpts)
         XCTAssertFalse(shell.executed(encodedCommand:
                 LogicalShellContext.encodeDownload(url: URL(string: fetchOpts.url)!, toFile: downloadPath)

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -58,7 +58,8 @@ class RepositoryContext(object):
             enable_modules = True,
             generate_module_map = True,
             header_visibility = "pod_support",
-            src_root = None):
+            src_root = None,
+            extraction_handler = "default"):
         self.target_name = target_name
         self.url = url
         self.podspec_url = podspec_url
@@ -71,6 +72,7 @@ class RepositoryContext(object):
         self.generate_module_map = generate_module_map
         self.header_visibility = header_visibility
         self.src_root = src_root
+        self.extraction_handler = extraction_handler
 
     def GetPodRootDir(self):
         return self.src_root + "/Vendor/" + self.target_name
@@ -129,7 +131,9 @@ def _fetch_remote_repo(repository_ctx, repo_tool_bin, target_name, url):
         "--sub_dir",
         repository_ctx.strip_prefix,
         "--trace",
-        "true" if repository_ctx.GetTrace() else "false"
+        "true" if repository_ctx.GetTrace() else "false",
+        "--handler",
+        repository_ctx.extraction_handler,
     ]
 
     _exec(repository_ctx, fetch_cmd, repository_ctx.GetPodRootDir())
@@ -280,13 +284,14 @@ def new_pod_repository(name,
             podspec_url = None,
             strip_prefix = "",
             user_options = [],
-            install_script = None, 
+            install_script = None,
             inhibit_warnings = False,
             trace = False,
             enable_modules = True,
             generate_module_map = True,
             owner = "", # This is a Noop
-            header_visibility = "pod_support"):
+            header_visibility = "pod_support"
+            extraction_handler = "default"):
     """Declare a repository for a Pod
     Args:
          name: the name of this repo
@@ -347,6 +352,10 @@ def new_pod_repository(name,
 
          header_visibility: DEPRECATED: This is replaced by headermaps:
          https://github.com/bazelbuild/bazel/pull/3712
+
+         extraction_handler: override for what archive type to treat the file as
+         when extracting it, supports `tar` and `zip`.  The default is `default`
+         which will try and infer from the file extension of the target file.
     """
 
     # The SRC_ROOT is the directory of the WORKSPACE and Pods.WORKSPACE
@@ -367,7 +376,8 @@ def new_pod_repository(name,
             enable_modules = enable_modules,
             generate_module_map = generate_module_map,
             header_visibility = header_visibility,
-            src_root = SRC_ROOT)
+            src_root = SRC_ROOT,
+            extraction_handler = extraction_handler)
     _update_repo_impl(repository_ctx)
 
 def _cleanupPods():

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -290,7 +290,7 @@ def new_pod_repository(name,
             enable_modules = True,
             generate_module_map = True,
             owner = "", # This is a Noop
-            header_visibility = "pod_support"
+            header_visibility = "pod_support",
             extraction_handler = "default"):
     """Declare a repository for a Pod
     Args:


### PR DESCRIPTION
This expands the logic around archive extraction to provide larger explicit filetype support and provides an override parameter to be able to explicitly define the filetype to use and bypass the inference logic.

Changes:
- Add addition suffix checks for `.tar` and `.tgz` alongside the existing `.tar.gz` check
- Add an optional parameter to the bazel rule for explicit definition, it is `extraction_handler` and only accepts `zip`, `tar`, and `default` (it defaults to `default` which maintains the pre-existing behavior)
- Passes this new parameter into the `RepoTool` call as the `-handler` flag for the `fetch` action
- This parameter is then checked and used to decide the extraction command to use, if it is `default` it will fallback to using the suffix based inference to determine the command.