### PR TITLE
Add a podspec_file attribute

### DIFF
--- a/BazelExtensions/workspace.bzl
+++ b/BazelExtensions/workspace.bzl
@@ -148,16 +148,20 @@ def _impl(repository_ctx):
     # Build up the script
     script = ""
 
-    # For now, we curl the podspec url before the script runs
     if repository_ctx.attr.podspec_url:
+        # For now, we curl the podspec url before the script runs
         if repository_ctx.attr.podspec_file:
             fail("Cannot specify both podspec_url and podspec_file")
         script += "curl -O " + repository_ctx.attr.podspec_url
         script += "\n"
     elif repository_ctx.attr.podspec_file:
+        # Note that we can't re-use the podspec_url attribute for this since
+        # that would require being able to determine the root of the main
+        # workspace (to resolve relative paths) which isn't possible in this context.
         if repository_ctx.attr.podspec_url:
             fail("Cannot specify both podspec_url and podspec_file")
-        script += "cp " + str(repository_ctx.path(repository_ctx.attr.podspec_file)) + " .\n"
+        script += "ditto " + str(repository_ctx.path(repository_ctx.attr.podspec_file)) + " ."
+        script += "\n"
 
     if repository_ctx.attr.install_script_tpl:
         for sub in substitutions:

--- a/BazelExtensions/workspace.bzl
+++ b/BazelExtensions/workspace.bzl
@@ -198,7 +198,6 @@ def new_pod_repository(name,
                        url,
                        owner="",
                        podspec_url=None,
-                       podspec_file=None,
                        strip_prefix="",
                        user_options=[],
                        install_script=None,
@@ -217,13 +216,12 @@ def new_pod_repository(name,
 
          url: the url of this repo
 
-         podspec_url: the podspec url. By default, we will look in the root of
-         the repository, and read a .podspec file. This requires having
-         CocoaPods installed on build nodes. If a JSON podspec is provided here,
-         then it is not required to run CocoaPods.
+         podspec_url: an override podspec file. Can be either a URL or a Bazel
+         label.
 
-         podspec_file: like podspec_url, but specifies a podspec in the project,
-         rather than downloading one from a URL.
+         By default, we will look in the root of the repository, and read a .podspec file.
+         This requires having CocoaPods installed on build nodes. If a JSON podspec is
+         provided here, then it is not required to run CocoaPods.
 
          owner: the owner of this dependency
 
@@ -276,6 +274,11 @@ def new_pod_repository(name,
     """
     if generate_module_map == None:
         generate_module_map = enable_modules
+
+    podspec_file = None
+    if podspec_url and not podspec_url.startswith("http"):
+         podspec_file = podspec_url
+         podspec_url = None
 
     tool_labels = []
     for tool in repo_tools:

--- a/README.md
+++ b/README.md
@@ -199,10 +199,13 @@ acknowledgments_plist(
 
 `url`: the url of this repo
 
-`podspec_url`: the podspec url. By default, we will look in the root of the
-repository, and read a .podspec file. This requires having CocoaPods installed
-on build nodes. If a JSON podspec is provided here, then it is not required to
-run CocoaPods.
+`podspec_url`: an override podspec file. Can be either a URL or a Bazel
+label (when used as a workspace rule) or a relative or absolute path to
+a file (when used in vendored mode).
+
+By default, we will look in the root of the repository, and read a .podspec file.
+This requires having CocoaPods installed on build nodes. If a JSON podspec is
+provided here, then it is not required to run CocoaPods.
 
 `strip_prefix`: a directory prefix to strip from the extracted files. Many
 archives contain a top-level directory that contains all of the useful files in


### PR DESCRIPTION
This allows a podspec to be checked into the repo, rather than only
allowing an external URL as a podspec.