### PR TITLE
Make pod_support headers more deterministic

### DIFF
--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -330,7 +330,8 @@ public enum RepoActions {
         // creating thousands of processes in few milliseconds will
         // blow up otherwise.
         let currentDirectoryPath = FileManager.default.currentDirectoryPath
-        let globResults = Set(globResultsArr)
+        // Get a de-duplicated, sorted (for determinism) list of all headers
+        let globResults = Array(Set(globResultsArr)).sorted()
         customHeaderSearchPaths.forEach { searchPath in
             let linkPath = currentDirectoryPath + "/" + searchPath
             guard FileManager.default.changeCurrentDirectoryPath(linkPath) else {


### PR DESCRIPTION
When we populate the `pod_support` directories, we put all the headers (or rather symlinks to them) in the same directory together. This means that if there are multiple headers that share a basename, only one can end up in a given directory. Previously which one was determined by the result of glob and set iteration ordering, both of which are non-deterministic (differ per run and/or machine). This sorts those headers before symlinking to guarantee that the same symlinks end up "winning out" and being used on all machines. This allows remote cache sharing/hits between machines.