### PR TITLE
Treat download links as non-file URLs

### DIFF
--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -400,7 +400,7 @@ public enum RepoActions {
         }
 
         let downloadsDir = shell.tmpdir()
-        let url = NSURL(fileURLWithPath: urlString)
+        let url = NSURL(string: urlString)!
         let fileName = url.lastPathComponent!
         let download = downloadsDir + "/" + podName + "-" + fileName
         guard let wwwUrl = NSURL(string: urlString).map({ $0 as URL }),
@@ -433,7 +433,7 @@ public enum RepoActions {
                     ),
                 ])
             }
-            fatalError("Cannot extract files other than .zip, .tar, .tar.gz, or .tgz")
+            fatalError("Cannot extract files other than .zip, .tar, .tar.gz, or .tgz. Got \(lowercasedFileName)")
         }
 
         assertCommandOutput(extract(), message: "Extraction of \(podName) failed")


### PR DESCRIPTION
This allows the file-type determination to correctly ignore the fragment (part after the `#`) in the URL, plus it's more correct, since the URL *isn't* a file path.