### PR TITLE
Improved skylark compiler output

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,19 +14,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "Adjust_hdrs",
   srcs = glob(
@@ -34,21 +34,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Core_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Adjust_includes",
   include = [
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Adjust",
   "Adjust_module_map",
@@ -56,7 +54,7 @@ gen_module_map(
   [
     "Adjust_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Adjust",
   enable_modules = 0,
@@ -65,10 +63,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Adjust",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -82,15 +78,12 @@ objc_library(
         "AdSupport"
       ]
     }
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Adjust_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -100,7 +93,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
   ] + [
     "-fmodule-name=Adjust_pod_module"
@@ -108,14 +101,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Adjust_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -124,11 +115,11 @@ filegroup(
       "Adjust/ADJAdditions/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -138,13 +129,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -159,7 +150,7 @@ objc_library(
       "plugin/Trademob/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -168,7 +159,7 @@ objc_library(
     [
       "Adjust/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -182,15 +173,11 @@ objc_library(
         "AdSupport"
       ]
     }
-    ),
+  ),
   deps = [
-
-  ] + [
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -200,7 +187,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
   ] + [
     "-fmodule-name=Adjust_pod_module"
@@ -208,14 +195,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
@@ -223,11 +208,11 @@ filegroup(
       "plugin/Sociomantic/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Sociomantic_union_hdrs",
   srcs = [
@@ -237,13 +222,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Sociomantic_includes",
   include = [
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Sociomantic",
   enable_modules = 0,
@@ -252,7 +237,7 @@ objc_library(
       "plugin/Sociomantic/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Sociomantic_union_hdrs"
   ],
@@ -261,7 +246,7 @@ objc_library(
     [
       "plugin/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -275,15 +260,12 @@ objc_library(
         "AdSupport"
       ]
     }
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Sociomantic_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -293,7 +275,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
   ] + [
     "-fmodule-name=Adjust_pod_module"
@@ -301,14 +283,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Sociomantic_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
@@ -316,11 +296,11 @@ filegroup(
       "plugin/Criteo/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Criteo_union_hdrs",
   srcs = [
@@ -330,13 +310,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Criteo_includes",
   include = [
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Criteo",
   enable_modules = 0,
@@ -345,7 +325,7 @@ objc_library(
       "plugin/Criteo/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Criteo_union_hdrs"
   ],
@@ -354,7 +334,7 @@ objc_library(
     [
       "plugin/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -368,15 +348,12 @@ objc_library(
         "AdSupport"
       ]
     }
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Criteo_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -386,7 +363,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
   ] + [
     "-fmodule-name=Adjust_pod_module"
@@ -394,14 +371,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Criteo_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Trademob_hdrs",
   srcs = glob(
@@ -409,11 +384,11 @@ filegroup(
       "plugin/Trademob/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Trademob_union_hdrs",
   srcs = [
@@ -423,13 +398,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Trademob_includes",
   include = [
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Trademob",
   enable_modules = 0,
@@ -438,7 +413,7 @@ objc_library(
       "plugin/Trademob/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Trademob_union_hdrs"
   ],
@@ -447,7 +422,7 @@ objc_library(
     [
       "plugin/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -461,15 +436,12 @@ objc_library(
         "AdSupport"
       ]
     }
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Trademob_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -479,7 +451,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
   ] + [
     "-fmodule-name=Adjust_pod_module"
@@ -487,11 +459,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Trademob_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,31 +14,31 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "osxCase",
   values = {
     "cpu": "powerpc2"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 config_setting(
   name = "watchosCase",
   values = {
     "cpu": "powerpc4"
   }
-  )
+)
 filegroup(
   name = "Bolts_hdrs",
   srcs = glob(
@@ -46,22 +46,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Tasks_hdrs",
     ":AppLinks_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Bolts_includes",
   include = [
     "Vendor/Bolts/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Bolts",
   "Bolts_module_map",
@@ -69,7 +67,7 @@ gen_module_map(
   [
     "Bolts_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Bolts",
   enable_modules = 0,
@@ -78,19 +76,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Bolts",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     ":AppLinks",
-    ":Tasks"
-  ] + [
+    ":Tasks",
     ":Bolts_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -100,7 +93,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
   ] + [
     "-fmodule-name=Bolts_pod_module"
@@ -108,14 +101,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Bolts_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Tasks_hdrs",
   srcs = select(
@@ -125,31 +116,31 @@ filegroup(
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":watchosCase": glob(
         [
           "Bolts/Common/*.h"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Tasks_union_hdrs",
   srcs = [
@@ -159,13 +150,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Tasks_includes",
   include = [
     "Vendor/Bolts/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Tasks",
   enable_modules = 0,
@@ -179,27 +170,27 @@ objc_library(
           "Bolts/iOS/**/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Bolts/Common/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Bolts/Common/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":watchosCase": glob(
         [
           "Bolts/Common/*.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Tasks_union_hdrs"
   ],
@@ -208,15 +199,11 @@ objc_library(
     [
       "Bolts/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":Tasks_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -226,7 +213,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
   ] + [
     "-fmodule-name=Bolts_pod_module"
@@ -234,14 +221,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Tasks_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "AppLinks_hdrs",
   srcs = select(
@@ -251,13 +236,13 @@ filegroup(
           "Bolts/iOS/**/*.h"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "AppLinks_union_hdrs",
   srcs = [
@@ -267,13 +252,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "AppLinks_includes",
   include = [
     "Vendor/Bolts/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "AppLinks",
   enable_modules = 0,
@@ -284,9 +269,9 @@ objc_library(
           "Bolts/iOS/**/*.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":AppLinks_union_hdrs"
   ],
@@ -295,15 +280,12 @@ objc_library(
     [
       "Bolts/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Tasks"
-  ] + [
+    ":Tasks",
     ":AppLinks_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -313,7 +295,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
   ] + [
     "-fmodule-name=Bolts_pod_module"
@@ -321,11 +303,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "AppLinks_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Braintree_hdrs",
   srcs = glob(
@@ -23,9 +23,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Core_hdrs",
     ":Card_hdrs",
     ":PayPal_hdrs",
@@ -34,13 +32,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Braintree_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Braintree",
   "Braintree_module_map",
@@ -48,7 +46,7 @@ gen_module_map(
   [
     "Braintree_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Braintree",
   enable_modules = 0,
@@ -57,16 +55,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Braintree",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     ":Card",
     ":Core",
     ":PayPal",
-    ":UI"
-  ] + [
+    ":UI",
     ":Braintree_includes"
   ],
   copts = [
@@ -81,7 +76,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -89,14 +84,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Braintree_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -104,11 +97,11 @@ filegroup(
       "BraintreeCore/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -118,13 +111,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -145,7 +138,7 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -154,7 +147,7 @@ objc_library(
     [
       "BraintreeCore/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "AddressBook"
   ],
@@ -162,8 +155,6 @@ objc_library(
     "Contacts"
   ],
   deps = [
-
-  ] + [
     ":Core_includes"
   ],
   copts = [
@@ -178,7 +169,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -186,14 +177,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Apple-Pay_hdrs",
   srcs = glob(
@@ -201,11 +190,11 @@ filegroup(
       "BraintreeApplePay/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Apple-Pay_union_hdrs",
   srcs = [
@@ -215,13 +204,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Apple-Pay_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Apple-Pay",
   enable_modules = 0,
@@ -230,7 +219,7 @@ objc_library(
       "BraintreeApplePay/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Apple-Pay_union_hdrs"
   ],
@@ -239,13 +228,12 @@ objc_library(
     [
       "BraintreeApplePay/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "PassKit"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Apple-Pay_includes"
   ],
   copts = [
@@ -260,7 +248,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -268,14 +256,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Apple-Pay_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Card_hdrs",
   srcs = glob(
@@ -283,11 +269,11 @@ filegroup(
       "BraintreeCard/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Card_union_hdrs",
   srcs = [
@@ -297,13 +283,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Card_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Card",
   enable_modules = 0,
@@ -317,7 +303,7 @@ objc_library(
       "BraintreeUnionPay/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Card_union_hdrs"
   ],
@@ -326,10 +312,9 @@ objc_library(
     [
       "BraintreeCard/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Card_includes"
   ],
   copts = [
@@ -344,7 +329,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -352,14 +337,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Card_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "DataCollector_hdrs",
   srcs = glob(
@@ -367,11 +350,11 @@ filegroup(
       "BraintreeDataCollector/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "DataCollector_union_hdrs",
   srcs = [
@@ -381,13 +364,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "DataCollector_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "DataCollector",
   enable_modules = 0,
@@ -396,7 +379,7 @@ objc_library(
       "BraintreeDataCollector/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":DataCollector_union_hdrs"
   ],
@@ -405,11 +388,10 @@ objc_library(
     [
       "BraintreeDataCollector/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":DataCollector_VendoredLibraries"
-  ] + [
+    ":DataCollector_VendoredLibraries",
     ":DataCollector_includes"
   ],
   copts = [
@@ -424,7 +406,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -432,20 +414,18 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "DataCollector_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 objc_import(
   name = "DataCollector_VendoredLibraries",
   archives = [
     "BraintreeDataCollector/Kount/libDeviceCollectorLibrary.a"
   ]
-  )
+)
 filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
@@ -454,11 +434,11 @@ filegroup(
       "BraintreePayPal/Public/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PayPal_union_hdrs",
   srcs = [
@@ -468,13 +448,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PayPal_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PayPal",
   enable_modules = 0,
@@ -483,7 +463,7 @@ objc_library(
       "BraintreePayPal/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PayPal_union_hdrs"
   ],
@@ -492,11 +472,10 @@ objc_library(
     [
       "BraintreePayPal/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":PayPalOneTouch"
-  ] + [
+    ":PayPalOneTouch",
     ":PayPal_includes"
   ],
   copts = [
@@ -511,7 +490,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -519,14 +498,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PayPal_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Venmo_hdrs",
   srcs = glob(
@@ -534,11 +511,11 @@ filegroup(
       "BraintreeVenmo/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Venmo_union_hdrs",
   srcs = [
@@ -548,13 +525,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Venmo_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Venmo",
   enable_modules = 0,
@@ -563,7 +540,7 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Venmo_union_hdrs"
   ],
@@ -572,11 +549,10 @@ objc_library(
     [
       "BraintreeVenmo/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":PayPalDataCollector"
-  ] + [
+    ":PayPalDataCollector",
     ":Venmo_includes"
   ],
   copts = [
@@ -591,7 +567,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -599,14 +575,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Venmo_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_resource_bundle(
   name = "UI_Bundle_Braintree-Drop-In-Localization",
   resources = glob(
@@ -614,8 +588,8 @@ apple_resource_bundle(
       "BraintreeUI/Drop-In/Localization/*.lproj"
     ],
     exclude_directories = 1
-    )
   )
+)
 apple_resource_bundle(
   name = "UI_Bundle_Braintree-UI-Localization",
   resources = glob(
@@ -623,8 +597,8 @@ apple_resource_bundle(
       "BraintreeUI/Localization/*.lproj"
     ],
     exclude_directories = 1
-    )
   )
+)
 filegroup(
   name = "UI_hdrs",
   srcs = glob(
@@ -632,11 +606,11 @@ filegroup(
       "BraintreeUI/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "UI_union_hdrs",
   srcs = [
@@ -646,13 +620,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "UI_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "UI",
   enable_modules = 0,
@@ -661,7 +635,7 @@ objc_library(
       "BraintreeUI/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":UI_union_hdrs"
   ],
@@ -670,14 +644,13 @@ objc_library(
     [
       "BraintreeUI/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
-    ":Core"
-  ] + [
+    ":Core",
     ":UI_includes"
   ],
   copts = [
@@ -692,7 +665,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -704,14 +677,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "UI_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "UnionPay_hdrs",
   srcs = glob(
@@ -719,11 +690,11 @@ filegroup(
       "BraintreeUnionPay/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "UnionPay_union_hdrs",
   srcs = [
@@ -733,13 +704,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "UnionPay_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "UnionPay",
   enable_modules = 0,
@@ -748,7 +719,7 @@ objc_library(
       "BraintreeUnionPay/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":UnionPay_union_hdrs"
   ],
@@ -757,14 +728,13 @@ objc_library(
     [
       "BraintreeUnionPay/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
-    ":Core"
-  ] + [
+    ":Core",
     ":UnionPay_includes"
   ],
   copts = [
@@ -779,7 +749,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -787,14 +757,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "UnionPay_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_resource_bundle(
   name = "3D-Secure_Bundle_Braintree-3D-Secure-Localization",
   resources = glob(
@@ -802,8 +770,8 @@ apple_resource_bundle(
       "Braintree3DSecure/Localization/*.lproj"
     ],
     exclude_directories = 1
-    )
   )
+)
 filegroup(
   name = "3D-Secure_hdrs",
   srcs = glob(
@@ -811,11 +779,11 @@ filegroup(
       "Braintree3DSecure/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "3D-Secure_union_hdrs",
   srcs = [
@@ -825,13 +793,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "3D-Secure_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "3D-Secure",
   enable_modules = 0,
@@ -840,7 +808,7 @@ objc_library(
       "Braintree3DSecure/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":3D-Secure_union_hdrs"
   ],
@@ -849,14 +817,13 @@ objc_library(
     [
       "Braintree3DSecure/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
     ":Card",
-    ":Core"
-  ] + [
+    ":Core",
     ":3D-Secure_includes"
   ],
   copts = [
@@ -871,7 +838,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -882,14 +849,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "3D-Secure_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PayPalOneTouch_hdrs",
   srcs = glob(
@@ -897,11 +862,11 @@ filegroup(
       "BraintreePayPal/PayPalOneTouch/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PayPalOneTouch_union_hdrs",
   srcs = [
@@ -911,13 +876,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PayPalOneTouch_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PayPalOneTouch",
   enable_modules = 0,
@@ -929,7 +894,7 @@ objc_library(
       "BraintreePayPal/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PayPalOneTouch_union_hdrs"
   ],
@@ -938,7 +903,7 @@ objc_library(
     [
       "BraintreePayPal/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
@@ -948,8 +913,7 @@ objc_library(
   deps = [
     ":Core",
     ":PayPalDataCollector",
-    ":PayPalUtils"
-  ] + [
+    ":PayPalUtils",
     ":PayPalOneTouch_includes"
   ],
   copts = [
@@ -966,7 +930,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -974,14 +938,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PayPalOneTouch_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PayPalDataCollector_hdrs",
   srcs = glob(
@@ -989,11 +951,11 @@ filegroup(
       "BraintreePayPal/PayPalDataCollector/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PayPalDataCollector_union_hdrs",
   srcs = [
@@ -1003,13 +965,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PayPalDataCollector_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PayPalDataCollector",
   enable_modules = 0,
@@ -1023,7 +985,7 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PayPalDataCollector_union_hdrs"
   ],
@@ -1032,7 +994,7 @@ objc_library(
     [
       "BraintreePayPal/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",
@@ -1042,8 +1004,7 @@ objc_library(
   deps = [
     ":Core",
     ":PayPalDataCollector_VendoredLibraries",
-    ":PayPalUtils"
-  ] + [
+    ":PayPalUtils",
     ":PayPalDataCollector_includes"
   ],
   copts = [
@@ -1058,7 +1019,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -1066,20 +1027,18 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PayPalDataCollector_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 objc_import(
   name = "PayPalDataCollector_VendoredLibraries",
   archives = [
     "BraintreePayPal/PayPalDataCollector/Risk/libPPRiskComponent.a"
   ]
-  )
+)
 filegroup(
   name = "PayPalUtils_hdrs",
   srcs = glob(
@@ -1087,11 +1046,11 @@ filegroup(
       "BraintreePayPal/PayPalUtils/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PayPalUtils_union_hdrs",
   srcs = [
@@ -1101,13 +1060,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PayPalUtils_includes",
   include = [
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PayPalUtils",
   enable_modules = 0,
@@ -1122,7 +1081,7 @@ objc_library(
       "BraintreeVenmo/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PayPalUtils_union_hdrs"
   ],
@@ -1131,7 +1090,7 @@ objc_library(
     [
       "BraintreePayPal/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",
@@ -1139,8 +1098,6 @@ objc_library(
     "UIKit"
   ],
   deps = [
-
-  ] + [
     ":PayPalUtils_includes"
   ],
   copts = [
@@ -1155,7 +1112,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
   ] + [
     "-fmodule-name=Braintree_pod_module"
@@ -1163,11 +1120,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PayPalUtils_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Branch_hdrs",
   srcs = glob(
@@ -22,22 +22,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Core_hdrs",
     ":without-IDFA_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Branch_includes",
   include = [
     "Vendor/Branch/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Branch",
   "Branch_module_map",
@@ -45,7 +43,7 @@ gen_module_map(
   [
     "Branch_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Branch",
   enable_modules = 0,
@@ -54,19 +52,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Branch",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     ":Core",
-    ":without-IDFA"
-  ] + [
+    ":without-IDFA",
     ":Branch_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -76,7 +69,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
   ] + [
     "-fmodule-name=Branch_pod_module"
@@ -84,14 +77,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Branch_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -101,11 +92,11 @@ filegroup(
       "Branch-SDK/Fabric/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -115,13 +106,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/Branch/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -131,7 +122,7 @@ objc_library(
       "Branch-SDK/Branch-SDK/Requests/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -140,20 +131,16 @@ objc_library(
     [
       "Branch-SDK/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "AdSupport",
     "CoreTelephony",
     "MobileCoreServices"
   ],
   deps = [
-
-  ] + [
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -163,7 +150,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
   ] + [
     "-fmodule-name=Branch_pod_module"
@@ -171,14 +158,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "without-IDFA_hdrs",
   srcs = glob(
@@ -188,11 +173,11 @@ filegroup(
       "Branch-SDK/Fabric/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "without-IDFA_union_hdrs",
   srcs = [
@@ -202,13 +187,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "without-IDFA_includes",
   include = [
     "Vendor/Branch/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "without-IDFA",
   enable_modules = 0,
@@ -218,7 +203,7 @@ objc_library(
       "Branch-SDK/Branch-SDK/Requests/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":without-IDFA_union_hdrs"
   ],
@@ -227,19 +212,15 @@ objc_library(
     [
       "Branch-SDK/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "CoreTelephony",
     "MobileCoreServices"
   ],
   deps = [
-
-  ] + [
     ":without-IDFA_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -249,7 +230,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
   ] + [
     "-fmodule-name=Branch_pod_module"
@@ -257,11 +238,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "without-IDFA_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,13 +15,13 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
@@ -31,11 +31,11 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Calabash_cxx_union_hdrs",
   srcs = [
@@ -45,13 +45,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Calabash_cxx_includes",
   include = [
     "Vendor/Calabash/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Calabash_cxx",
   enable_modules = 0,
@@ -68,7 +68,7 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   non_arc_srcs = glob(
     [
       "calabash.framework/Versions/A/Headers/*.mm"
@@ -77,7 +77,7 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Calabash_cxx_union_hdrs"
   ],
@@ -86,17 +86,15 @@ objc_library(
     [
       "calabash.framework/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
         "CFNetwork"
       ]
     }
-    ),
+  ),
   deps = [
-
-  ] + [
     ":Calabash_cxx_includes"
   ],
   copts = [
@@ -113,7 +111,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Calabash/pod_support/Headers/Public/Calabash/"
   ] + [
     "-fmodule-name=Calabash_pod_module"
@@ -121,14 +119,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Calabash_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "Calabash_swift",
   srcs = glob(
@@ -136,14 +132,10 @@ swift_library(
       "calabash.framework/Versions/A/Headers/*.swift"
     ],
     exclude_directories = 1
-    ),
-  deps = [
-
-  ],
-  data = [
-
-  ]
-  )
+  ),
+  deps = [],
+  data = []
+)
 filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
@@ -151,26 +143,26 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":Calabash_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Calabash_includes",
   include = [
     "Vendor/Calabash/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Calabash",
   "Calabash_module_map",
@@ -178,7 +170,7 @@ gen_module_map(
   [
     "Calabash_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Calabash",
   enable_modules = 0,
@@ -189,13 +181,13 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   non_arc_srcs = glob(
     [
       "calabash.framework/Versions/A/Headers/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Calabash_hdrs"
   ],
@@ -204,18 +196,17 @@ objc_library(
     [
       "calabash.framework/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
         "CFNetwork"
       ]
     }
-    ),
+  ),
   deps = [
     ":Calabash_cxx",
-    ":Calabash_swift"
-  ] + [
+    ":Calabash_swift",
     ":Calabash_includes"
   ],
   copts = [
@@ -232,7 +223,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Calabash/pod_support/Headers/Public/Calabash/"
   ] + [
     "-fmodule-name=Calabash_pod_module"
@@ -240,11 +231,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Calabash_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "CardIO/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "CardIO_includes",
   include = [
     "Vendor/CardIO/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "CardIO",
   "CardIO_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "CardIO_hdrs"
   ]
-  )
+)
 objc_library(
   name = "CardIO",
   enable_modules = 0,
@@ -56,10 +54,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "CardIO",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Accelerate",
     "AVFoundation",
@@ -76,13 +72,10 @@ objc_library(
     "c++"
   ],
   deps = [
-    ":CardIO_VendoredLibraries"
-  ] + [
+    ":CardIO_VendoredLibraries",
     ":CardIO_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -92,7 +85,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/CardIO/pod_support/Headers/Public/CardIO/"
   ] + [
     "-fmodule-name=CardIO_pod_module"
@@ -100,14 +93,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "CardIO_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/CardIO/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 objc_import(
   name = "CardIO_VendoredLibraries",
   archives = [
@@ -115,4 +106,4 @@ objc_import(
     "CardIO/libopencv_core.a",
     "CardIO/libopencv_imgproc.a"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "ColorCube/ColorCube/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "ColorCube_includes",
   include = [
     "Vendor/ColorCube/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "ColorCube",
   "ColorCube_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "ColorCube_hdrs"
   ]
-  )
+)
 objc_library(
   name = "ColorCube",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "ColorCube/ColorCube/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":ColorCube_hdrs"
   ],
@@ -65,15 +63,11 @@ objc_library(
     [
       "ColorCube/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":ColorCube_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/ColorCube/pod_support/Headers/Public/ColorCube/"
   ] + [
     "-fmodule-name=ColorCube_pod_module"
@@ -91,11 +85,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "ColorCube_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/ColorCube/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,13 +15,13 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 filegroup(
   name = "EarlGrey_hdrs",
   srcs = glob(
@@ -29,21 +29,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "EarlGrey_includes",
   include = [
     "Vendor/EarlGrey/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "EarlGrey",
   "EarlGrey_module_map",
@@ -51,7 +47,7 @@ gen_module_map(
   [
     "EarlGrey_hdrs"
   ]
-  )
+)
 objc_library(
   name = "EarlGrey",
   enable_modules = 0,
@@ -60,10 +56,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "EarlGrey",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "CoreData",
     "CoreFoundation",
@@ -75,8 +69,7 @@ objc_library(
     "XCTest"
   ],
   deps = [
-    ":EarlGrey_VendoredFrameworks"
-  ] + [
+    ":EarlGrey_VendoredFrameworks",
     ":EarlGrey_includes"
   ],
   copts = [
@@ -91,7 +84,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/EarlGrey/pod_support/Headers/Public/EarlGrey/"
   ] + [
     "-fmodule-name=EarlGrey_pod_module"
@@ -99,14 +92,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "EarlGrey_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/EarlGrey/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "EarlGrey_VendoredFrameworks",
   framework_imports = select(
@@ -116,10 +107,10 @@ apple_static_framework_import(
           "EarlGrey/EarlGrey.framework/**"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,19 +15,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = glob(
@@ -35,7 +35,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + select(
+  ) + select(
     {
       "//conditions:default": glob(
         [
@@ -49,7 +49,7 @@ filegroup(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
@@ -84,21 +84,19 @@ filegroup(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FBSDKCoreKit_includes",
   include = [
     "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FBSDKCoreKit",
   "FBSDKCoreKit_module_map",
@@ -106,7 +104,7 @@ gen_module_map(
   [
     "FBSDKCoreKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
@@ -132,7 +130,7 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/*.m",
@@ -188,9 +186,9 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   non_arc_srcs = select(
     {
       "//conditions:default": glob(
@@ -208,7 +206,7 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -241,9 +239,9 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -252,7 +250,7 @@ objc_library(
     [
       "FBSDKCoreKit/**/*.pch"
     ]
-    ),
+  ),
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -276,7 +274,7 @@ objc_library(
         "AudioToolbox"
       ]
     }
-    ),
+  ),
   deps = [
     ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
   ] + select(
@@ -285,12 +283,10 @@ objc_library(
         "//Vendor/Bolts:Bolts"
       ]
     }
-    ) + [
+  ) + [
     ":FBSDKCoreKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -300,7 +296,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
   ] + [
     "-fmodule-name=FBSDKCoreKit_pod_module"
@@ -311,14 +307,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FBSDKCoreKit_acknowledgement",
   deps = [
     "//Vendor/Bolts:Bolts_acknowledgement"
   ],
   value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_bundle_import(
   name = "FBSDKCoreKit_Bundle_FacebookSDKStrings",
   bundle_imports = glob(
@@ -326,5 +322,5 @@ apple_bundle_import(
       "FacebookSDKStrings.bundle/**"
     ],
     exclude_directories = 1
-    )
   )
+)

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "FBSDKLoginKit_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FBSDKLoginKit_includes",
   include = [
     "Vendor/FBSDKLoginKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FBSDKLoginKit",
   "FBSDKLoginKit_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "FBSDKLoginKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FBSDKLoginKit",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "FBSDKLoginKit/FBSDKLoginKit/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FBSDKLoginKit_hdrs"
   ],
@@ -65,7 +63,7 @@ objc_library(
     [
       "FBSDKLoginKit/**/*.pch"
     ]
-    ),
+  ),
   weak_sdk_frameworks = [
     "Accounts",
     "CoreLocation",
@@ -78,8 +76,7 @@ objc_library(
     "AudioToolbox"
   ],
   deps = [
-    "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
-  ] + [
+    "//Vendor/FBSDKCoreKit:FBSDKCoreKit",
     ":FBSDKLoginKit_includes"
   ],
   copts = [
@@ -94,7 +91,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FBSDKLoginKit/pod_support/Headers/Public/FBSDKLoginKit/"
   ] + [
     "-fmodule-name=FBSDKLoginKit_pod_module"
@@ -102,11 +99,11 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FBSDKLoginKit_acknowledgement",
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit_acknowledgement"
   ],
   value = "//Vendor/FBSDKLoginKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "FBSDKMessengerShareKit_hdrs",
   srcs = glob(
@@ -22,7 +22,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "FBSDKMessengerShareKit/**/*.h",
       "FBSDKMessengerShareKit/**/*.hpp",
@@ -30,19 +30,17 @@ filegroup(
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FBSDKMessengerShareKit_includes",
   include = [
     "Vendor/FBSDKMessengerShareKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FBSDKMessengerShareKit",
   "FBSDKMessengerShareKit_module_map",
@@ -50,7 +48,7 @@ gen_module_map(
   [
     "FBSDKMessengerShareKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FBSDKMessengerShareKit",
   enable_modules = 0,
@@ -59,7 +57,7 @@ objc_library(
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"
   ],
@@ -68,15 +66,11 @@ objc_library(
     [
       "FBSDKMessengerShareKit/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":FBSDKMessengerShareKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -86,7 +80,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FBSDKMessengerShareKit/pod_support/Headers/Public/FBSDKMessengerShareKit/"
   ] + [
     "-fmodule-name=FBSDKMessengerShareKit_pod_module"
@@ -94,11 +88,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FBSDKMessengerShareKit_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FBSDKMessengerShareKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,19 +14,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "FBSDKShareKit_hdrs",
   srcs = glob(
@@ -34,7 +34,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + select(
+  ) + select(
     {
       "//conditions:default": glob(
         [
@@ -48,7 +48,7 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "FBSDKShareKit/**/*.h",
@@ -80,21 +80,19 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FBSDKShareKit_includes",
   include = [
     "Vendor/FBSDKShareKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FBSDKShareKit",
   "FBSDKShareKit_module_map",
@@ -102,7 +100,7 @@ gen_module_map(
   [
     "FBSDKShareKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FBSDKShareKit",
   enable_modules = 0,
@@ -117,7 +115,7 @@ objc_library(
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.m",
@@ -140,9 +138,9 @@ objc_library(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":FBSDKShareKit_hdrs"
   ],
@@ -151,7 +149,7 @@ objc_library(
     [
       "FBSDKShareKit/**/*.pch"
     ]
-    ),
+  ),
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -175,10 +173,9 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   deps = [
-    "//Vendor/FBSDKCoreKit:FBSDKCoreKit"
-  ] + [
+    "//Vendor/FBSDKCoreKit:FBSDKCoreKit",
     ":FBSDKShareKit_includes"
   ],
   copts = [
@@ -193,7 +190,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FBSDKShareKit/pod_support/Headers/Public/FBSDKShareKit/"
   ] + [
     "-fmodule-name=FBSDKShareKit_pod_module"
@@ -201,11 +198,11 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FBSDKShareKit_acknowledgement",
   deps = [
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit_acknowledgement"
   ],
   value = "//Vendor/FBSDKShareKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "FLAnimatedImage/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FLAnimatedImage_includes",
   include = [
     "Vendor/FLAnimatedImage/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FLAnimatedImage",
   "FLAnimatedImage_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "FLAnimatedImage_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FLAnimatedImage",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "FLAnimatedImage/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
   ],
@@ -65,7 +63,7 @@ objc_library(
     [
       "FLAnimatedImage/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "QuartzCore",
     "ImageIO",
@@ -73,13 +71,9 @@ objc_library(
     "CoreGraphics"
   ],
   deps = [
-
-  ] + [
     ":FLAnimatedImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -89,7 +83,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FLAnimatedImage/pod_support/Headers/Public/FLAnimatedImage/"
   ] + [
     "-fmodule-name=FLAnimatedImage_pod_module"
@@ -97,11 +91,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FLAnimatedImage_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FLAnimatedImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "FLEX_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Classes/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FLEX_includes",
   include = [
     "Vendor/FLEX/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FLEX",
   "FLEX_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "FLEX_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FLEX",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "Classes/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FLEX_hdrs"
   ],
@@ -65,7 +63,7 @@ objc_library(
     [
       "Classes/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation",
     "UIKit",
@@ -76,13 +74,9 @@ objc_library(
     "sqlite3"
   ],
   deps = [
-
-  ] + [
     ":FLEX_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -92,7 +86,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FLEX/pod_support/Headers/Public/FLEX/"
   ] + [
     "-fmodule-name=FLEX_pod_module"
@@ -100,11 +94,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FLEX_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FLEX/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "FMDB_hdrs",
   srcs = glob(
@@ -22,21 +22,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":standard_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FMDB_includes",
   include = [
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FMDB",
   "FMDB_module_map",
@@ -44,7 +42,7 @@ gen_module_map(
   [
     "FMDB_hdrs"
   ]
-  )
+)
 objc_library(
   name = "FMDB",
   enable_modules = 0,
@@ -53,18 +51,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "FMDB",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-    ":standard"
-  ] + [
+    ":standard",
     ":FMDB_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -74,7 +67,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
   ] + [
     "-fmodule-name=FMDB_pod_module"
@@ -82,14 +75,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FMDB_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "standard_hdrs",
   srcs = glob(
@@ -97,11 +88,11 @@ filegroup(
       "src/fmdb/FM*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "standard_union_hdrs",
   srcs = [
@@ -111,13 +102,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "standard_includes",
   include = [
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "standard",
   enable_modules = 0,
@@ -130,7 +121,7 @@ objc_library(
       "src/fmdb.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":standard_union_hdrs"
   ],
@@ -139,18 +130,14 @@ objc_library(
     [
       "src/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "sqlite3"
   ],
   deps = [
-
-  ] + [
     ":standard_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -160,7 +147,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
   ] + [
     "-fmodule-name=FMDB_pod_module"
@@ -168,14 +155,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "standard_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "FTS_hdrs",
   srcs = glob(
@@ -183,11 +168,11 @@ filegroup(
       "src/extra/fts3/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "FTS_union_hdrs",
   srcs = [
@@ -197,13 +182,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FTS_includes",
   include = [
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "FTS",
   enable_modules = 0,
@@ -212,7 +197,7 @@ objc_library(
       "src/extra/fts3/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FTS_union_hdrs"
   ],
@@ -221,15 +206,12 @@ objc_library(
     [
       "src/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":standard"
-  ] + [
+    ":standard",
     ":FTS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -239,7 +221,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
   ] + [
     "-fmodule-name=FMDB_pod_module"
@@ -247,23 +229,19 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FTS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "standalone_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "standalone_union_hdrs",
   srcs = [
@@ -273,13 +251,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "standalone_includes",
   include = [
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "standalone",
   enable_modules = 0,
@@ -288,13 +266,9 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "FMDB",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-
-  ] + [
     ":standalone_includes"
   ],
   copts = [
@@ -309,7 +283,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
   ] + [
     "-fmodule-name=FMDB_pod_module"
@@ -317,14 +291,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "standalone_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "SQLCipher_hdrs",
   srcs = glob(
@@ -332,11 +304,11 @@ filegroup(
       "src/fmdb/FM*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "SQLCipher_union_hdrs",
   srcs = [
@@ -346,13 +318,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "SQLCipher_includes",
   include = [
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "SQLCipher",
   enable_modules = 0,
@@ -364,7 +336,7 @@ objc_library(
       "src/fmdb.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":SQLCipher_union_hdrs"
   ],
@@ -373,10 +345,9 @@ objc_library(
     [
       "src/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    "//Vendor/SQLCipher:SQLCipher"
-  ] + [
+    "//Vendor/SQLCipher:SQLCipher",
     ":SQLCipher_includes"
   ],
   copts = [
@@ -392,7 +363,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
   ] + [
     "-fmodule-name=FMDB_pod_module"
@@ -400,11 +371,11 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "SQLCipher_acknowledgement",
   deps = [
     "//Vendor/SQLCipher:SQLCipher_acknowledgement"
   ],
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 swift_library(
   name = "FolioReaderKit",
   srcs = glob(
@@ -25,7 +25,7 @@ swift_library(
       "Vendor/**/*.swift"
     ],
     exclude_directories = 1
-    ),
+  ),
   deps = [
     "//Vendor/AEXML:AEXML",
     "//Vendor/FontBlaster:FontBlaster",
@@ -44,5 +44,5 @@ swift_library(
       "Source/Resources/Fonts/**/*.ttf"
     ],
     exclude_directories = 1
-    )
   )
+)

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Folly_hdrs",
   srcs = glob(
@@ -22,20 +22,18 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "folly/*.h",
       "folly/detail/*.h",
       "folly/portability/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Folly_includes",
   include = [
@@ -43,7 +41,7 @@ gen_includes(
     "Vendor/boost-for-react-native",
     "Vendor/DoubleConversion"
   ]
-  )
+)
 gen_module_map(
   "folly",
   "Folly_module_map",
@@ -51,7 +49,7 @@ gen_module_map(
   [
     "Folly_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Folly",
   enable_modules = 0,
@@ -68,7 +66,7 @@ objc_library(
       "folly/portability/BitsFunctexcept.cpp"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Folly_hdrs"
   ],
@@ -77,15 +75,14 @@ objc_library(
     [
       "folly/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "stdc++"
   ],
   deps = [
     "//Vendor/DoubleConversion:DoubleConversion",
     "//Vendor/boost-for-react-native:boost-for-react-native",
-    "//Vendor/glog:glog"
-  ] + [
+    "//Vendor/glog:glog",
     ":Folly_includes"
   ],
   copts = [
@@ -101,15 +98,13 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
-
-  ] + [
+  ) + [
     "-fmodule-name=folly_pod_module"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Folly_acknowledgement",
   deps = [
@@ -118,4 +113,4 @@ acknowledged_target(
     "//Vendor/glog:glog_acknowledgement"
   ],
   value = "//Vendor/Folly/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -6,7 +6,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -16,7 +16,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
@@ -24,26 +24,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Changelog/**/*.h",
       "Changelog/**/*.hpp",
       "Changelog/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleAppIndexing_includes",
   include = [
     "Vendor/GoogleAppIndexing/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleAppIndexing",
   "GoogleAppIndexing_module_map",
@@ -51,7 +49,7 @@ gen_module_map(
   [
     "GoogleAppIndexing_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleAppIndexing",
   enable_modules = 0,
@@ -60,23 +58,18 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleAppIndexing",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "CoreText",
     "SafariServices"
   ],
   deps = [
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
-    ":GoogleAppIndexing_VendoredFrameworks"
-  ] + [
+    ":GoogleAppIndexing_VendoredFrameworks",
     ":GoogleAppIndexing_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -86,7 +79,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleAppIndexing/pod_support/Headers/Public/GoogleAppIndexing/"
   ] + [
     "-fmodule-name=GoogleAppIndexing_pod_module"
@@ -97,14 +90,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleAppIndexing_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/GoogleAppIndexing/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_bundle_import(
   name = "GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
   bundle_imports = glob(
@@ -112,8 +103,8 @@ apple_bundle_import(
       "Resources/GoogleAppIndexingResources.bundle/**"
     ],
     exclude_directories = 1
-    )
   )
+)
 apple_static_framework_import(
   name = "GoogleAppIndexing_VendoredFrameworks",
   framework_imports = glob(
@@ -121,8 +112,8 @@ apple_static_framework_import(
       "Frameworks/GoogleAppIndexing.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleAppUtilities_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleAppUtilities_includes",
   include = [
     "Vendor/GoogleAppUtilities/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleAppUtilities",
   "GoogleAppUtilities_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "GoogleAppUtilities_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleAppUtilities",
   enable_modules = 0,
@@ -54,19 +50,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleAppUtilities",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
-    ":GoogleAppUtilities_VendoredFrameworks"
-  ] + [
+    ":GoogleAppUtilities_VendoredFrameworks",
     ":GoogleAppUtilities_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -76,7 +67,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleAppUtilities/pod_support/Headers/Public/GoogleAppUtilities/"
   ] + [
     "-fmodule-name=GoogleAppUtilities_pod_module"
@@ -84,14 +75,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleAppUtilities_acknowledgement",
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
   ],
   value = "//Vendor/GoogleAppUtilities/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "GoogleAppUtilities_VendoredFrameworks",
   framework_imports = glob(
@@ -99,8 +90,8 @@ apple_static_framework_import(
       "Frameworks/frameworks/GoogleAppUtilities.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleAuthUtilities_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleAuthUtilities_includes",
   include = [
     "Vendor/GoogleAuthUtilities/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleAuthUtilities",
   "GoogleAuthUtilities_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "GoogleAuthUtilities_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleAuthUtilities",
   enable_modules = 0,
@@ -54,10 +50,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleAuthUtilities",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Security",
     "SystemConfiguration"
@@ -65,13 +59,10 @@ objc_library(
   deps = [
     "//Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities",
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
-    ":GoogleAuthUtilities_VendoredFrameworks"
-  ] + [
+    ":GoogleAuthUtilities_VendoredFrameworks",
     ":GoogleAuthUtilities_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -81,7 +72,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleAuthUtilities/pod_support/Headers/Public/GoogleAuthUtilities/"
   ] + [
     "-fmodule-name=GoogleAuthUtilities_pod_module"
@@ -91,11 +82,11 @@ objc_library(
       "Frameworks/frameworks/GoogleAuthUtilities.framework/Resources/GTMOAuth2ViewTouch.xib"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleAuthUtilities_acknowledgement",
   deps = [
@@ -103,7 +94,7 @@ acknowledged_target(
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
   ],
   value = "//Vendor/GoogleAuthUtilities/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "GoogleAuthUtilities_VendoredFrameworks",
   framework_imports = glob(
@@ -111,8 +102,8 @@ apple_static_framework_import(
       "Frameworks/frameworks/GoogleAuthUtilities.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleNetworkingUtilities_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleNetworkingUtilities_includes",
   include = [
     "Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleNetworkingUtilities",
   "GoogleNetworkingUtilities_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "GoogleNetworkingUtilities_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleNetworkingUtilities",
   enable_modules = 0,
@@ -54,22 +50,17 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleNetworkingUtilities",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Security"
   ],
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
-    ":GoogleNetworkingUtilities_VendoredFrameworks"
-  ] + [
+    ":GoogleNetworkingUtilities_VendoredFrameworks",
     ":GoogleNetworkingUtilities_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -79,7 +70,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleNetworkingUtilities/pod_support/Headers/Public/GoogleNetworkingUtilities/"
   ] + [
     "-fmodule-name=GoogleNetworkingUtilities_pod_module"
@@ -87,14 +78,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleNetworkingUtilities_acknowledgement",
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
   ],
   value = "//Vendor/GoogleNetworkingUtilities/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "GoogleNetworkingUtilities_VendoredFrameworks",
   framework_imports = glob(
@@ -102,8 +93,8 @@ apple_static_framework_import(
       "Frameworks/frameworks/GoogleNetworkingUtilities.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -6,7 +6,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -16,7 +16,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleSignIn_hdrs",
   srcs = glob(
@@ -24,21 +24,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleSignIn_includes",
   include = [
     "Vendor/GoogleSignIn/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleSignIn",
   "GoogleSignIn_module_map",
@@ -46,7 +42,7 @@ gen_module_map(
   [
     "GoogleSignIn_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleSignIn",
   enable_modules = 0,
@@ -55,10 +51,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleSignIn",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "CoreText",
     "SafariServices",
@@ -70,13 +64,10 @@ objc_library(
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments",
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
     ":GoogleSignIn_Bundle_GoogleSignIn",
-    ":GoogleSignIn_VendoredFrameworks"
-  ] + [
+    ":GoogleSignIn_VendoredFrameworks",
     ":GoogleSignIn_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -86,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleSignIn/pod_support/Headers/Public/GoogleSignIn/"
   ] + [
     "-fmodule-name=GoogleSignIn_pod_module"
@@ -97,7 +88,7 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleSignIn_acknowledgement",
   deps = [
@@ -107,7 +98,7 @@ acknowledged_target(
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments_acknowledgement"
   ],
   value = "//Vendor/GoogleSignIn/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_bundle_import(
   name = "GoogleSignIn_Bundle_GoogleSignIn",
   bundle_imports = glob(
@@ -115,8 +106,8 @@ apple_bundle_import(
       "Resources/GoogleSignIn.bundle/**"
     ],
     exclude_directories = 1
-    )
   )
+)
 apple_static_framework_import(
   name = "GoogleSignIn_VendoredFrameworks",
   framework_imports = glob(
@@ -124,8 +115,8 @@ apple_static_framework_import(
       "Frameworks/GoogleSignIn.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleSymbolUtilities_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleSymbolUtilities_includes",
   include = [
     "Vendor/GoogleSymbolUtilities/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleSymbolUtilities",
   "GoogleSymbolUtilities_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "GoogleSymbolUtilities_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleSymbolUtilities",
   enable_modules = 0,
@@ -54,18 +50,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleSymbolUtilities",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-    ":GoogleSymbolUtilities_VendoredFrameworks"
-  ] + [
+    ":GoogleSymbolUtilities_VendoredFrameworks",
     ":GoogleSymbolUtilities_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -75,7 +66,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleSymbolUtilities/pod_support/Headers/Public/GoogleSymbolUtilities/"
   ] + [
     "-fmodule-name=GoogleSymbolUtilities_pod_module"
@@ -83,14 +74,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleSymbolUtilities_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/GoogleSymbolUtilities/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "GoogleSymbolUtilities_VendoredFrameworks",
   framework_imports = glob(
@@ -98,8 +87,8 @@ apple_static_framework_import(
       "Frameworks/frameworks/GoogleSymbolUtilities.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "GoogleUtilities_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "GoogleUtilities_includes",
   include = [
     "Vendor/GoogleUtilities/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "GoogleUtilities",
   "GoogleUtilities_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "GoogleUtilities_hdrs"
   ]
-  )
+)
 objc_library(
   name = "GoogleUtilities",
   enable_modules = 0,
@@ -54,10 +50,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "GoogleUtilities",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "AddressBook",
     "CoreGraphics"
@@ -67,13 +61,10 @@ objc_library(
   ],
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
-    ":GoogleUtilities_VendoredFrameworks"
-  ] + [
+    ":GoogleUtilities_VendoredFrameworks",
     ":GoogleUtilities_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +74,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/GoogleUtilities/pod_support/Headers/Public/GoogleUtilities/"
   ] + [
     "-fmodule-name=GoogleUtilities_pod_module"
@@ -91,14 +82,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "GoogleUtilities_acknowledgement",
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_acknowledgement"
   ],
   value = "//Vendor/GoogleUtilities/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "GoogleUtilities_VendoredFrameworks",
   framework_imports = glob(
@@ -106,8 +97,8 @@ apple_static_framework_import(
       "Frameworks/frameworks/GoogleUtilities.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "IBActionSheet_includes",
   include = [
     "Vendor/IBActionSheet/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "IBActionSheet",
   "IBActionSheet_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "IBActionSheet_hdrs"
   ]
-  )
+)
 objc_library(
   name = "IBActionSheet",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":IBActionSheet_hdrs"
   ],
@@ -65,18 +63,14 @@ objc_library(
     [
       "IBActionSheetSample/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "QuartzCore"
   ],
   deps = [
-
-  ] + [
     ":IBActionSheet_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -86,7 +80,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IBActionSheet/pod_support/Headers/Public/IBActionSheet/"
   ] + [
     "-fmodule-name=IBActionSheet_pod_module"
@@ -94,11 +88,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "IBActionSheet_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IBActionSheet/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,25 +14,25 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "osxCase",
   values = {
     "cpu": "powerpc2"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
@@ -40,21 +40,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Default_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "IGListKit_includes",
   include = [
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "IGListKit",
   "IGListKit_module_map",
@@ -62,7 +60,7 @@ gen_module_map(
   [
     "IGListKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "IGListKit",
   enable_modules = 0,
@@ -71,10 +69,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "IGListKit",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -87,18 +83,15 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-    ":Default"
-  ] + [
+    ":Default",
     ":IGListKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -108,7 +101,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
   ] + [
     "-fmodule-name=IGListKit_pod_module"
@@ -116,14 +109,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "IGListKit_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
@@ -132,11 +123,11 @@ filegroup(
       "Source/Common/Internal/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Diffing_cxx_union_hdrs",
   srcs = [
@@ -146,13 +137,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Diffing_cxx_includes",
   include = [
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Diffing_cxx",
   enable_modules = 0,
@@ -168,7 +159,7 @@ objc_library(
           "Source/Common/**/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.mm"
@@ -179,9 +170,9 @@ objc_library(
           "Source/Common/**/*.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Diffing_cxx_union_hdrs"
   ],
@@ -190,7 +181,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -203,13 +194,11 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-
-  ] + [
     ":Diffing_cxx_includes"
   ],
   copts = [
@@ -225,7 +214,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
   ] + [
     "-fmodule-name=IGListKit_pod_module"
@@ -233,14 +222,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Diffing_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
@@ -249,11 +236,11 @@ filegroup(
       "Source/Common/Internal/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Diffing_union_hdrs",
   srcs = [
@@ -263,13 +250,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Diffing_includes",
   include = [
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Diffing",
   enable_modules = 0,
@@ -284,7 +271,7 @@ objc_library(
           "Source/**/*.mm"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.m"
@@ -294,9 +281,9 @@ objc_library(
           "Source/**/*.mm"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Diffing_union_hdrs"
   ],
@@ -305,7 +292,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -318,18 +305,15 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-    ":Diffing_cxx"
-  ] + [
+    ":Diffing_cxx",
     ":Diffing_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -339,7 +323,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
   ] + [
     "-fmodule-name=IGListKit_pod_module"
@@ -347,14 +331,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Diffing_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Default_cxx_hdrs",
   srcs = select(
@@ -366,7 +348,7 @@ filegroup(
           "Source/Internal/*.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/**/*.h",
@@ -374,13 +356,13 @@ filegroup(
           "Source/Internal/*.h"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Default_cxx_union_hdrs",
   srcs = [
@@ -390,13 +372,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Default_cxx_includes",
   include = [
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Default_cxx",
   enable_modules = 0,
@@ -410,7 +392,7 @@ objc_library(
           "Source/**/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/**/*.mm"
@@ -419,9 +401,9 @@ objc_library(
           "Source/**/*.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Default_cxx_union_hdrs"
   ],
@@ -430,7 +412,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -443,13 +425,12 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-    ":Diffing"
-  ] + [
+    ":Diffing",
     ":Default_cxx_includes"
   ],
   copts = [
@@ -465,7 +446,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
   ] + [
     "-fmodule-name=IGListKit_pod_module"
@@ -473,14 +454,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Default_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Default_hdrs",
   srcs = select(
@@ -492,7 +471,7 @@ filegroup(
           "Source/Internal/*.h"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/**/*.h",
@@ -500,13 +479,13 @@ filegroup(
           "Source/Internal/*.h"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Default_union_hdrs",
   srcs = [
@@ -516,13 +495,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Default_includes",
   include = [
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Default",
   enable_modules = 0,
@@ -533,15 +512,15 @@ objc_library(
           "Source/**/*.m"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "Source/**/*.m"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Default_union_hdrs"
   ],
@@ -550,7 +529,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -563,19 +542,16 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     ":Default_cxx",
-    ":Diffing"
-  ] + [
+    ":Diffing",
     ":Default_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -585,7 +561,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
   ] + [
     "-fmodule-name=IGListKit_pod_module"
@@ -593,11 +569,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Default_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "FBKVOController/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KVOController_includes",
   include = [
     "Vendor/KVOController/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "KVOController",
   "KVOController_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "KVOController_hdrs"
   ]
-  )
+)
 objc_library(
   name = "KVOController",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "FBKVOController/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":KVOController_hdrs"
   ],
@@ -65,15 +63,11 @@ objc_library(
     [
       "FBKVOController/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":KVOController_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KVOController/pod_support/Headers/Public/KVOController/"
   ] + [
     "-fmodule-name=KVOController_pod_module"
@@ -91,11 +85,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KVOController_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KVOController/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,16 +15,14 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "KakaoOpenSDK_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoOpenSDK_union_hdrs",
   srcs = [
@@ -34,13 +32,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KakaoOpenSDK_includes",
   include = [
     "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "KakaoOpenSDK",
   enable_modules = 0,
@@ -49,22 +47,17 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit",
     "WebKit"
   ],
   deps = [
-    ":KakaoOpenSDK_VendoredFrameworks"
-  ] + [
+    ":KakaoOpenSDK_VendoredFrameworks",
     ":KakaoOpenSDK_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -74,7 +67,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
   ] + [
     "-fmodule-name=KakaoOpenSDK_pod_module"
@@ -82,23 +75,19 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KakaoOpenSDK_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "KakaoOpenSDK_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoOpenSDK_union_hdrs",
   srcs = [
@@ -108,13 +97,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KakaoOpenSDK_includes",
   include = [
     "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "KakaoOpenSDK",
   enable_modules = 0,
@@ -123,22 +112,17 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit",
     "WebKit"
   ],
   deps = [
-    ":KakaoOpenSDK_VendoredFrameworks"
-  ] + [
+    ":KakaoOpenSDK_VendoredFrameworks",
     ":KakaoOpenSDK_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -148,7 +132,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
   ] + [
     "-fmodule-name=KakaoOpenSDK_pod_module"
@@ -156,14 +140,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KakaoOpenSDK_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "KakaoOpenSDK_VendoredFrameworks",
   framework_imports = glob(
@@ -171,20 +153,18 @@ apple_static_framework_import(
       "KakaoOpenSDK.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoNavi_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoNavi_union_hdrs",
   srcs = [
@@ -194,13 +174,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KakaoNavi_includes",
   include = [
     "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "KakaoNavi",
   enable_modules = 0,
@@ -209,21 +189,16 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
-    ":KakaoNavi_VendoredFrameworks"
-  ] + [
+    ":KakaoNavi_VendoredFrameworks",
     ":KakaoNavi_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -233,7 +208,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
   ] + [
     "-fmodule-name=KakaoOpenSDK_pod_module"
@@ -241,14 +216,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KakaoNavi_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "KakaoNavi_VendoredFrameworks",
   framework_imports = glob(
@@ -256,20 +229,18 @@ apple_static_framework_import(
       "KakaoNavi.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoLink_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoLink_union_hdrs",
   srcs = [
@@ -279,13 +250,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KakaoLink_includes",
   include = [
     "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "KakaoLink",
   enable_modules = 0,
@@ -294,21 +265,16 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
-    ":KakaoLink_VendoredFrameworks"
-  ] + [
+    ":KakaoLink_VendoredFrameworks",
     ":KakaoLink_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -318,7 +284,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
   ] + [
     "-fmodule-name=KakaoOpenSDK_pod_module"
@@ -326,14 +292,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KakaoLink_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "KakaoLink_VendoredFrameworks",
   framework_imports = glob(
@@ -341,20 +305,18 @@ apple_static_framework_import(
       "KakaoLink.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoS2_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "KakaoS2_union_hdrs",
   srcs = [
@@ -364,13 +326,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "KakaoS2_includes",
   include = [
     "Vendor/KakaoOpenSDK/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "KakaoS2",
   enable_modules = 0,
@@ -379,21 +341,16 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "KakaoOpenSDK",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
   deps = [
-    ":KakaoS2_VendoredFrameworks"
-  ] + [
+    ":KakaoS2_VendoredFrameworks",
     ":KakaoS2_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -403,7 +360,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
   ] + [
     "-fmodule-name=KakaoOpenSDK_pod_module"
@@ -411,14 +368,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "KakaoS2_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_static_framework_import(
   name = "KakaoS2_VendoredFrameworks",
   framework_imports = glob(
@@ -426,8 +381,8 @@ apple_static_framework_import(
       "KakaoS2.framework/**"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,25 +14,25 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "osxCase",
   values = {
     "cpu": "powerpc2"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
@@ -40,24 +40,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Masonry/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Masonry_includes",
   include = [
     "Vendor/Masonry/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Masonry",
   "Masonry_module_map",
@@ -65,7 +63,7 @@ gen_module_map(
   [
     "Masonry_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Masonry",
   enable_modules = 0,
@@ -74,7 +72,7 @@ objc_library(
       "Masonry/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Masonry_hdrs"
   ],
@@ -83,7 +81,7 @@ objc_library(
     [
       "Masonry/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -99,15 +97,11 @@ objc_library(
         "UIKit"
       ]
     }
-    ),
+  ),
   deps = [
-
-  ] + [
     ":Masonry_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -117,7 +111,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Masonry/pod_support/Headers/Public/Masonry/"
   ] + [
     "-fmodule-name=Masonry_pod_module"
@@ -125,11 +119,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Masonry_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Masonry/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
@@ -23,7 +23,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "*.h"
     ],
@@ -33,19 +33,17 @@ filegroup(
       "Demos/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "OnePasswordExtension_includes",
   include = [
     "Vendor/OnePasswordExtension/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "OnePasswordExtension",
   "1PasswordExtension_module_map",
@@ -53,14 +51,14 @@ gen_module_map(
   [
     "1PasswordExtension_hdrs"
   ]
-  )
+)
 alias(
   name = "1PasswordExtension",
   actual = "OnePasswordExtension",
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 objc_library(
   name = "OnePasswordExtension",
   enable_modules = 0,
@@ -79,16 +77,14 @@ objc_library(
       "Demos/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":1PasswordExtension_hdrs"
   ],
   pch = pch_with_name_hint(
     "1PasswordExtension",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Foundation",
     "MobileCoreServices",
@@ -98,13 +94,10 @@ objc_library(
     "WebKit"
   ],
   deps = [
-    ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
-  ] + [
+    ":OnePasswordExtension_Bundle_OnePasswordExtensionResources",
     ":OnePasswordExtension_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -114,7 +107,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/OnePasswordExtension/pod_support/Headers/Public/OnePasswordExtension/"
   ] + [
     "-fmodule-name=OnePasswordExtension_pod_module"
@@ -125,14 +118,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "OnePasswordExtension_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/OnePasswordExtension/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_resource_bundle(
   name = "OnePasswordExtension_Bundle_OnePasswordExtensionResources",
   resources = glob(
@@ -141,5 +132,5 @@ apple_resource_bundle(
       "1Password.xcassets/*.imageset/*.png"
     ],
     exclude_directories = 1
-    )
   )
+)

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,19 +14,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "osxCase",
   values = {
     "cpu": "powerpc2"
   }
-  )
+)
 filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
@@ -34,22 +34,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Core_hdrs",
     ":Arc-exception-safe_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINCache_includes",
   include = [
     "Vendor/PINCache/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "PINCache",
   "PINCache_module_map",
@@ -57,7 +55,7 @@ gen_module_map(
   [
     "PINCache_hdrs"
   ]
-  )
+)
 objc_library(
   name = "PINCache",
   enable_modules = 0,
@@ -66,10 +64,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINCache",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
@@ -82,16 +78,13 @@ objc_library(
         "AppKit"
       ]
     }
-    ),
+  ),
   deps = [
     ":Arc-exception-safe",
-    ":Core"
-  ] + [
+    ":Core",
     ":PINCache_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -101,7 +94,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
   ] + [
     "-fmodule-name=PINCache_pod_module"
@@ -109,14 +102,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINCache_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -124,11 +115,11 @@ filegroup(
       "Source/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -138,13 +129,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/PINCache/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -156,7 +147,7 @@ objc_library(
       "Source/PINDiskCache.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -165,7 +156,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
@@ -178,15 +169,12 @@ objc_library(
         "AppKit"
       ]
     }
-    ),
+  ),
   deps = [
-    "//Vendor/PINOperation:PINOperation"
-  ] + [
+    "//Vendor/PINOperation:PINOperation",
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -196,7 +184,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
   ] + [
     "-fmodule-name=PINCache_pod_module"
@@ -204,23 +192,21 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
     "//Vendor/PINOperation:PINOperation_acknowledgement"
   ],
   value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Arc-exception-safe_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Arc-exception-safe_union_hdrs",
   srcs = [
@@ -230,13 +216,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Arc-exception-safe_includes",
   include = [
     "Vendor/PINCache/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Arc-exception-safe",
   enable_modules = 0,
@@ -245,7 +231,7 @@ objc_library(
       "Source/PINDiskCache.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Arc-exception-safe_union_hdrs"
   ],
@@ -254,7 +240,7 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
@@ -267,10 +253,9 @@ objc_library(
         "AppKit"
       ]
     }
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Arc-exception-safe_includes"
   ],
   copts = [
@@ -285,7 +270,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
   ] + [
     "-fmodule-name=PINCache_pod_module"
@@ -293,11 +278,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Arc-exception-safe_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
@@ -22,11 +22,11 @@ filegroup(
       "Source/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PINOperation_cxx_union_hdrs",
   srcs = [
@@ -36,13 +36,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINOperation_cxx_includes",
   include = [
     "Vendor/PINOperation/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PINOperation_cxx",
   enable_modules = 0,
@@ -54,7 +54,7 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PINOperation_cxx_union_hdrs"
   ],
@@ -63,18 +63,14 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
   deps = [
-
-  ] + [
     ":PINOperation_cxx_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -84,7 +80,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINOperation/pod_support/Headers/Public/PINOperation/"
   ] + [
     "-fmodule-name=PINOperation_pod_module"
@@ -92,14 +88,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINOperation_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINOperation/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PINOperation_hdrs",
   srcs = glob(
@@ -107,24 +101,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Source/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":PINOperation_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINOperation_includes",
   include = [
     "Vendor/PINOperation/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "PINOperation",
   "PINOperation_module_map",
@@ -132,7 +126,7 @@ gen_module_map(
   [
     "PINOperation_hdrs"
   ]
-  )
+)
 objc_library(
   name = "PINOperation",
   enable_modules = 0,
@@ -141,7 +135,7 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PINOperation_hdrs"
   ],
@@ -150,18 +144,15 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation"
   ],
   deps = [
-    ":PINOperation_cxx"
-  ] + [
+    ":PINOperation_cxx",
     ":PINOperation_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -171,7 +162,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINOperation/pod_support/Headers/Public/PINOperation/"
   ] + [
     "-fmodule-name=PINOperation_pod_module"
@@ -179,11 +170,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINOperation_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINOperation/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "PINRemoteImage_hdrs",
   srcs = glob(
@@ -22,22 +22,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":FLAnimatedImage_hdrs",
     ":PINCache_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINRemoteImage_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "PINRemoteImage",
   "PINRemoteImage_module_map",
@@ -45,7 +43,7 @@ gen_module_map(
   [
     "PINRemoteImage_hdrs"
   ]
-  )
+)
 objc_library(
   name = "PINRemoteImage",
   enable_modules = 0,
@@ -54,19 +52,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     ":FLAnimatedImage",
-    ":PINCache"
-  ] + [
+    ":PINCache",
     ":PINRemoteImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -76,7 +69,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -84,14 +77,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINRemoteImage_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -103,11 +94,11 @@ filegroup(
       "Source/Classes/PINCache/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -117,13 +108,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -136,7 +127,7 @@ objc_library(
       "Source/Classes/PINCache/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -145,19 +136,16 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "ImageIO",
     "Accelerate"
   ],
   deps = [
-    "//Vendor/PINOperation:PINOperation"
-  ] + [
+    "//Vendor/PINOperation:PINOperation",
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -167,7 +155,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -175,23 +163,21 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
     "//Vendor/PINOperation:PINOperation_acknowledgement"
   ],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "iOS_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "iOS_union_hdrs",
   srcs = [
@@ -201,13 +187,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "iOS_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "iOS",
   enable_modules = 0,
@@ -216,21 +202,16 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":iOS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -240,7 +221,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -248,23 +229,19 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "iOS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "OSX_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "OSX_union_hdrs",
   srcs = [
@@ -274,13 +251,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "OSX_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "OSX",
   enable_modules = 0,
@@ -289,22 +266,17 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Cocoa",
     "CoreServices"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":OSX_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -314,7 +286,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -322,23 +294,19 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "OSX_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "tvOS_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "tvOS_union_hdrs",
   srcs = [
@@ -348,13 +316,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "tvOS_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "tvOS",
   enable_modules = 0,
@@ -363,18 +331,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-    ":iOS"
-  ] + [
+    ":iOS",
     ":tvOS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -384,7 +347,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -392,14 +355,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "tvOS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
@@ -407,11 +368,11 @@ filegroup(
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "FLAnimatedImage_union_hdrs",
   srcs = [
@@ -421,13 +382,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "FLAnimatedImage_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "FLAnimatedImage",
   enable_modules = 0,
@@ -436,7 +397,7 @@ objc_library(
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":FLAnimatedImage_union_hdrs"
   ],
@@ -445,16 +406,13 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/FLAnimatedImage:FLAnimatedImage",
-    ":Core"
-  ] + [
+    ":Core",
     ":FLAnimatedImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -464,7 +422,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -472,23 +430,21 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "FLAnimatedImage_acknowledgement",
   deps = [
     "//Vendor/FLAnimatedImage:FLAnimatedImage_acknowledgement"
   ],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "WebP_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "WebP_union_hdrs",
   srcs = [
@@ -498,13 +454,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "WebP_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "WebP",
   enable_modules = 0,
@@ -513,14 +469,11 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "PINRemoteImage",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     "//Vendor/libwebp:libwebp",
-    ":Core"
-  ] + [
+    ":Core",
     ":WebP_includes"
   ],
   copts = [
@@ -535,7 +488,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -543,14 +496,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "WebP_acknowledgement",
   deps = [
     "//Vendor/libwebp:libwebp_acknowledgement"
   ],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
@@ -558,11 +511,11 @@ filegroup(
       "Source/Classes/PINCache/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PINCache_union_hdrs",
   srcs = [
@@ -572,13 +525,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINCache_includes",
   include = [
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PINCache",
   enable_modules = 0,
@@ -587,7 +540,7 @@ objc_library(
       "Source/Classes/PINCache/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PINCache_union_hdrs"
   ],
@@ -596,16 +549,13 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/PINCache:PINCache",
-    ":Core"
-  ] + [
+    ":Core",
     ":PINCache_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -615,7 +565,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
   ] + [
     "-fmodule-name=PINRemoteImage_pod_module"
@@ -623,11 +573,11 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINCache_acknowledgement",
   deps = [
     "//Vendor/PINCache:PINCache_acknowledgement"
   ],
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "PaymentKit/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PaymentKit_includes",
   include = [
     "Vendor/PaymentKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "PaymentKit",
   "PaymentKit_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "PaymentKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "PaymentKit",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "PaymentKit/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PaymentKit_hdrs"
   ],
@@ -65,15 +63,11 @@ objc_library(
     [
       "PaymentKit/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":PaymentKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/PaymentKit/pod_support/Headers/Public/PaymentKit/"
   ] + [
     "-fmodule-name=PaymentKit_pod_module"
@@ -94,15 +88,13 @@ objc_library(
       "PaymentKit/Resources/Cards/*.png"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PaymentKit_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/PaymentKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "RadarKit/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RadarKit_includes",
   include = [
     "Vendor/RadarKit/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "RadarKit",
   "RadarKit_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "RadarKit_hdrs"
   ]
-  )
+)
 objc_library(
   name = "RadarKit",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "RadarKit/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RadarKit_hdrs"
   ],
@@ -65,19 +63,15 @@ objc_library(
     [
       "RadarKit/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation",
     "SystemConfiguration"
   ],
   deps = [
-
-  ] + [
     ":RadarKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -87,7 +81,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/RadarKit/pod_support/Headers/Public/RadarKit/"
   ] + [
     "-fmodule-name=RadarKit_pod_module"
@@ -95,11 +89,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RadarKit_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/RadarKit/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,19 +15,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "tvosCase",
   values = {
     "cpu": "powerpc3"
   }
-  )
+)
 filegroup(
   name = "React_hdrs",
   srcs = glob(
@@ -35,21 +35,19 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Core_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "React_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "React",
   "React_module_map",
@@ -57,7 +55,7 @@ gen_module_map(
   [
     "React_hdrs"
   ]
-  )
+)
 objc_library(
   name = "React",
   enable_modules = 0,
@@ -66,18 +64,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "React",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":React_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -87,7 +80,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -95,14 +88,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "React_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = select(
@@ -140,7 +131,7 @@ filegroup(
           "ReactCommon/yoga/*.hxx"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "React/**/*.h",
@@ -192,13 +183,13 @@ filegroup(
           "ReactCommon/yoga/*.hxx"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_cxx_union_hdrs",
   srcs = [
@@ -208,14 +199,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_cxx_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core_cxx",
   enable_modules = 0,
@@ -323,7 +314,7 @@ objc_library(
           "ReactCommon/yoga/*.s"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "React/**/*.cpp",
@@ -475,9 +466,9 @@ objc_library(
           "ReactCommon/yoga/*.s"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Core_cxx_union_hdrs"
   ],
@@ -486,7 +477,7 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -494,13 +485,10 @@ objc_library(
     "stdc++"
   ],
   deps = [
-    "//Vendor/Yoga:Yoga"
-  ] + [
+    "//Vendor/Yoga:Yoga",
     ":Core_cxx_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -510,7 +498,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -518,14 +506,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_cxx_acknowledgement",
   deps = [
     "//Vendor/Yoga:Yoga_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = select(
@@ -563,7 +551,7 @@ filegroup(
           "ReactCommon/yoga/*.hxx"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "React/**/*.h",
@@ -615,13 +603,13 @@ filegroup(
           "ReactCommon/yoga/*.hxx"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -631,14 +619,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -744,7 +732,7 @@ objc_library(
           "ReactCommon/yoga/*.s"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":tvosCase": glob(
         [
           "React/**/*.S",
@@ -894,9 +882,9 @@ objc_library(
           "ReactCommon/yoga/*.s"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -905,7 +893,7 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -914,13 +902,10 @@ objc_library(
   ],
   deps = [
     "//Vendor/Yoga:Yoga",
-    ":Core_cxx"
-  ] + [
+    ":Core_cxx",
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -930,7 +915,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -938,14 +923,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
   deps = [
     "//Vendor/Yoga:Yoga_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
@@ -953,11 +938,11 @@ filegroup(
       "React/Cxx*/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "CxxBridge_cxx_union_hdrs",
   srcs = [
@@ -967,13 +952,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "CxxBridge_cxx_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "CxxBridge_cxx",
   enable_modules = 0,
@@ -985,7 +970,7 @@ objc_library(
       "React/Cxx*/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":CxxBridge_cxx_union_hdrs"
   ],
@@ -994,12 +979,11 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
-    ":cxxreact"
-  ] + [
+    ":cxxreact",
     ":CxxBridge_cxx_includes"
   ],
   copts = [
@@ -1015,7 +999,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1023,14 +1007,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "CxxBridge_cxx_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "CxxBridge_hdrs",
   srcs = glob(
@@ -1038,11 +1022,11 @@ filegroup(
       "React/Cxx*/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "CxxBridge_union_hdrs",
   srcs = [
@@ -1052,13 +1036,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "CxxBridge_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "CxxBridge",
   enable_modules = 0,
@@ -1067,7 +1051,7 @@ objc_library(
       "React/Cxx*/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":CxxBridge_union_hdrs"
   ],
@@ -1076,13 +1060,12 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
     ":CxxBridge_cxx",
-    ":cxxreact"
-  ] + [
+    ":cxxreact",
     ":CxxBridge_includes"
   ],
   copts = [
@@ -1097,7 +1080,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1105,14 +1088,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "CxxBridge_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
@@ -1125,11 +1108,11 @@ filegroup(
       "React/Inspector/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "DevSupport_cxx_union_hdrs",
   srcs = [
@@ -1139,13 +1122,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "DevSupport_cxx_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "DevSupport_cxx",
   enable_modules = 0,
@@ -1171,7 +1154,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":DevSupport_cxx_union_hdrs"
   ],
@@ -1180,11 +1163,10 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":RCTWebSocket"
-  ] + [
+    ":RCTWebSocket",
     ":DevSupport_cxx_includes"
   ],
   copts = [
@@ -1199,7 +1181,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1207,14 +1189,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "DevSupport_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "DevSupport_swift",
   srcs = glob(
@@ -1223,15 +1203,13 @@ swift_library(
       "React/Inspector/*.swift"
     ],
     exclude_directories = 1
-    ),
+  ),
   deps = [
     ":Core",
     ":RCTWebSocket"
   ],
-  data = [
-
-  ]
-  )
+  data = []
+)
 filegroup(
   name = "DevSupport_hdrs",
   srcs = glob(
@@ -1244,11 +1222,11 @@ filegroup(
       "React/Inspector/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "DevSupport_union_hdrs",
   srcs = [
@@ -1258,13 +1236,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "DevSupport_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "DevSupport",
   enable_modules = 0,
@@ -1280,7 +1258,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":DevSupport_union_hdrs"
   ],
@@ -1289,18 +1267,15 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
     ":DevSupport_cxx",
     ":DevSupport_swift",
-    ":RCTWebSocket"
-  ] + [
+    ":RCTWebSocket",
     ":DevSupport_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1310,7 +1285,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1318,14 +1293,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "DevSupport_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
@@ -1341,11 +1314,11 @@ filegroup(
       "**/tests/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTFabric_cxx_union_hdrs",
   srcs = [
@@ -1355,14 +1328,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTFabric_cxx_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTFabric_cxx",
   enable_modules = 0,
@@ -1385,7 +1358,7 @@ objc_library(
       "React/Fabric/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTFabric_cxx_union_hdrs"
   ],
@@ -1394,15 +1367,14 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
-    ":fabric"
-  ] + [
+    ":fabric",
     ":RCTFabric_cxx_includes"
   ],
   copts = [
@@ -1417,7 +1389,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1425,14 +1397,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTFabric_cxx_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
@@ -1448,11 +1420,11 @@ filegroup(
       "**/tests/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTFabric_union_hdrs",
   srcs = [
@@ -1462,14 +1434,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTFabric_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTFabric",
   enable_modules = 0,
@@ -1490,7 +1462,7 @@ objc_library(
       "**/tests/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTFabric_union_hdrs"
   ],
@@ -1499,7 +1471,7 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -1507,8 +1479,7 @@ objc_library(
     "//Vendor/Folly:Folly",
     ":Core",
     ":RCTFabric_cxx",
-    ":fabric"
-  ] + [
+    ":fabric",
     ":RCTFabric_includes"
   ],
   copts = [
@@ -1523,7 +1494,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1531,14 +1502,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTFabric_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
@@ -1546,11 +1517,11 @@ filegroup(
       "React/**/RCTTV*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "tvOS_union_hdrs",
   srcs = [
@@ -1560,13 +1531,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "tvOS_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "tvOS",
   enable_modules = 0,
@@ -1575,7 +1546,7 @@ objc_library(
       "React/**/RCTTV*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":tvOS_union_hdrs"
   ],
@@ -1584,15 +1555,12 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":tvOS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1602,7 +1570,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1610,14 +1578,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "tvOS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "jschelpers_hdrs",
   srcs = glob(
@@ -1625,11 +1591,11 @@ filegroup(
       "ReactCommon/jschelpers/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "jschelpers_union_hdrs",
   srcs = [
@@ -1639,14 +1605,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "jschelpers_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "jschelpers",
   enable_modules = 0,
@@ -1668,7 +1634,7 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":jschelpers_union_hdrs"
   ],
@@ -1677,14 +1643,13 @@ objc_library(
     [
       "ReactCommon/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
   deps = [
     "//Vendor/Folly:Folly",
-    ":PrivateDatabase"
-  ] + [
+    ":PrivateDatabase",
     ":jschelpers_includes"
   ],
   copts = [
@@ -1699,7 +1664,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1707,14 +1672,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "jschelpers_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "jsinspector_hdrs",
   srcs = glob(
@@ -1722,11 +1687,11 @@ filegroup(
       "ReactCommon/jsinspector/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "jsinspector_union_hdrs",
   srcs = [
@@ -1736,14 +1701,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "jsinspector_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "jsinspector",
   enable_modules = 0,
@@ -1765,7 +1730,7 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":jsinspector_union_hdrs"
   ],
@@ -1774,15 +1739,11 @@ objc_library(
     [
       "ReactCommon/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":jsinspector_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1792,7 +1753,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1800,14 +1761,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "jsinspector_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PrivateDatabase_hdrs",
   srcs = glob(
@@ -1815,11 +1774,11 @@ filegroup(
       "ReactCommon/privatedata/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PrivateDatabase_union_hdrs",
   srcs = [
@@ -1829,14 +1788,14 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PrivateDatabase_includes",
   include = [
     "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PrivateDatabase",
   enable_modules = 0,
@@ -1859,7 +1818,7 @@ objc_library(
       "ReactCommon/jschelpers/*.cpp"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":PrivateDatabase_union_hdrs"
   ],
@@ -1868,15 +1827,11 @@ objc_library(
     [
       "ReactCommon/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":PrivateDatabase_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1886,7 +1841,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1894,14 +1849,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PrivateDatabase_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "cxxreact_hdrs",
   srcs = glob(
@@ -1914,11 +1867,11 @@ filegroup(
       "ReactCommon/cxxreact/SampleCxxModule.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "cxxreact_union_hdrs",
   srcs = [
@@ -1928,7 +1881,7 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "cxxreact_includes",
   include = [
@@ -1938,7 +1891,7 @@ gen_includes(
     "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "cxxreact",
   enable_modules = 0,
@@ -1959,7 +1912,7 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":cxxreact_union_hdrs"
   ],
@@ -1968,13 +1921,12 @@ objc_library(
     [
       "ReactCommon/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/Folly:Folly",
     "//Vendor/boost-for-react-native:boost-for-react-native",
     ":jschelpers",
-    ":jsinspector"
-  ] + [
+    ":jsinspector",
     ":cxxreact_includes"
   ],
   copts = [
@@ -1989,7 +1941,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1997,7 +1949,7 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "cxxreact_acknowledgement",
   deps = [
@@ -2005,16 +1957,14 @@ acknowledged_target(
     "//Vendor/boost-for-react-native:boost-for-react-native_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "fabric_hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "fabric_union_hdrs",
   srcs = [
@@ -2024,13 +1974,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "fabric_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "fabric",
   enable_modules = 0,
@@ -2039,18 +1989,12 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "React",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-
-  ] + [
     ":fabric_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2060,7 +2004,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2068,14 +2012,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "fabric_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
@@ -2091,11 +2033,11 @@ filegroup(
       "**/tests/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTFabricSample_union_hdrs",
   srcs = [
@@ -2105,7 +2047,7 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTFabricSample_includes",
   include = [
@@ -2113,7 +2055,7 @@ gen_includes(
     "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTFabricSample",
   enable_modules = 0,
@@ -2132,7 +2074,7 @@ objc_library(
       "**/tests/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTFabricSample_union_hdrs"
   ],
@@ -2141,10 +2083,9 @@ objc_library(
     [
       "ReactCommon/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    "//Vendor/Folly:Folly"
-  ] + [
+    "//Vendor/Folly:Folly",
     ":RCTFabricSample_includes"
   ],
   copts = [
@@ -2159,7 +2100,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/sample/"
   ] + [
     "-fmodule-name=fabric/sample_pod_module"
@@ -2167,14 +2108,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTFabricSample_acknowledgement",
   deps = [
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
@@ -2182,11 +2123,11 @@ filegroup(
       "Libraries/ART/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "ART_union_hdrs",
   srcs = [
@@ -2196,13 +2137,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "ART_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "ART",
   enable_modules = 0,
@@ -2211,7 +2152,7 @@ objc_library(
       "Libraries/ART/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":ART_union_hdrs"
   ],
@@ -2220,15 +2161,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":ART_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2238,7 +2176,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2246,14 +2184,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "ART_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
@@ -2261,11 +2197,11 @@ filegroup(
       "Libraries/ActionSheetIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTActionSheet_union_hdrs",
   srcs = [
@@ -2275,13 +2211,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTActionSheet_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTActionSheet",
   enable_modules = 0,
@@ -2290,7 +2226,7 @@ objc_library(
       "Libraries/ActionSheetIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTActionSheet_union_hdrs"
   ],
@@ -2299,15 +2235,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTActionSheet_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2317,7 +2250,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2325,14 +2258,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTActionSheet_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
@@ -2345,11 +2276,11 @@ filegroup(
       "RCTAnimation/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTAnimation_union_hdrs",
   srcs = [
@@ -2359,13 +2290,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTAnimation_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTAnimation",
   enable_modules = 0,
@@ -2376,7 +2307,7 @@ objc_library(
       "Libraries/NativeAnimation/Nodes/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTAnimation_union_hdrs"
   ],
@@ -2385,15 +2316,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTAnimation_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2403,7 +2331,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/RCTAnimation/"
   ] + [
     "-fmodule-name=RCTAnimation_pod_module"
@@ -2411,14 +2339,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTAnimation_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTBlob_cxx_hdrs",
   srcs = glob(
@@ -2426,11 +2352,11 @@ filegroup(
       "Libraries/Blob/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTBlob_cxx_union_hdrs",
   srcs = [
@@ -2440,13 +2366,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTBlob_cxx_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTBlob_cxx",
   enable_modules = 0,
@@ -2475,7 +2401,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTBlob_cxx_union_hdrs"
   ],
@@ -2484,10 +2410,9 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTBlob_cxx_includes"
   ],
   copts = [
@@ -2502,7 +2427,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2510,14 +2435,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTBlob_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
@@ -2525,11 +2448,11 @@ filegroup(
       "Libraries/Blob/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTBlob_union_hdrs",
   srcs = [
@@ -2539,13 +2462,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTBlob_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTBlob",
   enable_modules = 0,
@@ -2573,7 +2496,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTBlob_union_hdrs"
   ],
@@ -2582,16 +2505,13 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":RCTBlob_cxx"
-  ] + [
+    ":RCTBlob_cxx",
     ":RCTBlob_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2601,7 +2521,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2609,14 +2529,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTBlob_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
@@ -2624,11 +2542,11 @@ filegroup(
       "Libraries/CameraRoll/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTCameraRoll_union_hdrs",
   srcs = [
@@ -2638,13 +2556,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTCameraRoll_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTCameraRoll",
   enable_modules = 0,
@@ -2653,7 +2571,7 @@ objc_library(
       "Libraries/CameraRoll/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTCameraRoll_union_hdrs"
   ],
@@ -2662,16 +2580,13 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":RCTImage"
-  ] + [
+    ":RCTImage",
     ":RCTCameraRoll_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2681,7 +2596,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2689,14 +2604,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTCameraRoll_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
@@ -2704,11 +2617,11 @@ filegroup(
       "Libraries/Geolocation/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTGeolocation_union_hdrs",
   srcs = [
@@ -2718,13 +2631,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTGeolocation_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTGeolocation",
   enable_modules = 0,
@@ -2733,7 +2646,7 @@ objc_library(
       "Libraries/Geolocation/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTGeolocation_union_hdrs"
   ],
@@ -2742,15 +2655,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTGeolocation_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2760,7 +2670,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2768,14 +2678,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTGeolocation_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
@@ -2783,11 +2691,11 @@ filegroup(
       "Libraries/Image/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTImage_union_hdrs",
   srcs = [
@@ -2797,13 +2705,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTImage_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTImage",
   enable_modules = 0,
@@ -2815,7 +2723,7 @@ objc_library(
       "Libraries/CameraRoll/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTImage_union_hdrs"
   ],
@@ -2824,16 +2732,13 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":RCTNetwork"
-  ] + [
+    ":RCTNetwork",
     ":RCTImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2843,7 +2748,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2851,14 +2756,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTImage_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTNetwork_cxx_hdrs",
   srcs = glob(
@@ -2866,11 +2769,11 @@ filegroup(
       "Libraries/Network/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTNetwork_cxx_union_hdrs",
   srcs = [
@@ -2880,13 +2783,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTNetwork_cxx_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTNetwork_cxx",
   enable_modules = 0,
@@ -2900,7 +2803,7 @@ objc_library(
       "Libraries/Network/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTNetwork_cxx_union_hdrs"
   ],
@@ -2909,10 +2812,9 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTNetwork_cxx_includes"
   ],
   copts = [
@@ -2927,7 +2829,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -2935,14 +2837,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTNetwork_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
@@ -2950,11 +2850,11 @@ filegroup(
       "Libraries/Network/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTNetwork_union_hdrs",
   srcs = [
@@ -2964,13 +2864,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTNetwork_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTNetwork",
   enable_modules = 0,
@@ -2983,7 +2883,7 @@ objc_library(
       "Libraries/Image/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTNetwork_union_hdrs"
   ],
@@ -2992,16 +2892,13 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
-    ":RCTNetwork_cxx"
-  ] + [
+    ":RCTNetwork_cxx",
     ":RCTNetwork_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3011,7 +2908,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3019,14 +2916,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTNetwork_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
@@ -3034,11 +2929,11 @@ filegroup(
       "Libraries/PushNotificationIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTPushNotification_union_hdrs",
   srcs = [
@@ -3048,13 +2943,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTPushNotification_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTPushNotification",
   enable_modules = 0,
@@ -3063,7 +2958,7 @@ objc_library(
       "Libraries/PushNotificationIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTPushNotification_union_hdrs"
   ],
@@ -3072,15 +2967,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTPushNotification_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3090,7 +2982,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3098,14 +2990,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTPushNotification_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
@@ -3113,11 +3003,11 @@ filegroup(
       "Libraries/Settings/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTSettings_union_hdrs",
   srcs = [
@@ -3127,13 +3017,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTSettings_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTSettings",
   enable_modules = 0,
@@ -3142,7 +3032,7 @@ objc_library(
       "Libraries/Settings/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTSettings_union_hdrs"
   ],
@@ -3151,15 +3041,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTSettings_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3169,7 +3056,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3177,14 +3064,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTSettings_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
@@ -3192,11 +3077,11 @@ filegroup(
       "Libraries/Text/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTText_union_hdrs",
   srcs = [
@@ -3206,13 +3091,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTText_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTText",
   enable_modules = 0,
@@ -3221,7 +3106,7 @@ objc_library(
       "Libraries/Text/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTText_union_hdrs"
   ],
@@ -3230,15 +3115,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTText_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3248,7 +3130,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3256,14 +3138,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTText_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
@@ -3271,11 +3151,11 @@ filegroup(
       "Libraries/Vibration/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTVibration_union_hdrs",
   srcs = [
@@ -3285,13 +3165,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTVibration_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTVibration",
   enable_modules = 0,
@@ -3300,7 +3180,7 @@ objc_library(
       "Libraries/Vibration/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTVibration_union_hdrs"
   ],
@@ -3309,15 +3189,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTVibration_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3327,7 +3204,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3335,14 +3212,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTVibration_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
@@ -3350,11 +3225,11 @@ filegroup(
       "Libraries/WebSocket/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTWebSocket_union_hdrs",
   srcs = [
@@ -3364,13 +3239,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTWebSocket_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTWebSocket",
   enable_modules = 0,
@@ -3397,7 +3272,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTWebSocket_union_hdrs"
   ],
@@ -3406,17 +3281,14 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":Core",
     ":RCTBlob",
-    ":fishhook"
-  ] + [
+    ":fishhook",
     ":RCTWebSocket_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3426,7 +3298,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3434,14 +3306,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTWebSocket_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
@@ -3452,11 +3322,11 @@ filegroup(
       "fishhook/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "fishhook_union_hdrs",
   srcs = [
@@ -3466,13 +3336,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "fishhook_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "fishhook",
   enable_modules = 0,
@@ -3500,7 +3370,7 @@ objc_library(
       "React/Inspector/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":fishhook_union_hdrs"
   ],
@@ -3509,15 +3379,11 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":fishhook_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3527,7 +3393,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/fishhook/"
   ] + [
     "-fmodule-name=fishhook_pod_module"
@@ -3535,14 +3401,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "fishhook_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
@@ -3550,11 +3414,11 @@ filegroup(
       "Libraries/LinkingIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTLinkingIOS_union_hdrs",
   srcs = [
@@ -3564,13 +3428,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTLinkingIOS_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTLinkingIOS",
   enable_modules = 0,
@@ -3579,7 +3443,7 @@ objc_library(
       "Libraries/LinkingIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTLinkingIOS_union_hdrs"
   ],
@@ -3588,15 +3452,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTLinkingIOS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3606,7 +3467,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3614,14 +3475,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTLinkingIOS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
@@ -3629,11 +3488,11 @@ filegroup(
       "Libraries/RCTTest/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTTest_union_hdrs",
   srcs = [
@@ -3643,13 +3502,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTTest_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTTest",
   enable_modules = 0,
@@ -3658,7 +3517,7 @@ objc_library(
       "Libraries/RCTTest/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTTest_union_hdrs"
   ],
@@ -3667,18 +3526,15 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "XCTest"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTTest_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3688,7 +3544,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3696,23 +3552,19 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTTest_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "_ignore_me_subspec_for_linting__hdrs",
-  srcs = [
-
-  ],
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "_ignore_me_subspec_for_linting__union_hdrs",
   srcs = [
@@ -3722,13 +3574,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "_ignore_me_subspec_for_linting__includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "_ignore_me_subspec_for_linting_",
   enable_modules = 0,
@@ -3737,19 +3589,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "React",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     ":Core",
-    ":CxxBridge"
-  ] + [
+    ":CxxBridge",
     ":_ignore_me_subspec_for_linting__includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3759,7 +3606,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -3767,11 +3614,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "_ignore_me_subspec_for_linting__acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "React_hdrs",
   srcs = glob(
@@ -22,7 +22,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "PATENTS/**/*.h",
       "PATENTS/**/*.hpp",
@@ -41,19 +41,19 @@ filegroup(
       "react-native-cli/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":Core_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "React_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "React",
   "React_module_map",
@@ -61,7 +61,7 @@ gen_module_map(
   [
     "React_hdrs"
   ]
-  )
+)
 objc_library(
   name = "React",
   enable_modules = 0,
@@ -70,18 +70,13 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "React",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":React_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -91,7 +86,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -99,14 +94,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "React_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -137,11 +130,11 @@ filegroup(
       "IntegrationTests/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -151,13 +144,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -197,7 +190,7 @@ objc_library(
       "Libraries/WebSocket/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -206,18 +199,14 @@ objc_library(
     [
       "React/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "JavaScriptCore"
   ],
   deps = [
-
-  ] + [
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -227,7 +216,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -235,14 +224,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
@@ -250,11 +237,11 @@ filegroup(
       "Libraries/ART/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "ART_union_hdrs",
   srcs = [
@@ -264,13 +251,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "ART_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "ART",
   enable_modules = 0,
@@ -279,7 +266,7 @@ objc_library(
       "Libraries/ART/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":ART_union_hdrs"
   ],
@@ -288,15 +275,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":ART_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -306,7 +290,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -314,14 +298,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "ART_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
@@ -329,11 +311,11 @@ filegroup(
       "Libraries/ActionSheetIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTActionSheet_union_hdrs",
   srcs = [
@@ -343,13 +325,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTActionSheet_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTActionSheet",
   enable_modules = 0,
@@ -358,7 +340,7 @@ objc_library(
       "Libraries/ActionSheetIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTActionSheet_union_hdrs"
   ],
@@ -367,15 +349,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTActionSheet_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -385,7 +364,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -393,14 +372,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTActionSheet_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
@@ -408,11 +385,11 @@ filegroup(
       "Libraries/AdSupport/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTAdSupport_union_hdrs",
   srcs = [
@@ -422,13 +399,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTAdSupport_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTAdSupport",
   enable_modules = 0,
@@ -437,7 +414,7 @@ objc_library(
       "Libraries/AdSupport/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTAdSupport_union_hdrs"
   ],
@@ -446,15 +423,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTAdSupport_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -464,7 +438,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -472,14 +446,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTAdSupport_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
@@ -487,11 +459,11 @@ filegroup(
       "Libraries/Geolocation/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTGeolocation_union_hdrs",
   srcs = [
@@ -501,13 +473,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTGeolocation_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTGeolocation",
   enable_modules = 0,
@@ -516,7 +488,7 @@ objc_library(
       "Libraries/Geolocation/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTGeolocation_union_hdrs"
   ],
@@ -525,15 +497,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTGeolocation_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -543,7 +512,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -551,14 +520,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTGeolocation_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
@@ -566,11 +533,11 @@ filegroup(
       "Libraries/Image/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTImage_union_hdrs",
   srcs = [
@@ -580,13 +547,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTImage_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTImage",
   enable_modules = 0,
@@ -595,7 +562,7 @@ objc_library(
       "Libraries/Image/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTImage_union_hdrs"
   ],
@@ -604,15 +571,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -622,7 +586,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -630,14 +594,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTImage_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
@@ -645,11 +607,11 @@ filegroup(
       "Libraries/Network/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTNetwork_union_hdrs",
   srcs = [
@@ -659,13 +621,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTNetwork_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTNetwork",
   enable_modules = 0,
@@ -674,7 +636,7 @@ objc_library(
       "Libraries/Network/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTNetwork_union_hdrs"
   ],
@@ -683,15 +645,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTNetwork_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -701,7 +660,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -709,14 +668,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTNetwork_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
@@ -724,11 +681,11 @@ filegroup(
       "Libraries/PushNotificationIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTPushNotification_union_hdrs",
   srcs = [
@@ -738,13 +695,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTPushNotification_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTPushNotification",
   enable_modules = 0,
@@ -753,7 +710,7 @@ objc_library(
       "Libraries/PushNotificationIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTPushNotification_union_hdrs"
   ],
@@ -762,15 +719,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTPushNotification_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -780,7 +734,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -788,14 +742,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTPushNotification_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
@@ -803,11 +755,11 @@ filegroup(
       "Libraries/Settings/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTSettings_union_hdrs",
   srcs = [
@@ -817,13 +769,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTSettings_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTSettings",
   enable_modules = 0,
@@ -832,7 +784,7 @@ objc_library(
       "Libraries/Settings/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTSettings_union_hdrs"
   ],
@@ -841,15 +793,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTSettings_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -859,7 +808,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -867,14 +816,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTSettings_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
@@ -882,11 +829,11 @@ filegroup(
       "Libraries/Text/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTText_union_hdrs",
   srcs = [
@@ -896,13 +843,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTText_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTText",
   enable_modules = 0,
@@ -911,7 +858,7 @@ objc_library(
       "Libraries/Text/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTText_union_hdrs"
   ],
@@ -920,15 +867,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTText_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -938,7 +882,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -946,14 +890,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTText_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
@@ -961,11 +903,11 @@ filegroup(
       "Libraries/Vibration/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTVibration_union_hdrs",
   srcs = [
@@ -975,13 +917,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTVibration_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTVibration",
   enable_modules = 0,
@@ -990,7 +932,7 @@ objc_library(
       "Libraries/Vibration/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTVibration_union_hdrs"
   ],
@@ -999,15 +941,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTVibration_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1017,7 +956,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1025,14 +964,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTVibration_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
@@ -1040,11 +977,11 @@ filegroup(
       "Libraries/WebSocket/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTWebSocket_union_hdrs",
   srcs = [
@@ -1054,13 +991,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTWebSocket_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTWebSocket",
   enable_modules = 0,
@@ -1069,7 +1006,7 @@ objc_library(
       "Libraries/WebSocket/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTWebSocket_union_hdrs"
   ],
@@ -1078,15 +1015,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTWebSocket_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1096,7 +1030,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1104,14 +1038,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTWebSocket_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
@@ -1119,11 +1051,11 @@ filegroup(
       "Libraries/LinkingIOS/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "RCTLinkingIOS_union_hdrs",
   srcs = [
@@ -1133,13 +1065,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "RCTLinkingIOS_includes",
   include = [
     "Vendor/React/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "RCTLinkingIOS",
   enable_modules = 0,
@@ -1148,7 +1080,7 @@ objc_library(
       "Libraries/LinkingIOS/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":RCTLinkingIOS_union_hdrs"
   ],
@@ -1157,15 +1089,12 @@ objc_library(
     [
       "Libraries/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":RCTLinkingIOS_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1175,7 +1104,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
   ] + [
     "-fmodule-name=React_pod_module"
@@ -1183,11 +1112,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "RCTLinkingIOS_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
@@ -25,11 +25,11 @@ filegroup(
       "security/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "SFHFKeychainUtils_cxx_union_hdrs",
   srcs = [
@@ -39,13 +39,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "SFHFKeychainUtils_cxx_includes",
   include = [
     "Vendor/SFHFKeychainUtils/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "SFHFKeychainUtils_cxx",
   enable_modules = 0,
@@ -62,7 +62,7 @@ objc_library(
       "security/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   non_arc_srcs = glob(
     [
       "security/**/*.mm"
@@ -71,7 +71,7 @@ objc_library(
       "security/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":SFHFKeychainUtils_cxx_union_hdrs"
   ],
@@ -80,18 +80,14 @@ objc_library(
     [
       "security/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Security"
   ],
   deps = [
-
-  ] + [
     ":SFHFKeychainUtils_cxx_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -101,7 +97,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/SFHFKeychainUtils/pod_support/Headers/Public/SFHFKeychainUtils/"
   ] + [
     "-fmodule-name=SFHFKeychainUtils_pod_module"
@@ -109,14 +105,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "SFHFKeychainUtils_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "SFHFKeychainUtils_swift",
   srcs = glob(
@@ -124,14 +118,10 @@ swift_library(
       "security/**/*.swift"
     ],
     exclude_directories = 1
-    ),
-  deps = [
-
-  ],
-  data = [
-
-  ]
-  )
+  ),
+  deps = [],
+  data = []
+)
 filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
@@ -139,26 +129,26 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "SFHFKeychainUtils_includes",
   include = [
     "Vendor/SFHFKeychainUtils/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "SFHFKeychainUtils",
   "SFHFKeychainUtils_module_map",
@@ -166,7 +156,7 @@ gen_module_map(
   [
     "SFHFKeychainUtils_hdrs"
   ]
-  )
+)
 objc_library(
   name = "SFHFKeychainUtils",
   enable_modules = 0,
@@ -177,13 +167,13 @@ objc_library(
       "security/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   non_arc_srcs = glob(
     [
       "security/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":SFHFKeychainUtils_hdrs"
   ],
@@ -192,19 +182,16 @@ objc_library(
     [
       "security/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Security"
   ],
   deps = [
     ":SFHFKeychainUtils_cxx",
-    ":SFHFKeychainUtils_swift"
-  ] + [
+    ":SFHFKeychainUtils_swift",
     ":SFHFKeychainUtils_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -214,7 +201,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/SFHFKeychainUtils/pod_support/Headers/Public/SFHFKeychainUtils/"
   ] + [
     "-fmodule-name=SFHFKeychainUtils_pod_module"
@@ -222,11 +209,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "SFHFKeychainUtils_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "SPUserResizableView/SPUserResizableView.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "SPUserResizableView+Pion_includes",
   include = [
     "Vendor/SPUserResizableView+Pion/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "SPUserResizableView+Pion",
   "SPUserResizableView+Pion_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "SPUserResizableView+Pion_hdrs"
   ]
-  )
+)
 objc_library(
   name = "SPUserResizableView+Pion",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "SPUserResizableView/SPUserResizableView.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"
   ],
@@ -65,15 +63,11 @@ objc_library(
     [
       "SPUserResizableView/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":SPUserResizableView+Pion_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/SPUserResizableView+Pion/pod_support/Headers/Public/SPUserResizableView+Pion/"
   ] + [
     "-fmodule-name=SPUserResizableView+Pion_pod_module"
@@ -91,11 +85,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "SPUserResizableView_Pion_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/SPUserResizableView+Pion/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 swift_library(
   name = "SevenSwitch",
   srcs = glob(
@@ -26,11 +26,7 @@ swift_library(
       "Classes/Exclude/**/*.swift"
     ],
     exclude_directories = 1
-    ),
-  deps = [
-
-  ],
-  data = [
-
-  ]
-  )
+  ),
+  deps = [],
+  data = []
+)

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Source/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "SlackTextViewController_includes",
   include = [
     "Vendor/SlackTextViewController/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "SlackTextViewController",
   "SlackTextViewController_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "SlackTextViewController_hdrs"
   ]
-  )
+)
 objc_library(
   name = "SlackTextViewController",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":SlackTextViewController_hdrs"
   ],
@@ -65,15 +63,11 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":SlackTextViewController_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +77,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/SlackTextViewController/pod_support/Headers/Public/SlackTextViewController/"
   ] + [
     "-fmodule-name=SlackTextViewController_pod_module"
@@ -91,11 +85,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "SlackTextViewController_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/SlackTextViewController/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Smartling_includes",
   include = [
     "Vendor/Smartling/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Smartling",
   "Smartling_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "Smartling_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Smartling",
   enable_modules = 0,
@@ -56,10 +54,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Smartling",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "UIKit"
   ],
@@ -67,13 +63,9 @@ objc_library(
     "Smartling"
   ],
   deps = [
-
-  ] + [
     ":Smartling_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -83,7 +75,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Smartling/pod_support/Headers/Public/Smartling/"
   ] + [
     "-fmodule-name=Smartling_pod_module"
@@ -91,11 +83,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Smartling_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Smartling/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,13 +15,13 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
@@ -29,25 +29,23 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "Stripe/*.h",
       "Stripe/PublicHeaders/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Stripe_includes",
   include = [
     "Vendor/Stripe/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Stripe",
   "Stripe_module_map",
@@ -55,7 +53,7 @@ gen_module_map(
   [
     "Stripe_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Stripe",
   enable_modules = 0,
@@ -64,7 +62,7 @@ objc_library(
       "Stripe/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Stripe_hdrs"
   ],
@@ -73,7 +71,7 @@ objc_library(
     [
       "Stripe/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "Foundation",
     "Security",
@@ -82,13 +80,10 @@ objc_library(
     "AddressBook"
   ],
   deps = [
-    ":Stripe_Bundle_Stripe"
-  ] + [
+    ":Stripe_Bundle_Stripe",
     ":Stripe_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -98,7 +93,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Stripe/pod_support/Headers/Public/Stripe/"
   ] + [
     "-fmodule-name=Stripe_pod_module"
@@ -109,18 +104,16 @@ objc_library(
         ":Stripe_Bundle_Stripe"
       ]
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Stripe_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Stripe/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_resource_bundle(
   name = "Stripe_Bundle_Stripe",
   resources = select(
@@ -130,7 +123,7 @@ apple_resource_bundle(
           "Stripe/Resources/**/*"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    )
   )
+)

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Texture_hdrs",
   srcs = glob(
@@ -22,14 +22,14 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "AsyncDisplayKit/**/*.h",
       "AsyncDisplayKit/**/*.hpp",
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":PINRemoteImage_hdrs",
     ":MapKit_hdrs",
     ":Photos_hdrs",
@@ -38,13 +38,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Texture_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "AsyncDisplayKit",
   "Texture_module_map",
@@ -52,7 +52,7 @@ gen_module_map(
   [
     "Texture_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Texture",
   enable_modules = 0,
@@ -61,10 +61,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_dylibs = [
     "c++"
   ],
@@ -72,13 +70,10 @@ objc_library(
     ":AssetsLibrary",
     ":MapKit",
     ":PINRemoteImage",
-    ":Photos"
-  ] + [
+    ":Photos",
     ":Texture_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -88,7 +83,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -96,14 +91,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Texture_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
@@ -116,11 +109,11 @@ filegroup(
       "Source/TextKit/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_cxx_union_hdrs",
   srcs = [
@@ -130,13 +123,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_cxx_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core_cxx",
   enable_modules = 0,
@@ -149,7 +142,7 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_cxx_union_hdrs"
   ],
@@ -158,13 +151,11 @@ objc_library(
     [
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-
-  ] + [
     ":Core_cxx_includes"
   ],
   copts = [
@@ -181,7 +172,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -189,14 +180,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -209,11 +198,11 @@ filegroup(
       "Source/TextKit/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -223,13 +212,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -239,7 +228,7 @@ objc_library(
       "Source/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -249,13 +238,12 @@ objc_library(
       "Base/**/*.pch",
       "Source/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-    ":Core_cxx"
-  ] + [
+    ":Core_cxx",
     ":Core_includes"
   ],
   copts = [
@@ -270,7 +258,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -278,14 +266,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "PINRemoteImage_hdrs",
   srcs = glob(
@@ -295,11 +281,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "PINRemoteImage_union_hdrs",
   srcs = [
@@ -309,13 +295,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "PINRemoteImage_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "PINRemoteImage",
   enable_modules = 0,
@@ -324,23 +310,18 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     "//Vendor/PINRemoteImage:PINCache",
     "//Vendor/PINRemoteImage:iOS",
-    ":Core"
-  ] + [
+    ":Core",
     ":PINRemoteImage_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -350,7 +331,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -358,7 +339,7 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "PINRemoteImage_acknowledgement",
   deps = [
@@ -366,7 +347,7 @@ acknowledged_target(
     "//Vendor/PINRemoteImage:iOS_acknowledgement"
   ],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
@@ -376,11 +357,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "IGListKit_union_hdrs",
   srcs = [
@@ -390,13 +371,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "IGListKit_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "IGListKit",
   enable_modules = 0,
@@ -405,22 +386,17 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     "//Vendor/IGListKit:IGListKit",
-    ":Core"
-  ] + [
+    ":Core",
     ":IGListKit_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -430,7 +406,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -438,14 +414,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "IGListKit_acknowledgement",
   deps = [
     "//Vendor/IGListKit:IGListKit_acknowledgement"
   ],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Yoga_hdrs",
   srcs = glob(
@@ -455,11 +431,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Yoga_union_hdrs",
   srcs = [
@@ -469,13 +445,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Yoga_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Yoga",
   enable_modules = 0,
@@ -484,17 +460,14 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
     "//Vendor/Yoga:Yoga",
-    ":Core"
-  ] + [
+    ":Core",
     ":Yoga_includes"
   ],
   copts = [
@@ -509,7 +482,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -517,14 +490,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Yoga_acknowledgement",
   deps = [
     "//Vendor/Yoga:Yoga_acknowledgement"
   ],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "MapKit_hdrs",
   srcs = glob(
@@ -534,11 +507,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "MapKit_union_hdrs",
   srcs = [
@@ -548,13 +521,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "MapKit_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "MapKit",
   enable_modules = 0,
@@ -563,10 +536,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "MapKit"
   ],
@@ -574,8 +545,7 @@ objc_library(
     "c++"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":MapKit_includes"
   ],
   copts = [
@@ -590,7 +560,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -598,14 +568,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "MapKit_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Photos_hdrs",
   srcs = glob(
@@ -615,11 +583,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Photos_union_hdrs",
   srcs = [
@@ -629,13 +597,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Photos_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Photos",
   enable_modules = 0,
@@ -644,10 +612,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "Photos"
   ],
@@ -655,8 +621,7 @@ objc_library(
     "c++"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":Photos_includes"
   ],
   copts = [
@@ -671,7 +636,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -679,14 +644,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Photos_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "AssetsLibrary_hdrs",
   srcs = glob(
@@ -696,11 +659,11 @@ filegroup(
       "AsyncDisplayKit/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "AssetsLibrary_union_hdrs",
   srcs = [
@@ -710,13 +673,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "AssetsLibrary_includes",
   include = [
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "AssetsLibrary",
   enable_modules = 0,
@@ -725,10 +688,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Texture",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "AssetsLibrary"
   ],
@@ -736,8 +697,7 @@ objc_library(
     "c++"
   ],
   deps = [
-    ":Core"
-  ] + [
+    ":Core",
     ":AssetsLibrary_includes"
   ],
   copts = [
@@ -752,7 +712,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
   ] + [
     "-fmodule-name=AsyncDisplayKit_pod_module"
@@ -760,11 +720,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "AssetsLibrary_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
@@ -25,11 +25,11 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_union_hdrs",
   srcs = [
@@ -39,13 +39,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "UICollectionViewLeftAlignedLayout_cxx_includes",
   include = [
     "Vendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "UICollectionViewLeftAlignedLayout_cxx",
   enable_modules = 0,
@@ -63,7 +63,7 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_cxx_union_hdrs"
   ],
@@ -72,15 +72,11 @@ objc_library(
     [
       "UICollectionViewLeftAlignedLayout/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-
-  ] + [
     ":UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -90,7 +86,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/UICollectionViewLeftAlignedLayout/"
   ] + [
     "-fmodule-name=UICollectionViewLeftAlignedLayout_pod_module"
@@ -98,14 +94,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "UICollectionViewLeftAlignedLayout_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "UICollectionViewLeftAlignedLayout_swift",
   srcs = glob(
@@ -113,14 +107,10 @@ swift_library(
       "UICollectionViewLeftAlignedLayout/**/*.swift"
     ],
     exclude_directories = 1
-    ),
-  deps = [
-
-  ],
-  data = [
-
-  ]
-  )
+  ),
+  deps = [],
+  data = []
+)
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
@@ -128,26 +118,26 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "UICollectionViewLeftAlignedLayout_includes",
   include = [
     "Vendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "UICollectionViewLeftAlignedLayout",
   "UICollectionViewLeftAlignedLayout_module_map",
@@ -155,7 +145,7 @@ gen_module_map(
   [
     "UICollectionViewLeftAlignedLayout_hdrs"
   ]
-  )
+)
 objc_library(
   name = "UICollectionViewLeftAlignedLayout",
   enable_modules = 0,
@@ -167,7 +157,7 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_hdrs"
   ],
@@ -176,16 +166,13 @@ objc_library(
     [
       "UICollectionViewLeftAlignedLayout/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":UICollectionViewLeftAlignedLayout_cxx",
-    ":UICollectionViewLeftAlignedLayout_swift"
-  ] + [
+    ":UICollectionViewLeftAlignedLayout_swift",
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -195,7 +182,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/UICollectionViewLeftAlignedLayout/"
   ] + [
     "-fmodule-name=UICollectionViewLeftAlignedLayout_pod_module"
@@ -203,11 +190,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "UICollectionViewLeftAlignedLayout_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "SDK1.6.2/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Weixin_includes",
   include = [
     "Vendor/Weixin/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "Weixin",
   "Weixin_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "Weixin_hdrs"
   ]
-  )
+)
 objc_library(
   name = "Weixin",
   enable_modules = 0,
@@ -56,10 +54,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "Weixin",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "CoreTelephony",
     "SystemConfiguration"
@@ -70,13 +66,10 @@ objc_library(
     "z"
   ],
   deps = [
-    ":Weixin_VendoredLibraries"
-  ] + [
+    ":Weixin_VendoredLibraries",
     ":Weixin_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -86,7 +79,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/Weixin/pod_support/Headers/Public/Weixin/"
   ] + [
     "-fmodule-name=Weixin_pod_module"
@@ -94,17 +87,15 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Weixin_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/Weixin/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 objc_import(
   name = "Weixin_VendoredLibraries",
   archives = [
     "SDK1.6.2/libWeChatSDK.a"
   ]
-  )
+)

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
@@ -22,7 +22,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "*.h",
       "minizip/crypt.h",
@@ -32,19 +32,17 @@ filegroup(
       "minizip/zip.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "ZipArchive_includes",
   include = [
     "Vendor/ZipArchive/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "ZipArchive",
   "ZipArchive_module_map",
@@ -52,7 +50,7 @@ gen_module_map(
   [
     "ZipArchive_hdrs"
   ]
-  )
+)
 objc_library(
   name = "ZipArchive",
   enable_modules = 0,
@@ -65,13 +63,13 @@ objc_library(
       "minizip/zip.c"
     ],
     exclude_directories = 1
-    ),
+  ),
   non_arc_srcs = glob(
     [
       "*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":ZipArchive_hdrs"
   ],
@@ -80,13 +78,11 @@ objc_library(
     [
       "minizip/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "z"
   ],
   deps = [
-
-  ] + [
     ":ZipArchive_includes"
   ],
   copts = [
@@ -101,7 +97,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/ZipArchive/pod_support/Headers/Public/ZipArchive/"
   ] + [
     "-fmodule-name=ZipArchive_pod_module"
@@ -109,11 +105,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "ZipArchive_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/ZipArchive/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
@@ -22,26 +22,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "boost/**/*.h",
       "boost/**/*.hpp",
       "boost/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "boost-for-react-native_includes",
   include = [
     "Vendor/boost-for-react-native/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "boost",
   "boost-for-react-native_module_map",
@@ -49,7 +47,7 @@ gen_module_map(
   [
     "boost-for-react-native_hdrs"
   ]
-  )
+)
 objc_library(
   name = "boost-for-react-native",
   enable_modules = 0,
@@ -58,18 +56,12 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "boost-for-react-native",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
-
-  ] + [
     ":boost-for-react-native_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -79,7 +71,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/boost-for-react-native/pod_support/Headers/Public/boost/"
   ] + [
     "-fmodule-name=boost_pod_module"
@@ -87,11 +79,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "boost-for-react-native_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/boost-for-react-native/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "glog_hdrs",
   srcs = glob(
@@ -22,7 +22,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "glog/**/*.h",
       "glog/**/*.hpp",
@@ -37,19 +37,17 @@ filegroup(
       "src/windows/**/*.hxx"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "glog_includes",
   include = [
     "Vendor/glog/src"
   ]
-  )
+)
 gen_module_map(
   "glog",
   "glog_module_map",
@@ -57,7 +55,7 @@ gen_module_map(
   [
     "glog_hdrs"
   ]
-  )
+)
 objc_library(
   name = "glog",
   enable_modules = 0,
@@ -82,7 +80,7 @@ objc_library(
       "src/windows/**/*.s"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":glog_hdrs"
   ],
@@ -91,18 +89,14 @@ objc_library(
     [
       "src/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "stdc++"
   ],
   deps = [
-
-  ] + [
     ":glog_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -112,19 +106,15 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
-
-  ] + [
+  ) + [
     "-fmodule-name=glog_pod_module"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "glog_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/glog/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "googleapis_hdrs",
   srcs = glob(
@@ -22,22 +22,20 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
+  ) + [
     ":Messages_hdrs",
     ":Services_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "googleapis_includes",
   include = [
     "Vendor/googleapis/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "googleapis",
   "googleapis_module_map",
@@ -45,7 +43,7 @@ gen_module_map(
   [
     "googleapis_hdrs"
   ]
-  )
+)
 objc_library(
   name = "googleapis",
   enable_modules = 0,
@@ -54,15 +52,12 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "googleapis",
-    [
-
-    ]
-    ),
+    []
+  ),
   deps = [
     "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
     ":Messages",
-    ":Services"
-  ] + [
+    ":Services",
     ":googleapis_includes"
   ],
   copts = [
@@ -77,7 +72,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
   ] + [
     "-fmodule-name=googleapis_pod_module"
@@ -85,14 +80,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "googleapis_acknowledgement",
   deps = [
     "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin_acknowledgement"
   ],
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Messages_hdrs",
   srcs = glob(
@@ -100,11 +95,11 @@ filegroup(
       "google/**/*.pbobjc.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Messages_union_hdrs",
   srcs = [
@@ -114,13 +109,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Messages_includes",
   include = [
     "Vendor/googleapis/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Messages",
   enable_modules = 0,
@@ -132,7 +127,7 @@ objc_library(
       "google/**/*.pbrpc.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Messages_union_hdrs"
   ],
@@ -141,10 +136,9 @@ objc_library(
     [
       "google/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    "//Vendor/Protobuf:Protobuf"
-  ] + [
+    "//Vendor/Protobuf:Protobuf",
     ":Messages_includes"
   ],
   copts = [
@@ -159,7 +153,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
   ] + [
     "-fmodule-name=googleapis_pod_module"
@@ -167,14 +161,14 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Messages_acknowledgement",
   deps = [
     "//Vendor/Protobuf:Protobuf_acknowledgement"
   ],
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Services_hdrs",
   srcs = glob(
@@ -182,11 +176,11 @@ filegroup(
       "google/**/*.pbrpc.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Services_union_hdrs",
   srcs = [
@@ -196,13 +190,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Services_includes",
   include = [
     "Vendor/googleapis/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Services",
   enable_modules = 0,
@@ -211,7 +205,7 @@ objc_library(
       "google/**/*.pbrpc.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Services_union_hdrs"
   ],
@@ -220,11 +214,10 @@ objc_library(
     [
       "google/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
-    ":Messages"
-  ] + [
+    ":Messages",
     ":Services_includes"
   ],
   copts = [
@@ -239,7 +232,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
   ] + [
     "-fmodule-name=googleapis_pod_module"
@@ -247,11 +240,11 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Services_acknowledgement",
   deps = [
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC_acknowledgement"
   ],
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "iOSSnapshotTestCase_hdrs",
   srcs = glob(
@@ -23,21 +23,17 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + [
-
-  ] + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "iOSSnapshotTestCase_includes",
   include = [
     "Vendor/iOSSnapshotTestCase/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "FBSnapshotTestCase",
   "iOSSnapshotTestCase_module_map",
@@ -45,7 +41,7 @@ gen_module_map(
   [
     "iOSSnapshotTestCase_hdrs"
   ]
-  )
+)
 objc_library(
   name = "iOSSnapshotTestCase",
   enable_modules = 0,
@@ -54,10 +50,8 @@ objc_library(
   ],
   pch = pch_with_name_hint(
     "iOSSnapshotTestCase",
-    [
-
-    ]
-    ),
+    []
+  ),
   sdk_frameworks = [
     "XCTest",
     "UIKit",
@@ -65,13 +59,10 @@ objc_library(
     "QuartzCore"
   ],
   deps = [
-    ":SwiftSupport"
-  ] + [
+    ":SwiftSupport",
     ":iOSSnapshotTestCase_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -81,7 +72,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
   ] + [
     "-fmodule-name=FBSnapshotTestCase_pod_module"
@@ -89,14 +80,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "iOSSnapshotTestCase_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/iOSSnapshotTestCase/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
@@ -108,11 +97,11 @@ filegroup(
       "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "Core_union_hdrs",
   srcs = [
@@ -122,13 +111,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "Core_includes",
   include = [
     "Vendor/iOSSnapshotTestCase/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "Core",
   enable_modules = 0,
@@ -138,7 +127,7 @@ objc_library(
       "FBSnapshotTestCase/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":Core_union_hdrs"
   ],
@@ -147,7 +136,7 @@ objc_library(
     [
       "FBSnapshotTestCase/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "XCTest",
     "UIKit",
@@ -155,13 +144,9 @@ objc_library(
     "QuartzCore"
   ],
   deps = [
-
-  ] + [
     ":Core_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -171,7 +156,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
   ] + [
     "-fmodule-name=FBSnapshotTestCase_pod_module"
@@ -179,14 +164,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "Core_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/iOSSnapshotTestCase/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "SwiftSupport",
   srcs = glob(
@@ -194,11 +177,9 @@ swift_library(
       "FBSnapshotTestCase/**/*.swift"
     ],
     exclude_directories = 1
-    ),
+  ),
   deps = [
     ":Core"
   ],
-  data = [
-
-  ]
-  )
+  data = []
+)

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -5,7 +5,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -15,7 +15,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "iRate_hdrs",
   srcs = glob(
@@ -23,24 +23,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "iRate/iRate.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "iRate_includes",
   include = [
     "Vendor/iRate/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "iRate",
   "iRate_module_map",
@@ -48,7 +46,7 @@ gen_module_map(
   [
     "iRate_hdrs"
   ]
-  )
+)
 objc_library(
   name = "iRate",
   enable_modules = 0,
@@ -57,7 +55,7 @@ objc_library(
       "iRate/iRate.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":iRate_hdrs"
   ],
@@ -66,15 +64,12 @@ objc_library(
     [
       "iRate/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":iRate_Bundle_iRate"
-  ] + [
+    ":iRate_Bundle_iRate",
     ":iRate_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -84,7 +79,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/iRate/pod_support/Headers/Public/iRate/"
   ] + [
     "-fmodule-name=iRate_pod_module"
@@ -95,14 +90,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "iRate_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/iRate/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_bundle_import(
   name = "iRate_Bundle_iRate",
   bundle_imports = glob(
@@ -110,5 +103,5 @@ apple_bundle_import(
       "iRate/iRate.bundle/**"
     ],
     exclude_directories = 1
-    )
   )
+)

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
@@ -22,24 +22,22 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "kingpin/*.h"
     ],
     exclude_directories = 1
-    ) + [
-
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "kingpin_includes",
   include = [
     "Vendor/kingpin/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "kingpin",
   "kingpin_module_map",
@@ -47,7 +45,7 @@ gen_module_map(
   [
     "kingpin_hdrs"
   ]
-  )
+)
 objc_library(
   name = "kingpin",
   enable_modules = 0,
@@ -56,7 +54,7 @@ objc_library(
       "kingpin/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":kingpin_hdrs"
   ],
@@ -65,19 +63,15 @@ objc_library(
     [
       "kingpin/**/*.pch"
     ]
-    ),
+  ),
   sdk_frameworks = [
     "MapKit",
     "CoreLocation"
   ],
   deps = [
-
-  ] + [
     ":kingpin_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -87,7 +81,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/kingpin/pod_support/Headers/Public/kingpin/"
   ] + [
     "-fmodule-name=kingpin_pod_module"
@@ -95,11 +89,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "kingpin_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/kingpin/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -4,7 +4,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -14,7 +14,7 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 filegroup(
   name = "pop_cxx_hdrs",
   srcs = glob(
@@ -22,11 +22,11 @@ filegroup(
       "pop/**/*.h"
     ],
     exclude_directories = 1
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "pop_cxx_union_hdrs",
   srcs = [
@@ -36,13 +36,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "pop_cxx_includes",
   include = [
     "Vendor/pop/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "pop_cxx",
   enable_modules = 0,
@@ -55,7 +55,7 @@ objc_library(
       "pop/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":pop_cxx_union_hdrs"
   ],
@@ -64,13 +64,11 @@ objc_library(
     [
       "pop/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-
-  ] + [
     ":pop_cxx_includes"
   ],
   copts = [
@@ -86,7 +84,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/pop/pod_support/Headers/Public/pop/"
   ] + [
     "-fmodule-name=pop_pod_module"
@@ -94,14 +92,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "pop_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/pop/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 filegroup(
   name = "pop_hdrs",
   srcs = glob(
@@ -109,24 +105,24 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + glob(
+  ) + glob(
     [
       "pop/**/*.h"
     ],
     exclude_directories = 1
-    ) + [
+  ) + [
     ":pop_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "pop_includes",
   include = [
     "Vendor/pop/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "pop",
   "pop_module_map",
@@ -134,7 +130,7 @@ gen_module_map(
   [
     "pop_hdrs"
   ]
-  )
+)
 objc_library(
   name = "pop",
   enable_modules = 0,
@@ -143,7 +139,7 @@ objc_library(
       "pop/**/*.m"
     ],
     exclude_directories = 1
-    ),
+  ),
   hdrs = [
     ":pop_hdrs"
   ],
@@ -152,18 +148,15 @@ objc_library(
     [
       "pop/**/*.pch"
     ]
-    ),
+  ),
   sdk_dylibs = [
     "c++"
   ],
   deps = [
-    ":pop_cxx"
-  ] + [
+    ":pop_cxx",
     ":pop_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -173,7 +166,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/pop/pod_support/Headers/Public/pop/"
   ] + [
     "-fmodule-name=pop_pod_module"
@@ -181,11 +174,9 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "pop_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/pop/pod_support_buildable:acknowledgement_fragment"
-  )
+)

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -6,7 +6,7 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes"
-  )
+)
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
 # see the bazel user manual for more information
@@ -16,19 +16,19 @@ config_setting(
   values = {
     "compilation_mode": "opt"
   }
-  )
+)
 config_setting(
   name = "iosCase",
   values = {
     "cpu": "powerpc1"
   }
-  )
+)
 config_setting(
   name = "osxCase",
   values = {
     "cpu": "powerpc2"
   }
-  )
+)
 filegroup(
   name = "youtube-ios-player-helper_cxx_hdrs",
   srcs = select(
@@ -45,7 +45,7 @@ filegroup(
           "Classes/osx/**/*.hxx"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Classes/**/*.h",
@@ -58,13 +58,13 @@ filegroup(
           "Classes/ios/**/*.hxx"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 filegroup(
   name = "youtube-ios-player-helper_cxx_union_hdrs",
   srcs = [
@@ -74,13 +74,13 @@ filegroup(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "youtube-ios-player-helper_cxx_includes",
   include = [
     "Vendor/youtube-ios-player-helper/pod_support/Headers/Public/"
   ]
-  )
+)
 objc_library(
   name = "youtube-ios-player-helper_cxx",
   enable_modules = 0,
@@ -108,7 +108,7 @@ objc_library(
           "Classes/osx/**/*.s"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Classes/**/*.cc",
@@ -131,9 +131,9 @@ objc_library(
           "Classes/ios/**/*.s"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":youtube-ios-player-helper_cxx_union_hdrs"
   ],
@@ -142,15 +142,12 @@ objc_library(
     [
       "Classes/**/*.pch"
     ]
-    ),
+  ),
   deps = [
-    ":youtube-ios-player-helper_Bundle_Assets"
-  ] + [
+    ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -160,7 +157,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/youtube-ios-player-helper/pod_support/Headers/Public/youtube-ios-player-helper/"
   ] + [
     "-fmodule-name=youtube-ios-player-helper_pod_module"
@@ -171,14 +168,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "youtube-ios-player-helper_cxx_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 swift_library(
   name = "youtube-ios-player-helper_swift",
   srcs = select(
@@ -191,7 +186,7 @@ swift_library(
           "Classes/osx/**/*.swift"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Classes/**/*.swift"
@@ -200,16 +195,14 @@ swift_library(
           "Classes/ios/**/*.swift"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets"
   ],
-  data = [
-
-  ]
-  )
+  data = []
+)
 filegroup(
   name = "youtube-ios-player-helper_hdrs",
   srcs = glob(
@@ -217,7 +210,7 @@ filegroup(
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-    ) + select(
+  ) + select(
     {
       "//conditions:default": glob(
         [
@@ -231,7 +224,7 @@ filegroup(
           "Classes/osx/**/*.hxx"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Classes/**/*.h",
@@ -244,21 +237,21 @@ filegroup(
           "Classes/ios/**/*.hxx"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ) + [
+  ) + [
     ":youtube-ios-player-helper_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 gen_includes(
   name = "youtube-ios-player-helper_includes",
   include = [
     "Vendor/youtube-ios-player-helper/pod_support/Headers/Public/"
   ]
-  )
+)
 gen_module_map(
   "youtube-ios-player-helper",
   "youtube-ios-player-helper_module_map",
@@ -266,7 +259,7 @@ gen_module_map(
   [
     "youtube-ios-player-helper_hdrs"
   ]
-  )
+)
 objc_library(
   name = "youtube-ios-player-helper",
   enable_modules = 0,
@@ -290,7 +283,7 @@ objc_library(
           "Classes/osx/**/*.s"
         ],
         exclude_directories = 1
-        ),
+      ),
       ":osxCase": glob(
         [
           "Classes/**/*.S",
@@ -309,9 +302,9 @@ objc_library(
           "Classes/ios/**/*.s"
         ],
         exclude_directories = 1
-        )
+      )
     }
-    ),
+  ),
   hdrs = [
     ":youtube-ios-player-helper_hdrs"
   ],
@@ -320,17 +313,14 @@ objc_library(
     [
       "Classes/**/*.pch"
     ]
-    ),
+  ),
   deps = [
     ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx",
-    ":youtube-ios-player-helper_swift"
-  ] + [
+    ":youtube-ios-player-helper_swift",
     ":youtube-ios-player-helper_includes"
   ],
-  copts = [
-
-  ] + select(
+  copts = select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -340,7 +330,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-    ) + [
+  ) + [
     "-IVendor/youtube-ios-player-helper/pod_support/Headers/Public/youtube-ios-player-helper/"
   ] + [
     "-fmodule-name=youtube-ios-player-helper_pod_module"
@@ -351,14 +341,12 @@ objc_library(
   visibility = [
     "//visibility:public"
   ]
-  )
+)
 acknowledged_target(
   name = "youtube-ios-player-helper_acknowledgement",
-  deps = [
-
-  ],
+  deps = [],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
-  )
+)
 apple_bundle_import(
   name = "youtube-ios-player-helper_Bundle_Assets",
   bundle_imports = glob(
@@ -366,5 +354,5 @@ apple_bundle_import(
       "youtube-ios-player-helper/Assets.bundle/**"
     ],
     exclude_directories = 1
-    )
   )
+)

--- a/Tests/PodToBUILDTests/SkylarkTests.swift
+++ b/Tests/PodToBUILDTests/SkylarkTests.swift
@@ -18,7 +18,7 @@ class PodSpecToBUILDTests: XCTestCase {
         let expected = compilerOutput([
             "objc_library(",
             "  name = \"test\"",
-            "  )",
+            ")",
         ])
         print(compiler.run())
         XCTAssertEqual(expected, compiler.run())
@@ -38,8 +38,8 @@ class PodSpecToBUILDTests: XCTestCase {
             "      \"a.m\",",
             "      \"b.m\"",
             "    ]",
-            "    )",
             "  )",
+            ")",
         ])
 
         let expectedLines = expected.components(separatedBy: "\n")


### PR DESCRIPTION
Properly de-dents the `)` at the end of a function call, represents empty arrays/dictionaries on a single line, and coalesces lists whenever possible, to make it easier to read the generated build files