### PR TITLE
Don't put resource bundles in `deps` to comply with newer `rules_apple`

### DIFF
--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -98,9 +98,7 @@ headermap(
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
-  deps = [
-    ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
-  ] + select(
+  deps = select(
     {
       "//conditions:default": [
         "//Vendor/Bolts:Bolts"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -295,9 +295,7 @@ objc_library(
       ]
     }
   ),
-  deps = [
-    ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
-  ] + select(
+  deps = select(
     {
       "//conditions:default": [
         "//Vendor/Bolts:Bolts"

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -80,7 +80,6 @@ objc_library(
     "SafariServices"
   ],
   deps = [
-    ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
     ":GoogleAppIndexing_VendoredFrameworks",
     ":GoogleAppIndexing_includes"
   ],

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -44,7 +44,6 @@ headermap(
     ":GoogleAppIndexing_hdrs"
   ],
   deps = [
-    ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
     ":GoogleAppIndexing_VendoredFrameworks"
   ],
   visibility = [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -41,7 +41,6 @@ headermap(
     "//Vendor/GTMSessionFetcher:Core",
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments",
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
-    ":GoogleSignIn_Bundle_GoogleSignIn",
     ":GoogleSignIn_VendoredFrameworks"
   ],
   visibility = [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -82,7 +82,6 @@ objc_library(
     "//Vendor/GTMSessionFetcher:Core",
     "//Vendor/GoogleToolboxForMac:NSDictionary_URLArguments",
     "//Vendor/GoogleToolboxForMac:NSString_URLArguments",
-    ":GoogleSignIn_Bundle_GoogleSignIn",
     ":GoogleSignIn_VendoredFrameworks",
     ":GoogleSignIn_includes"
   ],

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -45,9 +45,7 @@ headermap(
   hdrs = [
     ":1PasswordExtension_hdrs"
   ],
-  deps = [
-    ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
-  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -108,7 +108,6 @@ objc_library(
     "WebKit"
   ],
   deps = [
-    ":OnePasswordExtension_Bundle_OnePasswordExtensionResources",
     ":OnePasswordExtension_includes"
   ],
   copts = select(

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -47,9 +47,7 @@ headermap(
   hdrs = [
     ":Stripe_hdrs"
   ],
-  deps = [
-    ":Stripe_Bundle_Stripe"
-  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -94,7 +94,6 @@ objc_library(
     "AddressBook"
   ],
   deps = [
-    ":Stripe_Bundle_Stripe",
     ":Stripe_includes"
   ],
   copts = select(

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -80,7 +80,6 @@ objc_library(
     ]
   ),
   deps = [
-    ":iRate_Bundle_iRate",
     ":iRate_includes"
   ],
   copts = select(

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -40,9 +40,7 @@ headermap(
   hdrs = [
     ":iRate_hdrs"
   ],
-  deps = [
-    ":iRate_Bundle_iRate"
-  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -158,7 +158,6 @@ objc_library(
     ]
   ),
   deps = [
-    ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx_includes"
   ],
   copts = select(
@@ -212,9 +211,7 @@ swift_library(
       )
     }
   ),
-  deps = [
-    ":youtube-ios-player-helper_Bundle_Assets"
-  ],
+  deps = [],
   data = []
 )
 filegroup(
@@ -344,7 +341,6 @@ objc_library(
     ]
   ),
   deps = [
-    ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx",
     ":youtube-ios-player-helper_swift",
     ":youtube-ios-player-helper_includes"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -82,9 +82,7 @@ headermap(
   hdrs = [
     ":youtube-ios-player-helper_cxx_union_hdrs"
   ],
-  deps = [
-    ":youtube-ios-player-helper_Bundle_Assets"
-  ],
+  deps = [],
   visibility = [
     "//visibility:public"
   ]
@@ -264,7 +262,6 @@ headermap(
     ":youtube-ios-player-helper_hdrs"
   ],
   deps = [
-    ":youtube-ios-player-helper_Bundle_Assets",
     ":youtube-ios-player-helper_cxx",
     ":youtube-ios-player-helper_swift"
   ],

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -22,7 +22,7 @@ public protocol BuildOptions {
 
     // pod_support, everything, none
     var headerVisibility: String { get }
-    
+
     var alwaysSplitRules: Bool { get }
     var vendorize: Bool { get }
 }
@@ -157,7 +157,7 @@ public struct AcknowledgmentNode: SkylarkConvertible {
         let nodeName = bazelLabel(fromString: name + "_acknowledgement").toSkylark()
         let options = GetBuildOptions()
         let podSupportBuildableDir = String(PodSupportBuidableDir.utf8.dropLast())!
-        let value = (getRulePrefix(name: options.podName) + 
+        let value = (getRulePrefix(name: options.podName) +
              podSupportBuildableDir +
              ":acknowledgement_fragment").toSkylark()
         let target = SkylarkNode.functionCall(
@@ -368,8 +368,7 @@ public struct PodBuildFile: SkylarkConvertible {
             return result + (filteredSpecs.contains(target.name) ? [target] : [])
         }
 
-        let extraDeps = bundleLibraries(withPodSpec: podSpec) +
-            vendoredFrameworks(withPodspec: podSpec) +
+        let extraDeps = vendoredFrameworks(withPodspec: podSpec) +
             vendoredLibraries(withPodspec: podSpec)
 
         let allRootDeps = ((defaultSubspecTargets.isEmpty ? subspecTargets :
@@ -403,7 +402,9 @@ public struct PodBuildFile: SkylarkConvertible {
                                           values: ["cpu": "powerpc4"])]))
         ) ?? []
 
-        var output: [SkylarkConvertible] = configs + sourceLibs + subspecTargets + extraDeps
+        var output: [SkylarkConvertible] = configs + sourceLibs + subspecTargets +
+            bundleLibraries(withPodSpec: podSpec) + extraDeps
+
         // Execute transforms manually
         // Don't use unneeded abstractions to make a few function calls
         // (bkase) but this is isomorphic to `BuildOptions -> Endo<SkylarkConvertible>` which means we *could* make a monoid out of it http://swift.sandbox.bluemix.net/#/repl/59090e9f9def327b2a45b255


### PR DESCRIPTION
The `rules_apple` repo made a change (https://github.com/bazelbuild/rules_apple/commit/c6d0b2ceda2b7596005f6efc67546b309261e96e) which removes the `objc` provider from `apple_bundle_import`, enforcing that this is included via `data` rather than `deps`. Generated `apple_bundle_import` rules have been in both `data` and `deps` via PodToBUILD for a while, but now that they're no longer allowed in `deps` this ensures they don't end up there (but that they do make it into the generated file output).