### PR TITLE
Fix acknowlegments plist generation

### DIFF
--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -20,7 +20,7 @@ def _acknowledgement_merger_impl(ctx):
         args.append(f.path)
 
     # Write the final output. Bazel only writes the file when required
-    ctx.actions.run_shell(
+    ctx.actions.run(
         inputs=concat,
         arguments=args,
         executable=ctx.attr.merger.files.to_list()[0],

--- a/IntegrationTests/Acknowlegements/BUILD.bazel
+++ b/IntegrationTests/Acknowlegements/BUILD.bazel
@@ -1,0 +1,39 @@
+load(
+  "//BazelExtensions:extensions.bzl",
+  "acknowledgments_plist",
+  "acknowledged_target",
+)
+
+acknowledgments_plist(
+  name = "Dep_acknowlegement",
+  output_name = "dep_acknowledgement",
+  deps = [
+    ":Dep1_acknowledgement",
+    ":Dep2_acknowledgement",
+  ],
+  merger = "//BazelExtensions:acknowledgement_merger",
+)
+
+filegroup(
+    name = "acknowledgments_plist1",
+    srcs = ["acknowledgement1.plist"],
+)
+
+filegroup(
+    name = "acknowledgments_plist2",
+    srcs = ["acknowledgement2.plist"],
+)
+
+acknowledged_target(
+  name = "Dep1_acknowledgement",
+  deps = [],
+  value = ":acknowledgments_plist1",
+  merger = "//BazelExtensions:acknowledgement_merger",
+)
+
+acknowledged_target(
+  name = "Dep2_acknowledgement",
+  deps = [],
+  value = ":acknowledgments_plist2",
+  merger = "//BazelExtensions:acknowledgement_merger",
+)

--- a/IntegrationTests/Acknowlegements/acknowledgement1.plist
+++ b/IntegrationTests/Acknowlegements/acknowledgement1.plist
@@ -1,0 +1,31 @@
+<dict>
+<key>Title</key>
+<string>Third Party Dep 1</string>
+<key>Type</key>
+<string>PSGroupSpecifier</string>
+<key>License</key>
+<string>MIT</string>
+<key>FooterText</key>
+<string>Copyright (c) dep1
+http://www.dep1.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&quot;Software&quot;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</string>
+</dict>

--- a/IntegrationTests/Acknowlegements/acknowledgement2.plist
+++ b/IntegrationTests/Acknowlegements/acknowledgement2.plist
@@ -1,0 +1,31 @@
+<dict>
+<key>Title</key>
+<string>Third Party Dep 2</string>
+<key>Type</key>
+<string>PSGroupSpecifier</string>
+<key>License</key>
+<string>MIT</string>
+<key>FooterText</key>
+<string>Copyright (c) dep2
+http://www.dep2.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&quot;Software&quot;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</string>
+</dict>

--- a/IntegrationTests/RunTests.sh
+++ b/IntegrationTests/RunTests.sh
@@ -27,3 +27,7 @@ for f in $(find Examples/PodSpecs/*); do
 		exit 1
     fi
 done
+
+
+# Test that acknowledgement plist generation works
+tools/bazelwrapper build --incompatible_depset_is_not_iterable=false IntegrationTests/Acknowlegements/...


### PR DESCRIPTION
- We cannot use `run_shell` without specifying a "command", switch to
just "run"
- Add integration test so this continues to be tested