### PR TITLE
Clean up Clang module handling

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -61,14 +61,6 @@ gen_includes(
     "Vendor/Adjust/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Adjust",
-  "Adjust_module_map",
-  "Adjust",
-  [
-    "Adjust_hdrs"
-  ]
-)
 objc_library(
   name = "Adjust",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -75,14 +75,6 @@ gen_includes(
     "Vendor/Bolts/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Bolts",
-  "Bolts_module_map",
-  "Bolts",
-  [
-    "Bolts_hdrs"
-  ]
-)
 objc_library(
   name = "Bolts",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -56,14 +56,6 @@ gen_includes(
     "Vendor/Braintree/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Braintree",
-  "Braintree_module_map",
-  "Braintree",
-  [
-    "Braintree_hdrs"
-  ]
-)
 objc_library(
   name = "Braintree",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -51,14 +51,6 @@ gen_includes(
     "Vendor/Branch/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Branch",
-  "Branch_module_map",
-  "Branch",
-  [
-    "Branch_hdrs"
-  ]
-)
 objc_library(
   name = "Branch",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -189,14 +189,6 @@ gen_includes(
     "Vendor/Calabash/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Calabash",
-  "Calabash_module_map",
-  "Calabash",
-  [
-    "Calabash_hdrs"
-  ]
-)
 objc_library(
   name = "Calabash",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -52,14 +52,6 @@ gen_includes(
     "Vendor/CardIO/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "CardIO",
-  "CardIO_module_map",
-  "CardIO",
-  [
-    "CardIO_hdrs"
-  ]
-)
 objc_library(
   name = "CardIO",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/ColorCube/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "ColorCube",
-  "ColorCube_module_map",
-  "ColorCube",
-  [
-    "ColorCube_hdrs"
-  ]
-)
 objc_library(
   name = "ColorCube",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -54,14 +54,6 @@ gen_includes(
     "Vendor/EarlGrey/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "EarlGrey",
-  "EarlGrey_module_map",
-  "EarlGrey",
-  [
-    "EarlGrey_hdrs"
-  ]
-)
 objc_library(
   name = "EarlGrey",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -115,14 +115,6 @@ gen_includes(
     "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FBSDKCoreKit",
-  "FBSDKCoreKit_module_map",
-  "FBSDKCoreKit",
-  [
-    "FBSDKCoreKit_hdrs"
-  ]
-)
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -52,14 +52,6 @@ gen_includes(
     "Vendor/FBSDKLoginKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FBSDKLoginKit",
-  "FBSDKLoginKit_module_map",
-  "FBSDKLoginKit",
-  [
-    "FBSDKLoginKit_hdrs"
-  ]
-)
 objc_library(
   name = "FBSDKLoginKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -53,14 +53,6 @@ gen_includes(
     "Vendor/FBSDKMessengerShareKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FBSDKMessengerShareKit",
-  "FBSDKMessengerShareKit_module_map",
-  "FBSDKMessengerShareKit",
-  [
-    "FBSDKMessengerShareKit_hdrs"
-  ]
-)
 objc_library(
   name = "FBSDKMessengerShareKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -107,14 +107,6 @@ gen_includes(
     "Vendor/FBSDKShareKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FBSDKShareKit",
-  "FBSDKShareKit_module_map",
-  "FBSDKShareKit",
-  [
-    "FBSDKShareKit_hdrs"
-  ]
-)
 objc_library(
   name = "FBSDKShareKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/FLAnimatedImage/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FLAnimatedImage",
-  "FLAnimatedImage_module_map",
-  "FLAnimatedImage",
-  [
-    "FLAnimatedImage_hdrs"
-  ]
-)
 objc_library(
   name = "FLAnimatedImage",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/FLEX/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FLEX",
-  "FLEX_module_map",
-  "FLEX",
-  [
-    "FLEX_hdrs"
-  ]
-)
 objc_library(
   name = "FLEX",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -49,14 +49,6 @@ gen_includes(
     "Vendor/FMDB/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FMDB",
-  "FMDB_module_map",
-  "FMDB",
-  [
-    "FMDB_hdrs"
-  ]
-)
 objc_library(
   name = "FMDB",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -58,14 +58,6 @@ gen_includes(
     "Vendor/DoubleConversion"
   ]
 )
-gen_module_map(
-  "folly",
-  "Folly_module_map",
-  "folly",
-  [
-    "Folly_hdrs"
-  ]
-)
 objc_library(
   name = "Folly",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -56,14 +56,6 @@ gen_includes(
     "Vendor/GoogleAppIndexing/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleAppIndexing",
-  "GoogleAppIndexing_module_map",
-  "GoogleAppIndexing",
-  [
-    "GoogleAppIndexing_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleAppIndexing",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -49,14 +49,6 @@ gen_includes(
     "Vendor/GoogleAppUtilities/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleAppUtilities",
-  "GoogleAppUtilities_module_map",
-  "GoogleAppUtilities",
-  [
-    "GoogleAppUtilities_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleAppUtilities",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/GoogleAuthUtilities/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleAuthUtilities",
-  "GoogleAuthUtilities_module_map",
-  "GoogleAuthUtilities",
-  [
-    "GoogleAuthUtilities_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleAuthUtilities",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -49,14 +49,6 @@ gen_includes(
     "Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleNetworkingUtilities",
-  "GoogleNetworkingUtilities_module_map",
-  "GoogleNetworkingUtilities",
-  [
-    "GoogleNetworkingUtilities_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleNetworkingUtilities",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -53,14 +53,6 @@ gen_includes(
     "Vendor/GoogleSignIn/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleSignIn",
-  "GoogleSignIn_module_map",
-  "GoogleSignIn",
-  [
-    "GoogleSignIn_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleSignIn",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -48,14 +48,6 @@ gen_includes(
     "Vendor/GoogleSymbolUtilities/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleSymbolUtilities",
-  "GoogleSymbolUtilities_module_map",
-  "GoogleSymbolUtilities",
-  [
-    "GoogleSymbolUtilities_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleSymbolUtilities",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -49,14 +49,6 @@ gen_includes(
     "Vendor/GoogleUtilities/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "GoogleUtilities",
-  "GoogleUtilities_module_map",
-  "GoogleUtilities",
-  [
-    "GoogleUtilities_hdrs"
-  ]
-)
 objc_library(
   name = "GoogleUtilities",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/IBActionSheet/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "IBActionSheet",
-  "IBActionSheet_module_map",
-  "IBActionSheet",
-  [
-    "IBActionSheet_hdrs"
-  ]
-)
 objc_library(
   name = "IBActionSheet",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -67,14 +67,6 @@ gen_includes(
     "Vendor/IGListKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "IGListKit",
-  "IGListKit_module_map",
-  "IGListKit",
-  [
-    "IGListKit_hdrs"
-  ]
-)
 objc_library(
   name = "IGListKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/KVOController/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "KVOController",
-  "KVOController_module_map",
-  "KVOController",
-  [
-    "KVOController_hdrs"
-  ]
-)
 objc_library(
   name = "KVOController",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -68,14 +68,6 @@ gen_includes(
     "Vendor/Masonry/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Masonry",
-  "Masonry_module_map",
-  "Masonry",
-  [
-    "Masonry_hdrs"
-  ]
-)
 objc_library(
   name = "Masonry",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -56,14 +56,6 @@ gen_includes(
     "Vendor/OnePasswordExtension/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "OnePasswordExtension",
-  "1PasswordExtension_module_map",
-  "OnePasswordExtension",
-  [
-    "1PasswordExtension_hdrs"
-  ]
-)
 alias(
   name = "1PasswordExtension",
   actual = "OnePasswordExtension",

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -63,14 +63,6 @@ gen_includes(
     "Vendor/PINCache/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "PINCache",
-  "PINCache_module_map",
-  "PINCache",
-  [
-    "PINCache_hdrs"
-  ]
-)
 objc_library(
   name = "PINCache",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -144,14 +144,6 @@ gen_includes(
     "Vendor/PINOperation/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "PINOperation",
-  "PINOperation_module_map",
-  "PINOperation",
-  [
-    "PINOperation_hdrs"
-  ]
-)
 objc_library(
   name = "PINOperation",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -51,14 +51,6 @@ gen_includes(
     "Vendor/PINRemoteImage/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "PINRemoteImage",
-  "PINRemoteImage_module_map",
-  "PINRemoteImage",
-  [
-    "PINRemoteImage_hdrs"
-  ]
-)
 objc_library(
   name = "PINRemoteImage",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/PaymentKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "PaymentKit",
-  "PaymentKit_module_map",
-  "PaymentKit",
-  [
-    "PaymentKit_hdrs"
-  ]
-)
 objc_library(
   name = "PaymentKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/RadarKit/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "RadarKit",
-  "RadarKit_module_map",
-  "RadarKit",
-  [
-    "RadarKit_hdrs"
-  ]
-)
 objc_library(
   name = "RadarKit",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -62,14 +62,6 @@ gen_includes(
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "React",
-  "React_module_map",
-  "React",
-  [
-    "React_hdrs"
-  ]
-)
 objc_library(
   name = "React",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -68,14 +68,6 @@ gen_includes(
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "React",
-  "React_module_map",
-  "React",
-  [
-    "React_hdrs"
-  ]
-)
 objc_library(
   name = "React",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -175,14 +175,6 @@ gen_includes(
     "Vendor/SFHFKeychainUtils/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "SFHFKeychainUtils",
-  "SFHFKeychainUtils_module_map",
-  "SFHFKeychainUtils",
-  [
-    "SFHFKeychainUtils_hdrs"
-  ]
-)
 objc_library(
   name = "SFHFKeychainUtils",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/SPUserResizableView+Pion/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "SPUserResizableView+Pion",
-  "SPUserResizableView+Pion_module_map",
-  "SPUserResizableView+Pion",
-  [
-    "SPUserResizableView+Pion_hdrs"
-  ]
-)
 objc_library(
   name = "SPUserResizableView+Pion",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/SlackTextViewController/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "SlackTextViewController",
-  "SlackTextViewController_module_map",
-  "SlackTextViewController",
-  [
-    "SlackTextViewController_hdrs"
-  ]
-)
 objc_library(
   name = "SlackTextViewController",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/Smartling/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Smartling",
-  "Smartling_module_map",
-  "Smartling",
-  [
-    "Smartling_hdrs"
-  ]
-)
 objc_library(
   name = "Smartling",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -58,14 +58,6 @@ gen_includes(
     "Vendor/Stripe/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Stripe",
-  "Stripe_module_map",
-  "Stripe",
-  [
-    "Stripe_hdrs"
-  ]
-)
 objc_library(
   name = "Stripe",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -62,14 +62,6 @@ gen_includes(
     "Vendor/Texture/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "AsyncDisplayKit",
-  "Texture_module_map",
-  "AsyncDisplayKit",
-  [
-    "Texture_hdrs"
-  ]
-)
 objc_library(
   name = "Texture",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -164,14 +164,6 @@ gen_includes(
     "Vendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "UICollectionViewLeftAlignedLayout",
-  "UICollectionViewLeftAlignedLayout_module_map",
-  "UICollectionViewLeftAlignedLayout",
-  [
-    "UICollectionViewLeftAlignedLayout_hdrs"
-  ]
-)
 objc_library(
   name = "UICollectionViewLeftAlignedLayout",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -52,14 +52,6 @@ gen_includes(
     "Vendor/Weixin/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "Weixin",
-  "Weixin_module_map",
-  "Weixin",
-  [
-    "Weixin_hdrs"
-  ]
-)
 objc_library(
   name = "Weixin",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -55,14 +55,6 @@ gen_includes(
     "Vendor/ZipArchive/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "ZipArchive",
-  "ZipArchive_module_map",
-  "ZipArchive",
-  [
-    "ZipArchive_hdrs"
-  ]
-)
 objc_library(
   name = "ZipArchive",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -52,14 +52,6 @@ gen_includes(
     "Vendor/boost-for-react-native/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "boost",
-  "boost-for-react-native_module_map",
-  "boost",
-  [
-    "boost-for-react-native_hdrs"
-  ]
-)
 objc_library(
   name = "boost-for-react-native",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -60,14 +60,6 @@ gen_includes(
     "Vendor/glog/src"
   ]
 )
-gen_module_map(
-  "glog",
-  "glog_module_map",
-  "glog",
-  [
-    "glog_hdrs"
-  ]
-)
 objc_library(
   name = "glog",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -52,14 +52,6 @@ gen_includes(
     "Vendor/googleapis/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "googleapis",
-  "googleapis_module_map",
-  "googleapis",
-  [
-    "googleapis_hdrs"
-  ]
-)
 objc_library(
   name = "googleapis",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -48,14 +48,6 @@ gen_includes(
     "Vendor/iOSSnapshotTestCase/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "FBSnapshotTestCase",
-  "iOSSnapshotTestCase_module_map",
-  "FBSnapshotTestCase",
-  [
-    "iOSSnapshotTestCase_hdrs"
-  ]
-)
 objc_library(
   name = "iOSSnapshotTestCase",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -51,14 +51,6 @@ gen_includes(
     "Vendor/iRate/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "iRate",
-  "iRate_module_map",
-  "iRate",
-  [
-    "iRate_hdrs"
-  ]
-)
 objc_library(
   name = "iRate",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -50,14 +50,6 @@ gen_includes(
     "Vendor/kingpin/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "kingpin",
-  "kingpin_module_map",
-  "kingpin",
-  [
-    "kingpin_hdrs"
-  ]
-)
 objc_library(
   name = "kingpin",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -148,14 +148,6 @@ gen_includes(
     "Vendor/pop/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "pop",
-  "pop_module_map",
-  "pop",
-  [
-    "pop_hdrs"
-  ]
-)
 objc_library(
   name = "pop",
   enable_modules = 0,

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -275,14 +275,6 @@ gen_includes(
     "Vendor/youtube-ios-player-helper/pod_support/Headers/Public/"
   ]
 )
-gen_module_map(
-  "youtube-ios-player-helper",
-  "youtube-ios-player-helper_module_map",
-  "youtube_ios_player_helper",
-  [
-    "youtube-ios-player-helper_hdrs"
-  ]
-)
 objc_library(
   name = "youtube-ios-player-helper",
   enable_modules = 0,

--- a/IntegrationTests/RunTests.sh
+++ b/IntegrationTests/RunTests.sh
@@ -10,21 +10,21 @@ CMD=bin/Compiler
 # Loop through all the examples and compare outputs
 for f in $(find Examples/PodSpecs/*); do
     GOLD_MASTER=`cat IntegrationTests/GoldMaster/$(basename $f).goldmaster`
-	TEMP_F=$(mktemp)
-	OUTPUT=$($CMD $f | tee $TEMP_F)
+    TEMP_F=$(mktemp)
+    OUTPUT=$($CMD $f | tee $TEMP_F)
 
     if [[ "$OUTPUT" == "$GOLD_MASTER" ]]; then
         echo "PASS $f"
     else
         echo "EXPECTED $GOLD_MASTER"
         echo "===BEGIN OUTPUT==="
-		echo "$OUTPUT"
+        echo "$OUTPUT"
         echo "===END OUTPUT==="
         echo "===BEGIN DIFF==="
-		echo "$(diff IntegrationTests/GoldMaster/$(basename $f).goldmaster $TEMP_F)"
+        echo "$(diff IntegrationTests/GoldMaster/$(basename $f).goldmaster $TEMP_F)"
         echo "===END DIFF==="
         echo "FAILURE $f"
-		exit 1
+        exit 1
     fi
 done
 

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -325,19 +325,9 @@ public enum RepoActions {
         // - Get all of the paths matching wild card imports
         // - Put them into the public header directory
         let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions: buildOptions)
-        let globResultsArr = buildFile.skylarkConvertibles.compactMap { $0 as? ObjcLibrary }
-            .flatMap {
-                objcLibrary -> Set<String> in
-                let headers: GlobNode = objcLibrary.headers
-                return headers.include.fold(basic: { (patterns: Set<String>?) -> Set<String> in
-                    let s: Set<String> = Set(patterns.map { $0.flatMap(podGlob) } ?? [])
-                    return s
-                }, multi: { (set: Set<String>, multi: MultiPlatform<Set<String>>) -> Set<String> in
-                    let inner: Set<String>? = multi |>
-                        MultiPlatform<Set<String>>.lens.viewAll { Set($0.flatMap(podGlob)) }
-                    return set.union(inner.denormalize())
-                })
-        }
+        let globResultsArr = buildFile.skylarkConvertibles
+                .compactMap { $0 as? ObjcLibrary }
+                .flatMap { podGlobSet(patternSet: $0.headers.include) }
 
         // Batch create several symlinks for Pod style includes
         // creating thousands of processes in few milliseconds will


### PR DESCRIPTION
Makes a couple of changes to make Clang modules work better with generated libraries. Namely:
- Only include public files in generated modulemap files. Previously it would include every header, which would A) potentially add headers from other modules (eg in React where multiple modules share a source directory) or include headers that aren't supposed to be compileable externally (eg all of Yoga's public headers handle both C and C++, but its internal ones assume C++ and would break when being used from a C translation unit).
- Generate module maps for each target, not just the top-level target, since they will (likely) have different sources from the top-level one.
- Populate the `module_map` attribute in the `objc_library` rule so Bazel doesn't generate its own module map.
- Explicitly specify `-fmodules` if we have modules enabled. I'm not sure why, but I was running into cases where Bazel *wouldn't* pass that flag to Clang even when modules were enabled.
- Only generate `gen_module_map` rule if module map generation is on.