### PR TITLE
Handle header patterns that start with "**/"

### DIFF
--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -161,6 +161,9 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":Calabash_cxx_hdrs"

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "CardIO/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "ColorCube/ColorCube/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -47,7 +47,8 @@ filegroup(
           "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
           "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
           "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx",
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       ),
@@ -82,7 +83,8 @@ filegroup(
           "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
           "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
           "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
-          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx",
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       )

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -30,6 +30,9 @@ filegroup(
       "FBSDKMessengerShareKit/**/*.hxx",
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -46,7 +46,8 @@ filegroup(
         ],
         exclude = [
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       ),
@@ -79,6 +80,9 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ],
+        exclude = [
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       )

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "FLAnimatedImage/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "Classes/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -29,6 +29,9 @@ filegroup(
       "folly/detail/*.h",
       "folly/portability/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -31,6 +31,9 @@ filegroup(
       "Changelog/**/*.hpp",
       "Changelog/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "FBKVOController/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -45,6 +45,9 @@ filegroup(
     [
       "Masonry/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -31,7 +31,8 @@ filegroup(
     exclude = [
       "Demos/**/*.h",
       "Demos/**/*.hpp",
-      "Demos/**/*.hxx"
+      "Demos/**/*.hxx",
+      "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
   ),

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -117,6 +117,9 @@ filegroup(
     [
       "Source/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":PINOperation_cxx_hdrs"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "PaymentKit/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "RadarKit/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -41,6 +41,9 @@ filegroup(
       "react-native-cli/**/*.hpp",
       "react-native-cli/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":Core_hdrs"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -147,6 +147,9 @@ filegroup(
       "security/**/*.hpp",
       "security/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":SFHFKeychainUtils_cxx_hdrs"

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "SPUserResizableView/SPUserResizableView.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "Source/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -35,6 +35,9 @@ filegroup(
       "Stripe/*.h",
       "Stripe/PublicHeaders/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -29,6 +29,9 @@ filegroup(
       "AsyncDisplayKit/**/*.hpp",
       "AsyncDisplayKit/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":PINRemoteImage_hdrs",

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -136,6 +136,9 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "SDK1.6.2/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -32,6 +32,9 @@ filegroup(
       "minizip/unzip.h",
       "minizip/zip.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -29,6 +29,9 @@ filegroup(
       "boost/**/*.hpp",
       "boost/**/*.hxx"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -33,6 +33,7 @@ filegroup(
       "src/glog/*.h"
     ],
     exclude = [
+      "pod_support/Headers/Public/**/*",
       "src/windows/**/*.h",
       "src/windows/**/*.hpp",
       "src/windows/**/*.hxx"

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -28,6 +28,9 @@ filegroup(
     [
       "iRate/iRate.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -27,6 +27,9 @@ filegroup(
     [
       "kingpin/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -121,6 +121,9 @@ filegroup(
     [
       "pop/**/*.h"
     ],
+    exclude = [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":pop_cxx_hdrs"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -230,7 +230,8 @@ filegroup(
         exclude = [
           "Classes/osx/**/*.h",
           "Classes/osx/**/*.hpp",
-          "Classes/osx/**/*.hxx"
+          "Classes/osx/**/*.hxx",
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       ),
@@ -243,7 +244,8 @@ filegroup(
         exclude = [
           "Classes/ios/**/*.h",
           "Classes/ios/**/*.hpp",
-          "Classes/ios/**/*.hxx"
+          "Classes/ios/**/*.hxx",
+          "pod_support/Headers/Public/**/*"
         ],
         exclude_directories = 1
       )

--- a/Sources/PodToBUILD/GlobUtils.swift
+++ b/Sources/PodToBUILD/GlobUtils.swift
@@ -121,12 +121,16 @@ public class Glob: Collection {
 
         var results = [String]()
         var parts = pattern.components(separatedBy: "**")
-        let firstPart = parts.removeFirst()
+        var firstPart = parts.removeFirst()
         var lastPart = parts.joined(separator: "**")
 
         let fileManager = FileManager.default
 
         var directories: [String]
+
+        if firstPart.isEmpty {
+            firstPart = "."
+        }
 
         do {
             directories = try fileManager.subpathsOfDirectory(atPath: firstPart).compactMap { subpath in


### PR DESCRIPTION
Some podspecs just include all files under their directory (eg [RCTText](https://github.com/facebook/react-native/blob/0.61-stable/Libraries/Text/React-RCTText.podspec#L30)). This breaks PodToBUILD both during generation (it passed an empty string to `fileManager.subpathsOfDirectory`, which threw an error) and at runtime (it double included the `pod_support` headers, which caused Bazel to fail). This fixes both of those issues.