### PR TITLE
Support nested pods, or pods inside of a pod

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,7 @@ swift_library(
     name = "PodToBUILD",
     srcs = glob(["Sources/PodToBUILD/*.swift"]),
     deps = [":ObjcSupport"],
-    copts = ["-swift-version", "4", "-static-stdlib"],
+    copts = ["-swift-version", "4"],
 )
 
 # Compiler
@@ -46,7 +46,7 @@ swift_library(
     name = "RepoToolsCore",
     srcs = glob(["Sources/RepoToolsCore/*.swift"]),
     deps = [":PodToBUILD"],
-    copts = ["-swift-version", "4", "-static-stdlib"],
+    copts = ["-swift-version", "4"],
 )
 
 alias(name = "update_pods", actual = "//bin:update_pods")

--- a/Sources/PodToBUILD/Alias.swift
+++ b/Sources/PodToBUILD/Alias.swift
@@ -1,0 +1,32 @@
+//
+//  Alias.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 3/25/2020.
+//  Copyright © 2020 Pinterest Inc. All rights reserved.
+
+/// This represents an alias in Bazel
+/// https://docs.bazel.build/versions/master/be/general.html#alias
+public struct Alias : BazelTarget {
+    let name: String
+    let actual: String
+
+    public init(name: String, actual: String) {
+        self.name = name
+        self.actual = actual
+    }
+
+    var acknowledged: Bool {
+        return false
+    }
+
+    public func toSkylark() -> SkylarkNode {
+        return .functionCall(
+            name: "alias",
+            arguments: [
+                .named(name: "name", value: bazelLabel(fromString: name).toSkylark()),
+                .named(name: "actual", value: actual.toSkylark()),
+                ])
+    }
+}
+

--- a/Sources/PodToBUILD/BazelConstants.swift
+++ b/Sources/PodToBUILD/BazelConstants.swift
@@ -1,0 +1,18 @@
+//
+//  BazelConstants.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 4/14/17.
+//  Copyright © 2017 Pinterest Inc. All rights reserved.
+//
+import Foundation
+
+public struct BazelConstants {
+    public static let buildFilePath = "BUILD.bazel"
+
+    /// Note: this is a factory, because we change directories. URL ends up
+    /// caching paths relative to the CWD.
+    public static func buildFileURL() -> URL {
+        return URL(fileURLWithPath: buildFilePath)
+    }
+}

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -130,8 +130,10 @@ public struct PodBuildFile: SkylarkConvertible {
     /// Skylark Convertibles excluding prefix nodes.
     /// @note Use toSkylark() to generate the actual BUILD file
     public let skylarkConvertibles: [SkylarkConvertible]
-    public let assimilate: Bool
 
+    /// When there is a podspec adjacent to another, we need to concat
+    /// the "child" BUILD file into the parents
+    public let assimilate: Bool
 
     public static func shouldAssimilate(buildOptions: BuildOptions) -> Bool {
         return buildOptions.path != "." &&

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -125,7 +125,7 @@ public struct PodBuildFile: SkylarkConvertible {
 
 
     public static func shouldAssimilate(buildOptions: BuildOptions) -> Bool {
-        let buildFilePath = URL(fileURLWithPath: "BUILD")
+        let buildFilePath = URL(fileURLWithPath: "BUILD.bazel")
         return buildOptions.path != "." &&
             FileManager.default.fileExists(atPath: buildFilePath.relativePath)
     }

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -5,6 +5,7 @@
 //  Created by Jerry Marino on 4/14/17.
 //  Copyright © 2017 Pinterest Inc. All rights reserved.
 //
+
 import Foundation
 
 private var sharedBuildOptions: BuildOptions = BasicBuildOptions.empty
@@ -125,9 +126,8 @@ public struct PodBuildFile: SkylarkConvertible {
 
 
     public static func shouldAssimilate(buildOptions: BuildOptions) -> Bool {
-        let buildFilePath = URL(fileURLWithPath: "BUILD.bazel")
         return buildOptions.path != "." &&
-            FileManager.default.fileExists(atPath: buildFilePath.relativePath)
+            FileManager.default.fileExists(atPath: BazelConstants.buildFilePath)
     }
 
     /// Return the skylark representation of the entire BUILD file

--- a/Sources/PodToBUILD/BuildOptions.swift
+++ b/Sources/PodToBUILD/BuildOptions.swift
@@ -1,0 +1,72 @@
+//
+//  BuildOptions.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 3/25/2020.
+//  Copyright © 2020 Pinterest Inc. All rights reserved.
+
+public protocol BuildOptions {
+    var userOptions: [String] { get }
+    var globalCopts: [String] { get }
+    var trace: Bool { get }
+    var podName: String { get }
+    var path: String { get }
+
+    // Frontend options
+
+    var enableModules: Bool { get }
+    var generateModuleMap: Bool { get }
+    var generateHeaderMap: Bool { get }
+
+    // pod_support, everything, none
+    var headerVisibility: String { get }
+    
+    var alwaysSplitRules: Bool { get }
+    var vendorize: Bool { get }
+    var childPaths: [String] { get }
+}
+
+public struct BasicBuildOptions: BuildOptions {
+    public let podName: String
+    public let path: String
+    public let userOptions: [String]
+    public let globalCopts: [String]
+    public let trace: Bool
+
+    public let enableModules: Bool
+    public let generateModuleMap: Bool
+    public let generateHeaderMap: Bool
+    public let headerVisibility: String
+    public let alwaysSplitRules: Bool
+    public let vendorize: Bool
+    public let childPaths: [String]
+
+    public init(podName: String = "",
+                path: String = ".",
+                userOptions: [String] = [],
+                globalCopts: [String] = [],
+                trace: Bool = false,
+                enableModules: Bool = false,
+                generateModuleMap: Bool = false,
+                generateHeaderMap: Bool = false,
+                headerVisibility: String = "",
+                alwaysSplitRules: Bool = true,
+                vendorize: Bool = true,
+                childPaths: [String] = []
+    ) {
+        self.podName = podName
+        self.path = path
+        self.userOptions = userOptions
+        self.globalCopts = globalCopts
+        self.trace = trace
+        self.enableModules = enableModules
+        self.generateModuleMap = generateModuleMap
+        self.generateHeaderMap = generateHeaderMap
+        self.headerVisibility = headerVisibility
+        self.alwaysSplitRules = alwaysSplitRules
+        self.vendorize = vendorize
+        self.childPaths = childPaths
+    }
+
+    public static let empty = BasicBuildOptions(podName: "")
+}

--- a/Sources/PodToBUILD/GlobUtils.swift
+++ b/Sources/PodToBUILD/GlobUtils.swift
@@ -121,9 +121,12 @@ public class Glob: Collection {
 
         var results = [String]()
         var parts = pattern.components(separatedBy: "**")
-        let firstPart = parts.removeFirst()
+        var firstPart = parts.removeFirst()
         var lastPart = parts.joined(separator: "**")
 
+        if firstPart == "" {
+            firstPart = "."
+        }
         let fileManager = FileManager.default
 
         var directories: [String]

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -674,9 +674,8 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         let getPodIQuotes = {
             () -> [String] in
             if options.generateHeaderMap {
-                let podName = GetBuildOptions().podName
                 return [
-                    "-I$(GENDIR)/\(getPodBaseDir())/\(podName)/" + lib.name + "_hmap.hmap",
+                    "-I$(GENDIR)/\(getGenfileOutputBaseDir())/" + lib.name + "_hmap.hmap",
                     "-I.", 
                 ]
             }

--- a/Sources/PodToBUILD/RuleUtils.swift
+++ b/Sources/PodToBUILD/RuleUtils.swift
@@ -65,6 +65,18 @@ public func getPodBaseDir() -> String {
     return options.vendorize ? "Vendor" : "external"
 }
 
+/// We need to hardcode a copt to the $(GENDIR) for simplicity.
+/// Expansion of $(location //target) is not supported in known Xcode generators
+public func getGenfileOutputBaseDir() -> String {
+    let options = GetBuildOptions()
+    let basePath = options.vendorize ? "Vendor" : "external"
+    let podName = options.podName
+    if options.path ==  "." {
+        return "\(basePath)/\(podName)"
+    }
+    return options.path
+}
+
 /// Compute the name of a lib
 public func computeLibName(rootSpec: PodSpec? = nil, spec: PodSpec, podName: String, isSplitDep: Bool = false, sourceType: BazelSourceLibType) -> String {
     let splitSuffix = isSplitDep ? sourceType.getLibNameSuffix() : ""

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -475,7 +475,7 @@ public enum RepoActions {
         }
         let nestingDepth = buildOptions.path.split(separator: "/").count
         let relativePathToWorkspace = (0..<nestingDepth).map { _ in ".." }.joined(separator: "/") 
-        return "\(relativePathToWorkspace)/../../../Vendor/rules_pods/BazelExtensions"
+        return "\(relativePathToWorkspace)/../Vendor/rules_pods/BazelExtensions"
     }
 
     /// Fetch pods from urls.

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -450,7 +450,6 @@ public enum RepoActions {
         let buildFileSkylarkCompiler = SkylarkCompiler(buildFile.toSkylark())
         let buildFileOut = buildFileSkylarkCompiler.run()
         let buildFilePath = URL(fileURLWithPath: "BUILD.bazel")
-        shell.write(value: buildFileOut, toPath: buildFilePath)
 
         // When there is a "child" podspec adjacent to a parent, concat the
         // "child" BUILD file into the parents

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -78,6 +78,7 @@ public enum SerializedRepoToolsAction {
         // First arg is the path, we don't care about it
         // The right most option will be the winner.
         var options: [String: CLIArgumentType] = [
+            "--path": .string,
             "--user_option": .stringList,
             "--global_copt": .string,
             "--trace": .bool,
@@ -86,6 +87,7 @@ public enum SerializedRepoToolsAction {
             "--generate_header_map": .bool,
             "--vendorize": .bool,
             "--header_visibility": .string,
+            "--child_path": .stringList,
         ]
 
         var idx = 0
@@ -128,21 +130,23 @@ public enum SerializedRepoToolsAction {
                 }
                 parsed[arg] = collected
             } else {
-                print("Invalid Arg: " + arg)
+                print("Invalid Arg: \(arg)")
                 error()
             }
         }
 
         return BasicBuildOptions(podName: podName,
-                                 userOptions: parsed["--user_option"] as? [String] ?? [String](),
-                                 globalCopts: parsed["--global_copt"] as? [String] ?? [String](),
+                                 path: parsed["--path"]?.first as? String ?? ".",
+                                 userOptions: parsed["--user_option"] as? [String] ?? [],
+                                 globalCopts: parsed["--global_copt"] as? [String] ?? [],
                                  trace: parsed["--trace"]?.first as? Bool ?? false,
                                  enableModules: parsed["--enable_modules"]?.first as? Bool ?? false,
                                  generateModuleMap: parsed["--generate_module_map"]?.first as? Bool ?? false,
                                  generateHeaderMap: parsed["--generate_header_map"]?.first as? Bool ?? false,
                                  headerVisibility: parsed["--header_visibility"]?.first as? String ?? "",
                                  alwaysSplitRules: false,
-                                 vendorize: parsed["--vendorize"]?.first as? Bool ?? true
+                                 vendorize: parsed["--vendorize"]?.first as? Bool ?? true,
+                                 childPaths: parsed["--child_path"] as? [String] ?? []
         )
     }
 }
@@ -192,13 +196,69 @@ public enum RepoActions {
     /// - Get the IPC JSON PodSpec
     /// - Compile a build file based on the PodSpec
     /// - Create a symLinked header structure to support angle bracket includes
-    public static func initializeRepository(shell: ShellContext, buildOptions: BasicBuildOptions) {
+    public static func initializeRepository(shell: ShellContext, buildOptions: BuildOptions) {
+        let podspecName = CommandLine.arguments[1]
+        if buildOptions.path != "." && buildOptions.childPaths.count == 0 {
+            // Write an alias BUILD file that points to the source directory
+            let visibility = SkylarkNode.functionCall(name: "package",
+                arguments: [
+                    .named(name: "default_visibility",
+                           value: .list([.string("//visibility:public")]))
+                ])
+            let alias = Alias(name: podspecName,
+                actual: "//" + buildOptions.path + ":" + podspecName)
+            let compiler = SkylarkCompiler(.lines([
+                    visibility.toSkylark(),
+                    alias.toSkylark()
+            ]))
+            shell.write(value: compiler.run(), toPath: URL(fileURLWithPath: "BUILD"))
+            return
+        }
+
+        initializePodspecDirectory(shell: shell, podspecName: podspecName,
+                buildOptions: buildOptions)
+        let currentDirectoryPath = FileManager.default.currentDirectoryPath
+        // Child podspec logic - initializes a child pod, for a given Podspec url
+        var childInfoIter = buildOptions.childPaths.makeIterator()
+        while let childInfo = childInfoIter.next() {
+            let childName = childInfo
+            guard let childPath = childInfoIter.next() else {
+                fatalError("Invalid path in update_pods.py")
+            }
+            let childBuildOptions = BasicBuildOptions(
+                podName: childName,
+                path: childPath,
+                userOptions: buildOptions.userOptions,
+                globalCopts: buildOptions.globalCopts,
+                trace: buildOptions.trace,
+                enableModules: buildOptions.enableModules,
+                generateModuleMap: buildOptions.generateModuleMap,
+                generateHeaderMap: buildOptions.generateHeaderMap,
+                headerVisibility: buildOptions.headerVisibility,
+                alwaysSplitRules: buildOptions.alwaysSplitRules,
+                vendorize: buildOptions.vendorize,
+                childPaths: buildOptions.childPaths)
+            let absPath = "\(currentDirectoryPath)/../../\(childPath)"
+            guard
+            FileManager.default.changeCurrentDirectoryPath(
+                absPath) else {
+                fatalError("Can't change path to child subspec path: " + String(describing: absPath))
+            }
+
+            initializePodspecDirectory(shell: shell, podspecName: childName,
+                buildOptions: childBuildOptions)
+            guard FileManager.default.changeCurrentDirectoryPath(currentDirectoryPath) else {
+                fatalError("Can't change path back to original directory after genning subspec")
+            }
+        }
+    }
+
+    private static func initializePodspecDirectory(shell: ShellContext, podspecName: String,buildOptions: BuildOptions) {
         // This uses the current environment's cocoapods installation.
         let whichPod = shell.shellOut("which pod").standardOutputAsString
         if whichPod.isEmpty {
             fatalError("RepoTools requires a cocoapod installation on host")
         }
-        let podspecName = CommandLine.arguments[1]
 
         // make json data
         let jsonData: Data
@@ -207,16 +267,18 @@ public enum RepoActions {
             return shell.command("/bin/[",
                           arguments: ["-e", file, "]"]).terminationStatus == 0
         }
-        let hasPodspec: () -> Bool = {
-            hasFile(FileManager.default.currentDirectoryPath + "/" + podspecName
-                    + ".podspec") }
-        let hasPodspecJson: () -> Bool = {
-            hasFile(FileManager.default.currentDirectoryPath + "/"
-                    + podspecName + ".podspec.json") }
 
-        if hasPodspecJson() {
+        let workspaceRootPath: String
+        if buildOptions.path != "." && buildOptions.childPaths.count == 0 {
+            workspaceRootPath = "../..\(buildOptions.path)"
+        } else {
+            workspaceRootPath =  "."
+        }
+
+        let podspecPath = "\(workspaceRootPath)/\(podspecName).podspec"
+        if hasFile("\(podspecPath).json") {
             jsonData = shell.command("/bin/cat", arguments: [podspecName + ".podspec.json"]).standardOutputData
-        } else if hasPodspec() {
+        } else if hasFile(podspecPath) {
             let podBin = whichPod.components(separatedBy: "\n")[0]
             let podResult = shell.command(podBin, arguments: ["ipc", "spec", podspecName + ".podspec"])
             guard podResult.terminationStatus == 0 else {
@@ -228,7 +290,7 @@ public enum RepoActions {
             }
             jsonData = podResult.standardOutputData
         } else {
-            fatalError("Missing podspec!")
+            fatalError("Missing podspec ( \(podspecPath) )")
         }
 
         guard let JSONFile = try? JSONSerialization.jsonObject(with: jsonData, options:
@@ -383,11 +445,26 @@ public enum RepoActions {
         let supportBUILDFileFilePath = URL(fileURLWithPath: PodSupportBuidableDir + "BUILD.bazel")
         shell.symLink(from: supportBUILDFile.relativePath, to: supportBUILDFileFilePath.path)
 
+
         // Write the root BUILD file
         let buildFileSkylarkCompiler = SkylarkCompiler(buildFile.toSkylark())
         let buildFileOut = buildFileSkylarkCompiler.run()
         let buildFilePath = URL(fileURLWithPath: "BUILD.bazel")
         shell.write(value: buildFileOut, toPath: buildFilePath)
+
+        // When there is a "child" podspec adjacent to a parent, concat the
+        // "child" BUILD file into the parents
+        if PodBuildFile.shouldAssimilate(buildOptions: buildOptions) {
+            let fileUpdater = try! FileHandle(forWritingTo: buildFilePath)
+            fileUpdater.seekToEndOfFile()
+            fileUpdater.write("\n".data(using: .utf8)!)
+            if let data = buildFileOut.data(using: .utf8) {
+                fileUpdater.write(data)
+            }
+            fileUpdater.closeFile()
+        } else {
+            shell.write(value: buildFileOut, toPath: buildFilePath)
+        }
     }
 
     // Assume the directory structure relative to the pod root

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -132,7 +132,7 @@ def GetVersion(invocation_info):
     self_hash = HashFile(os.path.realpath(__file__))
     repo_tool_hash = HashFile(_getRepoToolPath())
     ctx_hash = str(hash(repository_ctx.GetIdentifier()))
-    child_pods = str(hash(child_pods))
+    child_pods = str(hash("".join(invocation_info.child_pods))) if invocation_info.child_pods else ""
     return self_hash + repo_tool_hash + ctx_hash + child_pods
 
 # Compiler Options

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -207,6 +207,8 @@ def _load_repo_if_needed(repository_ctx, repo_tool_bin_path):
 
     # Note: the pod is not cleaned out if the sourcecode is loaded from the
     # current directory
+    print("Updating Pod " + repository_ctx.target_name + "...")
+
     _exec(repository_ctx, ["rm", "-rf", repository_ctx.GetPodRootDir()])
     _exec(repository_ctx, ["mkdir", "-p", repository_ctx.GetPodRootDir()])
 

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -205,10 +205,6 @@ def _load_repo_if_needed(repository_ctx, repo_tool_bin_path):
         # the repo with that code.
         return
 
-    # Note: the pod is not cleaned out if the sourcecode is loaded from the
-    # current directory
-    print("Updating Pod " + repository_ctx.target_name + "...")
-
     _exec(repository_ctx, ["rm", "-rf", repository_ctx.GetPodRootDir()])
     _exec(repository_ctx, ["mkdir", "-p", repository_ctx.GetPodRootDir()])
 
@@ -227,6 +223,10 @@ def _update_repo_impl(invocation_info):
 
     if not _needs_update(repository_ctx):
         return
+
+    # Note: the pod is not cleaned out if the sourcecode is loaded from the
+    # current directory
+    print("Updating Pod " + repository_ctx.target_name + "...")
 
     # Note: the root directory that these commands execute is external/name
     # after the source code has been fetched


### PR DESCRIPTION
Adds the ability to handle "child pods" within a pod. In cocoapods, its
possible to provide a path within another pod, and this doesn't map to
any notion we have. Simply put, it generates a BUILD file in the parent
directory, and aliases the Vendor/__POD__ to the parent directory.

Additionally, it has a first pass at handling adjacent, child or top
level pods. When there are 2 adjacent podspecs, cocoapods effectively
merges these into a single file. The first pass at this ability is
achieved by concatting build files together. Some algorithms rely on
having all the data structures around, so we'll need to update it to
merge build files at a higher level in the stack, and this is much more
complex.

There's a few cleanups around `EmptyBuildOptions` as it was tedious to
keep updating new values everywhere, and we might not need the protocol
either. I think this was used as a legacy feature. Will submit that as a
followup