### PR TITLE
fix warnings and errors when building on catalina with xcode 11.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "PodToBUILD",
+    platforms: [
+        .macOS(.v10_12),
+    ],
     products: [
         // PodToBUILD is a core library enabling Skylark code generation
         .library(

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -288,7 +288,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         }
 
         self.includes = xcconfigFlags.filter { $0.hasPrefix("-I") }.map {
-            $0.substring(from: $0.characters.index($0.startIndex, offsetBy: 2))
+            String($0.dropFirst(2))
         } + includePodHeaderDirs()
         self.headerName = headerName
         self.externalName = externalName

--- a/Sources/PodToBUILD/UserConfigurable.swift
+++ b/Sources/PodToBUILD/UserConfigurable.swift
@@ -53,7 +53,7 @@ extension UserConfigurable {
                 fatalError()
             }
 
-            var components = keyPathOperator.components(separatedBy: opt.rawValue)
+            let components = keyPathOperator.components(separatedBy: opt.rawValue)
             guard components.count > 1 else { continue }
 
             let key = components[0].replacingOccurrences(of: " ", with: "")


### PR DESCRIPTION
- update to swift tools 5.0 to get supported platforms.
- macos 10.12 became the minimum requirement with https://github.com/pinterest/PodToBUILD/pull/96
- Fix some Swift4 string stuff.
- use `let` where compiler suggests it.