### PR TITLE
Preserve any . in the values uses for copts

### DIFF
--- a/Sources/PodToBUILD/UserConfigurable.swift
+++ b/Sources/PodToBUILD/UserConfigurable.swift
@@ -76,11 +76,11 @@ enum UserConfigurableTransform : SkylarkConvertibleTransform {
     public static  func executeUserOptionsTransform(onConvertibles convertibles: [SkylarkConvertible], copts: [String], userAttributes: UserConfigurableTargetAttributes) -> [SkylarkConvertible] {
         var operatorByTarget = [String: [String]]()
         for keyPath in userAttributes.keyPathOperators {
-            let components = keyPath.components(separatedBy: ".")
+            let components = keyPath.split(separator: ".", maxSplits: 1)
             if let target = components.first {
-                var oprs = (operatorByTarget[target] ?? [String]())
-                oprs.append(components[1])
-                operatorByTarget[target] = oprs
+                var oprs = (operatorByTarget[String(target)] ?? [String]())
+                oprs.append(String(components[1]))
+                operatorByTarget[String(target)] = oprs
             }
         }
 

--- a/Tests/PodToBUILDTests/UserConfigurableTests.swift
+++ b/Tests/PodToBUILDTests/UserConfigurableTests.swift
@@ -82,6 +82,15 @@ class UserConfigurableTests: XCTestCase {
         XCTAssertEqual(outputCopts?[1], "CoreGraphics")
         XCTAssertEqual(outputCopts?[2], "Foundation")
     }
+
+    func testUserOptionPresevesDotExtensions() {
+        let target = TestTarget()
+        let attributes = UserConfigurableTargetAttributes(keyPathOperators:  ["TestTarget.copts += TargetConditionals.h"])
+        let output = UserConfigurableTransform.executeUserOptionsTransform(onConvertibles: [target], copts: [String](), userAttributes: attributes)
+        let outputLib = output[0] as! TestTarget
+        let outputCopts = outputLib.copts.basic
+        XCTAssertEqual(outputCopts?[0], "TargetConditionals.h")
+    }
 }
 
 


### PR DESCRIPTION
Basically do not assume there is only one ".". Take the item before the "." as the key, and the remainder of the string is the value.