### PR TITLE
Preserve spaces in copts values

### DIFF
--- a/Sources/PodToBUILD/UserConfigurable.swift
+++ b/Sources/PodToBUILD/UserConfigurable.swift
@@ -56,10 +56,10 @@ extension UserConfigurable {
             let components = keyPathOperator.components(separatedBy: opt.rawValue)
             guard components.count > 1 else { continue }
 
-            let key = components[0].replacingOccurrences(of: " ", with: "")
+            let key = components[0].trimmingCharacters(in: .whitespaces)
             let values = components[1].components(separatedBy: ",")
             for value in values {
-                let value = value.replacingOccurrences(of: " ", with: "")
+                let value = value.trimmingCharacters(in: .whitespaces)
                 copy.add(configurableKey: key, value: value)
             }
         }

--- a/Tests/PodToBUILDTests/UserConfigurableTests.swift
+++ b/Tests/PodToBUILDTests/UserConfigurableTests.swift
@@ -91,6 +91,15 @@ class UserConfigurableTests: XCTestCase {
         let outputCopts = outputLib.copts.basic
         XCTAssertEqual(outputCopts?[0], "TargetConditionals.h")
     }
+
+    func testUserOptionPresevesSpaces() {
+        let target = TestTarget()
+        let attributes = UserConfigurableTargetAttributes(keyPathOperators:  ["TestTarget.copts += --include TargetConditionals.h"])
+        let output = UserConfigurableTransform.executeUserOptionsTransform(onConvertibles: [target], copts: [String](), userAttributes: attributes)
+        let outputLib = output[0] as! TestTarget
+        let outputCopts = outputLib.copts.basic
+        XCTAssertEqual(outputCopts?[0], "--include TargetConditionals.h")
+    }
 }
 
 


### PR DESCRIPTION
Do this by only trimming whitespace, which will limit it to the start and end of the string.