### PR TITLE
Remove workaround for build test issue

### DIFF
--- a/Examples/Example.Makefile
+++ b/Examples/Example.Makefile
@@ -9,7 +9,9 @@ BAZEL=~/.bazelenv/versions/0.28.1/bin/bazel
 
 # Override the repository to point at the source. It does a source build of the
 # current code.
-BAZEL_OPTS=--disk_cache=$(HOME)/Library/Caches/Bazel  --apple_platform_type=ios
+BAZEL_OPTS=--override_repository=rules_pods=$(RULES_PODS_DIR) \
+	--disk_cache=$(HOME)/Library/Caches/Bazel \
+	--apple_platform_type=ios
 
 all: pod_test fetch build
 
@@ -31,13 +33,19 @@ test: info
 # Generally, this would be ran when dependencies are updated, and then,
 # dependencies _would_ be checked in.
 vendorize:
-	$(BAZEL) run @rules_pods//:update_pods -- --src_root $(PWD)
+	$(BAZEL) run @rules_pods//:update_pods $(BAZEL_OPTS) -- --src_root $(PWD)
+	# The above is similar to running ../../bin/update_pods.py --src_root $(PWD)
+	# however, `rules_pods` is overriden
 	ditto $(RULES_PODS_DIR)/BazelExtensions Vendor/rules_pods/BazelExtensions
 
 fetch: info 
 	[[ ! -f Pods.WORKSPACE ]] || $(MAKE) vendorize
-	$(BAZEL) fetch :*
+	$(BAZEL) fetch :* --override_repository=rules_pods=$(RULES_PODS_DIR)
 
 info:
 	$(BAZEL) info
+
+# This command generates a workspace from a Podfile
+gen_workspace:
+	[[ ! -f Podfile ]]  ||../../bin/RepoTools generate_workspace > Pods.WORKSPACE
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ pod_test:
 # - run Bazel for all the examples
 .PHONY: build-test
 build-test: pod_test build archive init-sandbox 
-	cp PodToBUILD.zip /tmp/
 	cd Examples/BasiciOS && make all
 	cd Examples/PINRemoteImage && make all
 	cd Examples/Texture && make all


### PR DESCRIPTION
The build tests were missing override_repository, which required a hack.
Instead, override the repository directly.

Additionally, it adds a command to `gen_workspace` for testing purposes