### PR TITLE
[ReactNative] Smash child build files into parents

### DIFF
--- a/Examples/Example.Makefile
+++ b/Examples/Example.Makefile
@@ -9,9 +9,11 @@ BAZEL=~/.bazelenv/versions/0.28.1/bin/bazel
 
 # Override the repository to point at the source. It does a source build of the
 # current code.
+# TODO: there's an issue with non hermetic headers in the PINRemoteImage example
 REPOSITORY_OVERRIDE=--override_repository=rules_pods=$(RULES_PODS_DIR)
-BAZEL_OPTS=$(REPOSITORY_OVERRIDE) \
+BAZEL_OPTS=$(REPOSITORY_OVERRIDE) -s \
 	--disk_cache=$(HOME)/Library/Caches/Bazel \
+	--spawn_strategy=standalone \
 	--apple_platform_type=ios
 
 all: pod_test fetch build

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -35,6 +35,31 @@ config_setting(
   }
 )
 filegroup(
+  name = "Adjust_package_hdrs",
+  srcs = [
+    "Adjust_direct_hdrs",
+    "Core_direct_hdrs",
+    "Sociomantic_direct_hdrs",
+    "Criteo_direct_hdrs",
+    "Trademob_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Adjust_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Adjust_hdrs",
   srcs = glob(
     [
@@ -52,6 +77,7 @@ headermap(
   name = "Adjust_hmap",
   namespace = "Adjust",
   hdrs = [
+    "Adjust_package_hdrs",
     ":Adjust_hdrs"
   ],
   deps = [
@@ -120,6 +146,27 @@ acknowledged_target(
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Adjust/*.h",
+        "Adjust/ADJAdditions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -154,6 +201,7 @@ headermap(
   name = "Core_hmap",
   namespace = "Adjust",
   hdrs = [
+    "Adjust_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],
@@ -247,6 +295,26 @@ acknowledged_target(
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Sociomantic_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Sociomantic/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
     glob(
@@ -281,6 +349,7 @@ headermap(
   name = "Sociomantic_hmap",
   namespace = "Adjust",
   hdrs = [
+    "Adjust_package_hdrs",
     ":Sociomantic_union_hdrs"
   ],
   deps = [
@@ -360,6 +429,26 @@ acknowledged_target(
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Criteo_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Criteo/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
     glob(
@@ -394,6 +483,7 @@ headermap(
   name = "Criteo_hmap",
   namespace = "Adjust",
   hdrs = [
+    "Adjust_package_hdrs",
     ":Criteo_union_hdrs"
   ],
   deps = [
@@ -473,6 +563,26 @@ acknowledged_target(
   value = "//Vendor/Adjust/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Trademob_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Trademob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Trademob_hdrs",
   srcs = glob(
     glob(
@@ -507,6 +617,7 @@ headermap(
   name = "Trademob_hmap",
   namespace = "Adjust",
   hdrs = [
+    "Adjust_package_hdrs",
     ":Trademob_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -36,6 +36,29 @@ config_setting(
   }
 )
 filegroup(
+  name = "FBSDKCoreKit_package_hdrs",
+  srcs = [
+    "FBSDKCoreKit_direct_hdrs",
+    "Basics_direct_hdrs",
+    "Core_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = glob(
     [
@@ -54,6 +77,7 @@ headermap(
   name = "FBSDKCoreKit_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "FBSDKCoreKit_package_hdrs",
     ":FBSDKCoreKit_hdrs"
   ],
   deps = [
@@ -321,6 +345,27 @@ acknowledged_target(
   value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Basics_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Basics_hdrs",
   srcs = glob(
     glob(
@@ -355,6 +400,7 @@ headermap(
   name = "Basics_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "FBSDKCoreKit_package_hdrs",
     ":Basics_union_hdrs"
   ],
   deps = [],
@@ -1627,6 +1673,131 @@ acknowledged_target(
   value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKHybridAppEventsScriptMessageHandler.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKMeasurementEvent.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKURL.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAppLinkReturnToRefererView_Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAppLink_Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMeasurementEvent_Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKURL_Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = select(
     {
@@ -1766,6 +1937,7 @@ headermap(
   name = "Core_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "FBSDKCoreKit_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -35,6 +35,29 @@ config_setting(
   }
 )
 filegroup(
+  name = "Bolts_package_hdrs",
+  srcs = [
+    "Bolts_direct_hdrs",
+    "Tasks_direct_hdrs",
+    "AppLinks_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Bolts_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Bolts_hdrs",
   srcs = glob(
     [
@@ -53,6 +76,7 @@ headermap(
   name = "Bolts_hmap",
   namespace = "Bolts",
   hdrs = [
+    "Bolts_package_hdrs",
     ":Bolts_hdrs"
   ],
   deps = [
@@ -109,6 +133,26 @@ acknowledged_target(
   value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Tasks_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Bolts/Common/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Tasks_hdrs",
   srcs = glob(
     glob(
@@ -142,6 +186,7 @@ headermap(
   name = "Tasks_hmap",
   namespace = "Bolts",
   hdrs = [
+    "Bolts_package_hdrs",
     ":Tasks_union_hdrs"
   ],
   deps = [],
@@ -232,6 +277,48 @@ acknowledged_target(
   value = "//Vendor/Bolts/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "AppLinks_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Bolts/iOS/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "AppLinks_hdrs",
   srcs = select(
     {
@@ -288,6 +375,7 @@ headermap(
   name = "AppLinks_hmap",
   namespace = "Bolts",
   hdrs = [
+    "Bolts_package_hdrs",
     ":AppLinks_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -36,6 +36,39 @@ config_setting(
   }
 )
 filegroup(
+  name = "Braintree_package_hdrs",
+  srcs = [
+    "Braintree_direct_hdrs",
+    "Core_direct_hdrs",
+    "Apple-Pay_direct_hdrs",
+    "Card_direct_hdrs",
+    "DataCollector_direct_hdrs",
+    "PayPal_direct_hdrs",
+    "Venmo_direct_hdrs",
+    "UI_direct_hdrs",
+    "UnionPay_direct_hdrs",
+    "3D-Secure_direct_hdrs",
+    "PayPalOneTouch_direct_hdrs",
+    "PayPalDataCollector_direct_hdrs",
+    "PayPalUtils_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Braintree_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Braintree_hdrs",
   srcs = glob(
     [
@@ -56,6 +89,7 @@ headermap(
   name = "Braintree_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":Braintree_hdrs"
   ],
   deps = [
@@ -118,6 +152,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCore/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -151,6 +205,7 @@ headermap(
   name = "Core_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],
@@ -272,6 +327,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Apple-Pay_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeApplePay/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Apple-Pay_hdrs",
   srcs = glob(
     glob(
@@ -306,6 +381,7 @@ headermap(
   name = "Apple-Pay_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":Apple-Pay_union_hdrs"
   ],
   deps = [
@@ -376,6 +452,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Card_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCard/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Card_hdrs",
   srcs = glob(
     glob(
@@ -410,6 +506,7 @@ headermap(
   name = "Card_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":Card_union_hdrs"
   ],
   deps = [
@@ -493,6 +590,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "DataCollector_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeDataCollector/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "DataCollector_hdrs",
   srcs = glob(
     glob(
@@ -527,6 +644,7 @@ headermap(
   name = "DataCollector_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":DataCollector_union_hdrs"
   ],
   deps = [
@@ -607,6 +725,27 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PayPal_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/*.h",
+        "BraintreePayPal/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
     glob(
@@ -643,6 +782,7 @@ headermap(
   name = "PayPal_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":PayPal_union_hdrs"
   ],
   deps = [
@@ -712,6 +852,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Venmo_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeVenmo/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Venmo_hdrs",
   srcs = glob(
     glob(
@@ -747,6 +907,7 @@ headermap(
   name = "Venmo_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":Venmo_union_hdrs"
   ],
   deps = [
@@ -844,6 +1005,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "UI_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUI/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UI_hdrs",
   srcs = glob(
     glob(
@@ -879,6 +1060,7 @@ headermap(
   name = "UI_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":UI_union_hdrs"
   ],
   deps = [
@@ -955,6 +1137,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "UnionPay_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUnionPay/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UnionPay_hdrs",
   srcs = glob(
     glob(
@@ -990,6 +1192,7 @@ headermap(
   name = "UnionPay_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":UnionPay_union_hdrs"
   ],
   deps = [
@@ -1076,6 +1279,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "3D-Secure_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Braintree3DSecure/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "3D-Secure_hdrs",
   srcs = glob(
     glob(
@@ -1111,6 +1334,7 @@ headermap(
   name = "3D-Secure_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":3D-Secure_union_hdrs"
   ],
   deps = [
@@ -1186,6 +1410,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PayPalOneTouch_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PayPalOneTouch_hdrs",
   srcs = glob(
     glob(
@@ -1222,6 +1466,7 @@ headermap(
   name = "PayPalOneTouch_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":PayPalOneTouch_union_hdrs"
   ],
   deps = [
@@ -1307,6 +1552,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PayPalDataCollector_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalDataCollector/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PayPalDataCollector_hdrs",
   srcs = glob(
     glob(
@@ -1342,6 +1607,7 @@ headermap(
   name = "PayPalDataCollector_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":PayPalDataCollector_union_hdrs"
   ],
   deps = [
@@ -1441,6 +1707,26 @@ acknowledged_target(
   value = "//Vendor/Braintree/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PayPalUtils_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalUtils/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PayPalUtils_hdrs",
   srcs = glob(
     glob(
@@ -1474,6 +1760,7 @@ headermap(
   name = "PayPalUtils_hmap",
   namespace = "Braintree",
   hdrs = [
+    "Braintree_package_hdrs",
     ":PayPalUtils_union_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -35,6 +35,29 @@ config_setting(
   }
 )
 filegroup(
+  name = "Branch_package_hdrs",
+  srcs = [
+    "Branch_direct_hdrs",
+    "Core_direct_hdrs",
+    "without-IDFA_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Branch_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Branch_hdrs",
   srcs = glob(
     [
@@ -53,6 +76,7 @@ headermap(
   name = "Branch_hmap",
   namespace = "Branch",
   hdrs = [
+    "Branch_package_hdrs",
     ":Branch_hdrs"
   ],
   deps = [
@@ -109,6 +133,28 @@ acknowledged_target(
   value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -144,6 +190,7 @@ headermap(
   name = "Core_hmap",
   namespace = "Branch",
   hdrs = [
+    "Branch_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],
@@ -212,6 +259,28 @@ acknowledged_target(
   value = "//Vendor/Branch/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "without-IDFA_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "without-IDFA_hdrs",
   srcs = glob(
     glob(
@@ -247,6 +316,7 @@ headermap(
   name = "without-IDFA_hmap",
   namespace = "Branch",
   hdrs = [
+    "Branch_package_hdrs",
     ":without-IDFA_union_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -36,6 +36,38 @@ config_setting(
   }
 )
 filegroup(
+  name = "Calabash_package_hdrs",
+  srcs = [
+    "Calabash_cxx_direct_hdrs",
+    "Calabash_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Calabash_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
     glob(
@@ -71,6 +103,7 @@ headermap(
   name = "Calabash_cxx_hmap",
   namespace = "Calabash",
   hdrs = [
+    "Calabash_package_hdrs",
     ":Calabash_cxx_union_hdrs"
   ],
   deps = [],
@@ -168,6 +201,28 @@ swift_library(
   data = []
 )
 filegroup(
+  name = "Calabash_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
     glob(
@@ -195,6 +250,7 @@ headermap(
   name = "Calabash_hmap",
   namespace = "Calabash",
   hdrs = [
+    "Calabash_package_hdrs",
     ":Calabash_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "CardIO_package_hdrs",
+  srcs = [
+    "CardIO_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "CardIO_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "CardIO/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "CardIO_hmap",
   namespace = "CardIO",
   hdrs = [
+    "CardIO_package_hdrs",
     ":CardIO_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -36,6 +36,31 @@ config_setting(
   }
 )
 filegroup(
+  name = "CocoaLumberjack_package_hdrs",
+  srcs = [
+    "CocoaLumberjack_direct_hdrs",
+    "Default_direct_hdrs",
+    "Core_direct_hdrs",
+    "Extensions_direct_hdrs",
+    "CLI_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "CocoaLumberjack_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CocoaLumberjack_hdrs",
   srcs = glob(
     [
@@ -54,6 +79,7 @@ headermap(
   name = "CocoaLumberjack_hmap",
   namespace = "CocoaLumberjack",
   hdrs = [
+    "CocoaLumberjack_package_hdrs",
     ":CocoaLumberjack_hdrs"
   ],
   deps = [
@@ -110,6 +136,27 @@ acknowledged_target(
   value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Default_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/CocoaLumberjack.h",
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Default_hdrs",
   srcs = glob(
     glob(
@@ -144,6 +191,7 @@ headermap(
   name = "Default_hmap",
   namespace = "CocoaLumberjack",
   hdrs = [
+    "CocoaLumberjack_package_hdrs",
     ":Default_union_hdrs"
   ],
   deps = [],
@@ -212,6 +260,26 @@ acknowledged_target(
   value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -245,6 +313,7 @@ headermap(
   name = "Core_hmap",
   namespace = "CocoaLumberjack",
   hdrs = [
+    "CocoaLumberjack_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],
@@ -307,6 +376,26 @@ acknowledged_target(
   value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Extensions_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/Extensions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Extensions_hdrs",
   srcs = glob(
     glob(
@@ -341,6 +430,7 @@ headermap(
   name = "Extensions_hmap",
   namespace = "CocoaLumberjack",
   hdrs = [
+    "CocoaLumberjack_package_hdrs",
     ":Extensions_union_hdrs"
   ],
   deps = [
@@ -406,6 +496,48 @@ acknowledged_target(
   value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "CLI_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/CLI/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CLI_hdrs",
   srcs = select(
     {
@@ -468,6 +600,7 @@ headermap(
   name = "CLI_hmap",
   namespace = "CocoaLumberjack",
   hdrs = [
+    "CocoaLumberjack_package_hdrs",
     ":CLI_union_hdrs"
   ],
   deps = select(

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "ColorCube_package_hdrs",
+  srcs = [
+    "ColorCube_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "ColorCube_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ColorCube/ColorCube/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "ColorCube_hmap",
   namespace = "ColorCube",
   hdrs = [
+    "ColorCube_package_hdrs",
     ":ColorCube_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "EarlGrey_package_hdrs",
+  srcs = [
+    "EarlGrey_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "EarlGrey_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "EarlGrey_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "EarlGrey_hmap",
   namespace = "EarlGrey",
   hdrs = [
+    "EarlGrey_package_hdrs",
     ":EarlGrey_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -36,6 +36,117 @@ config_setting(
   }
 )
 filegroup(
+  name = "FBSDKCoreKit_package_hdrs",
+  srcs = [
+    "FBSDKCoreKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = select(
     {
@@ -141,6 +252,7 @@ headermap(
   name = "FBSDKCoreKit_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "FBSDKCoreKit_package_hdrs",
     ":FBSDKCoreKit_hdrs"
   ],
   deps = select(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "FBSDKLoginKit_package_hdrs",
+  srcs = [
+    "FBSDKLoginKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKLoginKit_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKLoginKit_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "FBSDKLoginKit_hmap",
   namespace = "FBSDKLoginKit",
   hdrs = [
+    "FBSDKLoginKit_package_hdrs",
     ":FBSDKLoginKit_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "FBSDKMessengerShareKit_package_hdrs",
+  srcs = [
+    "FBSDKMessengerShareKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKMessengerShareKit_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKMessengerShareKit_hdrs",
   srcs = glob(
     glob(
@@ -44,9 +73,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "FBSDKMessengerShareKit/**/*.h",
-        "FBSDKMessengerShareKit/**/*.hpp",
-        "FBSDKMessengerShareKit/**/*.hxx",
         "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
       ],
       exclude_directories = 1
@@ -61,6 +87,7 @@ headermap(
   name = "FBSDKMessengerShareKit_hmap",
   namespace = "FBSDKMessengerShareKit",
   hdrs = [
+    "FBSDKMessengerShareKit_package_hdrs",
     ":FBSDKMessengerShareKit_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -35,7 +35,16 @@ config_setting(
   }
 )
 filegroup(
-  name = "FBSDKShareKit_hdrs",
+  name = "FBSDKShareKit_package_hdrs",
+  srcs = [
+    "FBSDKShareKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKShareKit_direct_hdrs",
   srcs = select(
     {
       "//conditions:default": glob(
@@ -46,9 +55,6 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKShareKit/**/*.h",
-            "FBSDKShareKit/**/*.hpp",
-            "FBSDKShareKit/**/*.hxx",
             "FBSDKShareKit/FBSDKShareKit/**/*.h"
           ],
           exclude = [
@@ -60,19 +66,9 @@ filegroup(
         exclude_directories = 1
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKShareKit/**/*.h",
-            "FBSDKShareKit/**/*.hpp",
-            "FBSDKShareKit/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
         exclude_directories = 1
       ),
       ":tvosCase": glob(
@@ -83,9 +79,6 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKShareKit/**/*.h",
-            "FBSDKShareKit/**/*.hpp",
-            "FBSDKShareKit/**/*.hxx",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
@@ -116,6 +109,22 @@ filegroup(
         exclude_directories = 1
       ),
       ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKShareKit_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
         glob(
           [
             "pod_support/Headers/Public/**/*"
@@ -123,12 +132,63 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKShareKit/**/*.h",
-            "FBSDKShareKit/**/*.hpp",
-            "FBSDKShareKit/**/*.hxx"
+            "FBSDKShareKit/FBSDKShareKit/**/*.h"
+          ],
+          exclude = [
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
           ],
           exclude_directories = 1
         ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
         exclude_directories = 1
       )
     }
@@ -141,6 +201,7 @@ headermap(
   name = "FBSDKShareKit_hmap",
   namespace = "FBSDKShareKit",
   hdrs = [
+    "FBSDKShareKit_package_hdrs",
     ":FBSDKShareKit_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "FLAnimatedImage_package_hdrs",
+  srcs = [
+    "FLAnimatedImage_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FLAnimatedImage_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FLAnimatedImage/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "FLAnimatedImage_hmap",
   namespace = "FLAnimatedImage",
   hdrs = [
+    "FLAnimatedImage_package_hdrs",
     ":FLAnimatedImage_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "FLEX_package_hdrs",
+  srcs = [
+    "FLEX_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FLEX_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FLEX_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "FLEX_hmap",
   namespace = "FLEX",
   hdrs = [
+    "FLEX_package_hdrs",
     ":FLEX_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -35,6 +35,33 @@ config_setting(
   }
 )
 filegroup(
+  name = "FMDB_package_hdrs",
+  srcs = [
+    "FMDB_direct_hdrs",
+    "standard_direct_hdrs",
+    "FTS_direct_hdrs",
+    "standalone_direct_hdrs",
+    "standalone_default_direct_hdrs",
+    "standalone_FTS_direct_hdrs",
+    "SQLCipher_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FMDB_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FMDB_hdrs",
   srcs = glob(
     [
@@ -52,6 +79,7 @@ headermap(
   name = "FMDB_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":FMDB_hdrs"
   ],
   deps = [
@@ -106,6 +134,26 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "standard_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standard_hdrs",
   srcs = glob(
     glob(
@@ -139,6 +187,7 @@ headermap(
   name = "standard_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":standard_union_hdrs"
   ],
   deps = [],
@@ -212,6 +261,26 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "FTS_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FTS_hdrs",
   srcs = glob(
     glob(
@@ -246,6 +315,7 @@ headermap(
   name = "FTS_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":FTS_union_hdrs"
   ],
   deps = [
@@ -311,6 +381,18 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "standalone_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standalone_hdrs",
   srcs = glob(
     [
@@ -336,6 +418,7 @@ headermap(
   name = "standalone_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":standalone_union_hdrs"
   ],
   deps = [],
@@ -389,6 +472,26 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "standalone_default_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standalone_default_hdrs",
   srcs = glob(
     glob(
@@ -422,6 +525,7 @@ headermap(
   name = "standalone_default_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":standalone_default_union_hdrs"
   ],
   deps = [
@@ -494,6 +598,27 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "standalone_FTS_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h",
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standalone_FTS_hdrs",
   srcs = glob(
     glob(
@@ -528,6 +653,7 @@ headermap(
   name = "standalone_FTS_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":standalone_FTS_union_hdrs"
   ],
   deps = [
@@ -601,6 +727,26 @@ acknowledged_target(
   value = "//Vendor/FMDB/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "SQLCipher_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SQLCipher_hdrs",
   srcs = glob(
     glob(
@@ -634,6 +780,7 @@ headermap(
   name = "SQLCipher_hmap",
   namespace = "FMDB",
   hdrs = [
+    "FMDB_package_hdrs",
     ":SQLCipher_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -35,6 +35,13 @@ config_setting(
     "apple_platform_type": "watchos"
   }
 )
+filegroup(
+  name = "FolioReaderKit_package_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 swift_library(
   name = "FolioReaderKit",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -35,6 +35,37 @@ config_setting(
   }
 )
 filegroup(
+  name = "Folly_package_hdrs",
+  srcs = [
+    "Folly_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Folly_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "folly/*.h",
+        "folly/detail/*.h",
+        "folly/portability/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Folly_hdrs",
   srcs = glob(
     glob(
@@ -60,6 +91,7 @@ headermap(
   name = "Folly_hmap",
   namespace = "folly",
   hdrs = [
+    "Folly_package_hdrs",
     ":Folly_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -37,6 +37,37 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleAppIndexing_package_hdrs",
+  srcs = [
+    "GoogleAppIndexing_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleAppIndexing_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Changelog/**/*.h",
+        "Changelog/**/*.hpp",
+        "Changelog/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
     glob(
@@ -62,6 +93,7 @@ headermap(
   name = "GoogleAppIndexing_hmap",
   namespace = "GoogleAppIndexing",
   hdrs = [
+    "GoogleAppIndexing_package_hdrs",
     ":GoogleAppIndexing_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleAppUtilities_package_hdrs",
+  srcs = [
+    "GoogleAppUtilities_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleAppUtilities_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAppUtilities_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "GoogleAppUtilities_hmap",
   namespace = "GoogleAppUtilities",
   hdrs = [
+    "GoogleAppUtilities_package_hdrs",
     ":GoogleAppUtilities_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleAuthUtilities_package_hdrs",
+  srcs = [
+    "GoogleAuthUtilities_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleAuthUtilities_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAuthUtilities_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "GoogleAuthUtilities_hmap",
   namespace = "GoogleAuthUtilities",
   hdrs = [
+    "GoogleAuthUtilities_package_hdrs",
     ":GoogleAuthUtilities_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleNetworkingUtilities_package_hdrs",
+  srcs = [
+    "GoogleNetworkingUtilities_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleNetworkingUtilities_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleNetworkingUtilities_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "GoogleNetworkingUtilities_hmap",
   namespace = "GoogleNetworkingUtilities",
   hdrs = [
+    "GoogleNetworkingUtilities_package_hdrs",
     ":GoogleNetworkingUtilities_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -37,6 +37,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleSignIn_package_hdrs",
+  srcs = [
+    "GoogleSignIn_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleSignIn_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleSignIn_hdrs",
   srcs = glob(
     [
@@ -52,6 +73,7 @@ headermap(
   name = "GoogleSignIn_hmap",
   namespace = "GoogleSignIn",
   hdrs = [
+    "GoogleSignIn_package_hdrs",
     ":GoogleSignIn_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleSymbolUtilities_package_hdrs",
+  srcs = [
+    "GoogleSymbolUtilities_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleSymbolUtilities_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleSymbolUtilities_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "GoogleSymbolUtilities_hmap",
   namespace = "GoogleSymbolUtilities",
   hdrs = [
+    "GoogleSymbolUtilities_package_hdrs",
     ":GoogleSymbolUtilities_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -36,6 +36,27 @@ config_setting(
   }
 )
 filegroup(
+  name = "GoogleUtilities_package_hdrs",
+  srcs = [
+    "GoogleUtilities_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "GoogleUtilities_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleUtilities_hdrs",
   srcs = glob(
     [
@@ -51,6 +72,7 @@ headermap(
   name = "GoogleUtilities_hmap",
   namespace = "GoogleUtilities",
   hdrs = [
+    "GoogleUtilities_package_hdrs",
     ":GoogleUtilities_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "IBActionSheet_package_hdrs",
+  srcs = [
+    "IBActionSheet_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "IBActionSheet_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "IBActionSheet_hmap",
   namespace = "IBActionSheet",
   hdrs = [
+    "IBActionSheet_package_hdrs",
     ":IBActionSheet_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -35,6 +35,31 @@ config_setting(
   }
 )
 filegroup(
+  name = "IGListKit_package_hdrs",
+  srcs = [
+    "IGListKit_direct_hdrs",
+    "Diffing_cxx_direct_hdrs",
+    "Diffing_direct_hdrs",
+    "Default_cxx_direct_hdrs",
+    "Default_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "IGListKit_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
     [
@@ -52,6 +77,7 @@ headermap(
   name = "IGListKit_hmap",
   namespace = "IGListKit",
   hdrs = [
+    "IGListKit_package_hdrs",
     ":IGListKit_hdrs"
   ],
   deps = [
@@ -122,6 +148,27 @@ acknowledged_target(
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Diffing_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
     glob(
@@ -156,6 +203,7 @@ headermap(
   name = "Diffing_cxx_hmap",
   namespace = "IGListKit",
   hdrs = [
+    "IGListKit_package_hdrs",
     ":Diffing_cxx_union_hdrs"
   ],
   deps = [],
@@ -314,6 +362,27 @@ acknowledged_target(
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Diffing_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
     glob(
@@ -349,6 +418,7 @@ headermap(
   name = "Diffing_hmap",
   namespace = "IGListKit",
   hdrs = [
+    "IGListKit_package_hdrs",
     ":Diffing_union_hdrs"
   ],
   deps = [
@@ -484,6 +554,60 @@ acknowledged_target(
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Default_cxx_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Default_cxx_hdrs",
   srcs = select(
     {
@@ -552,6 +676,7 @@ headermap(
   name = "Default_cxx_hmap",
   namespace = "IGListKit",
   hdrs = [
+    "IGListKit_package_hdrs",
     ":Default_cxx_union_hdrs"
   ],
   deps = [
@@ -680,6 +805,60 @@ acknowledged_target(
   value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Default_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Default_hdrs",
   srcs = select(
     {
@@ -749,6 +928,7 @@ headermap(
   name = "Default_hmap",
   namespace = "IGListKit",
   hdrs = [
+    "IGListKit_package_hdrs",
     ":Default_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "KVOController_package_hdrs",
+  srcs = [
+    "KVOController_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "KVOController_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBKVOController/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "KVOController_hmap",
   namespace = "KVOController",
   hdrs = [
+    "KVOController_package_hdrs",
     ":KVOController_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -36,6 +36,31 @@ config_setting(
   }
 )
 filegroup(
+  name = "KakaoOpenSDK_package_hdrs",
+  srcs = [
+    "KakaoOpenSDK_direct_hdrs",
+    "KakaoOpenSDK_direct_hdrs",
+    "KakaoNavi_direct_hdrs",
+    "KakaoLink_direct_hdrs",
+    "KakaoS2_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "KakaoOpenSDK_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoOpenSDK_hdrs",
   srcs = glob(
     [
@@ -56,6 +81,7 @@ headermap(
   name = "KakaoOpenSDK_hmap",
   namespace = "KakaoOpenSDK",
   hdrs = [
+    "KakaoOpenSDK_package_hdrs",
     ":KakaoOpenSDK_hdrs"
   ],
   deps = [
@@ -124,6 +150,18 @@ acknowledged_target(
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "KakaoOpenSDK_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoOpenSDK_hdrs",
   srcs = glob(
     [
@@ -149,6 +187,7 @@ headermap(
   name = "KakaoOpenSDK_hmap",
   namespace = "KakaoOpenSDK",
   hdrs = [
+    "KakaoOpenSDK_package_hdrs",
     ":KakaoOpenSDK_union_hdrs"
   ],
   deps = [
@@ -224,6 +263,18 @@ acknowledged_target(
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "KakaoNavi_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoNavi_hdrs",
   srcs = glob(
     [
@@ -249,6 +300,7 @@ headermap(
   name = "KakaoNavi_hmap",
   namespace = "KakaoOpenSDK",
   hdrs = [
+    "KakaoOpenSDK_package_hdrs",
     ":KakaoNavi_union_hdrs"
   ],
   deps = [
@@ -323,6 +375,18 @@ acknowledged_target(
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "KakaoLink_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoLink_hdrs",
   srcs = glob(
     [
@@ -348,6 +412,7 @@ headermap(
   name = "KakaoLink_hmap",
   namespace = "KakaoOpenSDK",
   hdrs = [
+    "KakaoOpenSDK_package_hdrs",
     ":KakaoLink_union_hdrs"
   ],
   deps = [
@@ -422,6 +487,18 @@ acknowledged_target(
   value = "//Vendor/KakaoOpenSDK/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "KakaoS2_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoS2_hdrs",
   srcs = glob(
     [
@@ -447,6 +524,7 @@ headermap(
   name = "KakaoS2_hmap",
   namespace = "KakaoOpenSDK",
   hdrs = [
+    "KakaoOpenSDK_package_hdrs",
     ":KakaoS2_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "Masonry_package_hdrs",
+  srcs = [
+    "Masonry_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Masonry_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Masonry/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "Masonry_hmap",
   namespace = "Masonry",
   hdrs = [
+    "Masonry_package_hdrs",
     ":Masonry_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -36,6 +36,40 @@ config_setting(
   }
 )
 filegroup(
+  name = "OnePasswordExtension_package_hdrs",
+  srcs = [
+    "OnePasswordExtension_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "OnePasswordExtension_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h"
+      ],
+      exclude = [
+        "Demos/**/*.h",
+        "Demos/**/*.hpp",
+        "Demos/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
     glob(
@@ -64,6 +98,7 @@ headermap(
   name = "OnePasswordExtension_hmap",
   namespace = "OnePasswordExtension",
   hdrs = [
+    "OnePasswordExtension_package_hdrs",
     ":1PasswordExtension_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -35,6 +35,29 @@ config_setting(
   }
 )
 filegroup(
+  name = "PINCache_package_hdrs",
+  srcs = [
+    "PINCache_direct_hdrs",
+    "Core_direct_hdrs",
+    "Arc-exception-safe_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINCache_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
     [
@@ -53,6 +76,7 @@ headermap(
   name = "PINCache_hmap",
   namespace = "PINCache",
   hdrs = [
+    "PINCache_package_hdrs",
     ":PINCache_hdrs"
   ],
   deps = [
@@ -122,6 +146,26 @@ acknowledged_target(
   value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -155,6 +199,7 @@ headermap(
   name = "Core_hmap",
   namespace = "PINCache",
   hdrs = [
+    "PINCache_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [
@@ -241,6 +286,18 @@ acknowledged_target(
   value = "//Vendor/PINCache/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Arc-exception-safe_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Arc-exception-safe_hdrs",
   srcs = glob(
     [
@@ -267,6 +324,7 @@ headermap(
   name = "Arc-exception-safe_hmap",
   namespace = "PINCache",
   hdrs = [
+    "PINCache_package_hdrs",
     ":Arc-exception-safe_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -35,6 +35,36 @@ config_setting(
   }
 )
 filegroup(
+  name = "PINOperation_package_hdrs",
+  srcs = [
+    "PINOperation_cxx_direct_hdrs",
+    "PINOperation_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINOperation_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
     glob(
@@ -68,6 +98,7 @@ headermap(
   name = "PINOperation_cxx_hmap",
   namespace = "PINOperation",
   hdrs = [
+    "PINOperation_package_hdrs",
     ":PINOperation_cxx_union_hdrs"
   ],
   deps = [],
@@ -141,6 +172,26 @@ acknowledged_target(
   value = "//Vendor/PINOperation/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PINOperation_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINOperation_hdrs",
   srcs = glob(
     glob(
@@ -166,6 +217,7 @@ headermap(
   name = "PINOperation_hmap",
   namespace = "PINOperation",
   hdrs = [
+    "PINOperation_package_hdrs",
     ":PINOperation_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -35,6 +35,34 @@ config_setting(
   }
 )
 filegroup(
+  name = "PINRemoteImage_package_hdrs",
+  srcs = [
+    "PINRemoteImage_direct_hdrs",
+    "Core_direct_hdrs",
+    "iOS_direct_hdrs",
+    "OSX_direct_hdrs",
+    "tvOS_direct_hdrs",
+    "FLAnimatedImage_direct_hdrs",
+    "WebP_direct_hdrs",
+    "PINCache_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINRemoteImage_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINRemoteImage_hdrs",
   srcs = glob(
     [
@@ -53,6 +81,7 @@ headermap(
   name = "PINRemoteImage_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":PINRemoteImage_hdrs"
   ],
   deps = [
@@ -109,6 +138,30 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/**/*.h"
+      ],
+      exclude = [
+        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
+        "Source/Classes/PINCache/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -146,6 +199,7 @@ headermap(
   name = "Core_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [
@@ -231,6 +285,18 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "iOS_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iOS_hdrs",
   srcs = glob(
     [
@@ -257,6 +323,7 @@ headermap(
   name = "iOS_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":iOS_union_hdrs"
   ],
   deps = [
@@ -314,6 +381,18 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "OSX_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "OSX_hdrs",
   srcs = glob(
     [
@@ -340,6 +419,7 @@ headermap(
   name = "OSX_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":OSX_union_hdrs"
   ],
   deps = [
@@ -398,6 +478,18 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "tvOS_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
     [
@@ -424,6 +516,7 @@ headermap(
   name = "tvOS_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":tvOS_union_hdrs"
   ],
   deps = [
@@ -478,6 +571,26 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "FLAnimatedImage_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
     glob(
@@ -512,6 +625,7 @@ headermap(
   name = "FLAnimatedImage_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":FLAnimatedImage_union_hdrs"
   ],
   deps = [
@@ -581,6 +695,18 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "WebP_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "WebP_hdrs",
   srcs = glob(
     [
@@ -607,6 +733,7 @@ headermap(
   name = "WebP_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":WebP_union_hdrs"
   ],
   deps = [
@@ -667,6 +794,26 @@ acknowledged_target(
   value = "//Vendor/PINRemoteImage/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PINCache_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/PINCache/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
     glob(
@@ -701,6 +848,7 @@ headermap(
   name = "PINCache_hmap",
   namespace = "PINRemoteImage",
   hdrs = [
+    "PINRemoteImage_package_hdrs",
     ":PINCache_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "PaymentKit_package_hdrs",
+  srcs = [
+    "PaymentKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PaymentKit_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PaymentKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "PaymentKit_hmap",
   namespace = "PaymentKit",
   hdrs = [
+    "PaymentKit_package_hdrs",
     ":PaymentKit_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "RadarKit_package_hdrs",
+  srcs = [
+    "RadarKit_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RadarKit_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "RadarKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "RadarKit_hmap",
   namespace = "RadarKit",
   hdrs = [
+    "RadarKit_package_hdrs",
     ":RadarKit_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -36,6 +36,71 @@ config_setting(
   }
 )
 filegroup(
+  name = "React_package_hdrs",
+  srcs = [
+    "React_direct_hdrs",
+    "Core_cxx_direct_hdrs",
+    "Core_direct_hdrs",
+    "CxxBridge_cxx_direct_hdrs",
+    "CxxBridge_direct_hdrs",
+    "DevSupport_cxx_direct_hdrs",
+    "DevSupport_direct_hdrs",
+    "RCTFabric_cxx_direct_hdrs",
+    "RCTFabric_direct_hdrs",
+    "tvOS_direct_hdrs",
+    "jschelpers_direct_hdrs",
+    "jsinspector_direct_hdrs",
+    "PrivateDatabase_direct_hdrs",
+    "cxxreact_direct_hdrs",
+    "fabric_direct_hdrs",
+    "fabric_activityindicator_direct_hdrs",
+    "fabric_attributedstring_direct_hdrs",
+    "fabric_core_direct_hdrs",
+    "fabric_debug_direct_hdrs",
+    "fabric_graphics_direct_hdrs",
+    "fabric_scrollview_direct_hdrs",
+    "fabric_text_direct_hdrs",
+    "fabric_textlayoutmanager_direct_hdrs",
+    "fabric_uimanager_direct_hdrs",
+    "fabric_view_direct_hdrs",
+    "RCTFabricSample_direct_hdrs",
+    "ART_direct_hdrs",
+    "RCTActionSheet_direct_hdrs",
+    "RCTAnimation_direct_hdrs",
+    "RCTBlob_cxx_direct_hdrs",
+    "RCTBlob_direct_hdrs",
+    "RCTCameraRoll_direct_hdrs",
+    "RCTGeolocation_direct_hdrs",
+    "RCTImage_direct_hdrs",
+    "RCTNetwork_cxx_direct_hdrs",
+    "RCTNetwork_direct_hdrs",
+    "RCTPushNotification_direct_hdrs",
+    "RCTSettings_direct_hdrs",
+    "RCTText_direct_hdrs",
+    "RCTVibration_direct_hdrs",
+    "RCTWebSocket_direct_hdrs",
+    "fishhook_direct_hdrs",
+    "RCTLinkingIOS_direct_hdrs",
+    "RCTTest_direct_hdrs",
+    "_ignore_me_subspec_for_linting__direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "React_hdrs",
   srcs = glob(
     [
@@ -53,6 +118,7 @@ headermap(
   name = "React_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":React_hdrs"
   ],
   deps = [
@@ -107,7 +173,7 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
-  name = "Core_cxx_hdrs",
+  name = "Core_cxx_direct_hdrs",
   srcs = select(
     {
       "//conditions:default": glob(
@@ -118,9 +184,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -160,9 +224,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -199,9 +261,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -259,9 +319,189 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/**/RCTTV*.h",
+            "React/**/RCTTV*.hpp",
+            "React/**/RCTTV*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "React/Modules/RCTClipboard*.h",
+            "React/Modules/RCTClipboard*.hpp",
+            "React/Modules/RCTClipboard*.hxx",
+            "React/Views/RCTDatePicker*.h",
+            "React/Views/RCTDatePicker*.hpp",
+            "React/Views/RCTDatePicker*.hxx",
+            "React/Views/RCTPicker*.h",
+            "React/Views/RCTPicker*.hpp",
+            "React/Views/RCTPicker*.hxx",
+            "React/Views/RCTRefreshControl*.h",
+            "React/Views/RCTRefreshControl*.hpp",
+            "React/Views/RCTRefreshControl*.hxx",
+            "React/Views/RCTSlider*.h",
+            "React/Views/RCTSlider*.hpp",
+            "React/Views/RCTSlider*.hxx",
+            "React/Views/RCTSwitch*.h",
+            "React/Views/RCTSwitch*.hpp",
+            "React/Views/RCTSwitch*.hxx",
+            "React/Views/RCTWebView*.h",
+            "React/Views/RCTWebView*.hpp",
+            "React/Views/RCTWebView*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -310,6 +550,7 @@ headermap(
   name = "Core_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":Core_cxx_union_hdrs"
   ],
   deps = [
@@ -322,6 +563,7 @@ headermap(
 gen_includes(
   name = "Core_cxx_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -1639,7 +1881,6 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
-    "-std=c++14",
     "-std=c++14"
   ] + select(
     {
@@ -1668,7 +1909,7 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
-  name = "Core_hdrs",
+  name = "Core_direct_hdrs",
   srcs = select(
     {
       "//conditions:default": glob(
@@ -1679,9 +1920,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -1721,9 +1960,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -1760,9 +1997,7 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -1820,9 +2055,189 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "React/**/*.h",
-            "React/**/*.hpp",
-            "React/**/*.hxx"
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/**/RCTTV*.h",
+            "React/**/RCTTV*.hpp",
+            "React/**/RCTTV*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
+          ],
+          exclude = [
+            "**/__tests__/*.h",
+            "**/__tests__/*.hpp",
+            "**/__tests__/*.hxx",
+            "IntegrationTests/*.h",
+            "IntegrationTests/*.hpp",
+            "IntegrationTests/*.hxx",
+            "React/Cxx*/*.h",
+            "React/Cxx*/*.hpp",
+            "React/Cxx*/*.hxx",
+            "React/DevSupport/*.h",
+            "React/DevSupport/*.hpp",
+            "React/DevSupport/*.hxx",
+            "React/Fabric/**/*.h",
+            "React/Fabric/**/*.hpp",
+            "React/Fabric/**/*.hxx",
+            "React/Inspector/*.h",
+            "React/Inspector/*.hpp",
+            "React/Inspector/*.hxx",
+            "React/Modules/RCTClipboard*.h",
+            "React/Modules/RCTClipboard*.hpp",
+            "React/Modules/RCTClipboard*.hxx",
+            "React/Views/RCTDatePicker*.h",
+            "React/Views/RCTDatePicker*.hpp",
+            "React/Views/RCTDatePicker*.hxx",
+            "React/Views/RCTPicker*.h",
+            "React/Views/RCTPicker*.hpp",
+            "React/Views/RCTPicker*.hxx",
+            "React/Views/RCTRefreshControl*.h",
+            "React/Views/RCTRefreshControl*.hpp",
+            "React/Views/RCTRefreshControl*.hxx",
+            "React/Views/RCTSlider*.h",
+            "React/Views/RCTSlider*.hpp",
+            "React/Views/RCTSlider*.hxx",
+            "React/Views/RCTSwitch*.h",
+            "React/Views/RCTSwitch*.hpp",
+            "React/Views/RCTSwitch*.hxx",
+            "React/Views/RCTWebView*.h",
+            "React/Views/RCTWebView*.hpp",
+            "React/Views/RCTWebView*.hxx",
+            "ReactCommon/yoga/*.h",
+            "ReactCommon/yoga/*.hpp",
+            "ReactCommon/yoga/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/*.h"
           ],
           exclude = [
             "**/__tests__/*.h",
@@ -1872,6 +2287,7 @@ headermap(
   name = "Core_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [
@@ -1885,6 +2301,7 @@ headermap(
 gen_includes(
   name = "Core_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -2909,6 +3326,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "CxxBridge_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
     glob(
@@ -2944,6 +3381,7 @@ headermap(
   name = "CxxBridge_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":CxxBridge_cxx_union_hdrs"
   ],
   deps = [
@@ -3025,6 +3463,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "CxxBridge_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CxxBridge_hdrs",
   srcs = glob(
     glob(
@@ -3061,6 +3519,7 @@ headermap(
   name = "CxxBridge_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":CxxBridge_union_hdrs"
   ],
   deps = [
@@ -3136,6 +3595,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "DevSupport_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
     glob(
@@ -3176,6 +3660,7 @@ headermap(
   name = "DevSupport_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":DevSupport_cxx_union_hdrs"
   ],
   deps = [
@@ -3281,6 +3766,31 @@ swift_library(
   data = []
 )
 filegroup(
+  name = "DevSupport_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "DevSupport_hdrs",
   srcs = glob(
     glob(
@@ -3322,6 +3832,7 @@ headermap(
   name = "DevSupport_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":DevSupport_union_hdrs"
   ],
   deps = [
@@ -3399,6 +3910,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTFabric_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Fabric/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
     glob(
@@ -3408,9 +3944,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "React/**/*.h",
-        "React/**/*.hpp",
-        "React/**/*.hxx",
         "React/Fabric/**/*.h"
       ],
       exclude = [
@@ -3442,6 +3975,7 @@ headermap(
   name = "RCTFabric_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTFabric_cxx_union_hdrs"
   ],
   deps = [
@@ -3456,6 +3990,7 @@ headermap(
 gen_includes(
   name = "RCTFabric_cxx_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -3518,7 +4053,6 @@ objc_library(
     ":RCTFabric_cxx_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -3548,6 +4082,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTFabric_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Fabric/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
     glob(
@@ -3557,9 +4116,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "React/**/*.h",
-        "React/**/*.hpp",
-        "React/**/*.hxx",
         "React/Fabric/**/*.h"
       ],
       exclude = [
@@ -3592,6 +4148,7 @@ headermap(
   name = "RCTFabric_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTFabric_union_hdrs"
   ],
   deps = [
@@ -3607,6 +4164,7 @@ headermap(
 gen_includes(
   name = "RCTFabric_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -3682,6 +4240,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "tvOS_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/**/RCTTV*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
     glob(
@@ -3716,6 +4294,7 @@ headermap(
   name = "tvOS_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":tvOS_union_hdrs"
   ],
   deps = [
@@ -3781,6 +4360,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "jschelpers_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jschelpers/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "jschelpers_hdrs",
   srcs = glob(
     glob(
@@ -3815,6 +4414,7 @@ headermap(
   name = "jschelpers_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":jschelpers_union_hdrs"
   ],
   deps = [
@@ -3828,6 +4428,7 @@ headermap(
 gen_includes(
   name = "jschelpers_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -3892,7 +4493,6 @@ objc_library(
     ":jschelpers_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -3920,6 +4520,26 @@ acknowledged_target(
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "jsinspector_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jsinspector/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "jsinspector_hdrs",
@@ -3955,6 +4575,7 @@ headermap(
   name = "jsinspector_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":jsinspector_union_hdrs"
   ],
   deps = [],
@@ -3965,6 +4586,7 @@ headermap(
 gen_includes(
   name = "jsinspector_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4024,7 +4646,6 @@ objc_library(
     ":jsinspector_includes"
   ],
   copts = [
-    "-std=c++14",
     "-std=c++14"
   ] + select(
     {
@@ -4049,6 +4670,26 @@ acknowledged_target(
   name = "jsinspector_acknowledgement",
   deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "PrivateDatabase_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/privatedata/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "PrivateDatabase_hdrs",
@@ -4084,6 +4725,7 @@ headermap(
   name = "PrivateDatabase_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":PrivateDatabase_union_hdrs"
   ],
   deps = [],
@@ -4094,6 +4736,7 @@ headermap(
 gen_includes(
   name = "PrivateDatabase_includes",
   include = [
+    "Vendor/React/ReactCommon",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4158,7 +4801,6 @@ objc_library(
     ":PrivateDatabase_includes"
   ],
   copts = [
-    "-std=c++14",
     "-std=c++14"
   ] + select(
     {
@@ -4183,6 +4825,31 @@ acknowledged_target(
   name = "PrivateDatabase_acknowledgement",
   deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "cxxreact_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/cxxreact/*.h"
+      ],
+      exclude = [
+        "ReactCommon/cxxreact/SampleCxxModule.h",
+        "ReactCommon/cxxreact/SampleCxxModule.hpp",
+        "ReactCommon/cxxreact/SampleCxxModule.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "cxxreact_hdrs",
@@ -4225,6 +4892,7 @@ headermap(
   name = "cxxreact_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":cxxreact_union_hdrs"
   ],
   deps = [
@@ -4240,6 +4908,10 @@ headermap(
 gen_includes(
   name = "cxxreact_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/boost-for-react-native",
+    "Vendor/DoubleConversion",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4297,7 +4969,6 @@ objc_library(
     ":cxxreact_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -4328,6 +4999,18 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_hdrs",
   srcs = glob(
     [
@@ -4353,6 +5036,7 @@ headermap(
   name = "fabric_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_union_hdrs"
   ],
   deps = [],
@@ -4404,6 +5088,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_activityindicator_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/activityindicator/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_activityindicator_hdrs",
   srcs = glob(
     glob(
@@ -4413,10 +5122,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/activityindicator/**/*.h",
-        "fabric/activityindicator/**/*.h",
-        "fabric/activityindicator/**/*.hpp",
-        "fabric/activityindicator/**/*.hxx"
+        "ReactCommon/fabric/activityindicator/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -4445,6 +5151,7 @@ headermap(
   name = "fabric_activityindicator_hmap",
   namespace = "fabric/activityindicator",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_activityindicator_union_hdrs"
   ],
   deps = [
@@ -4457,6 +5164,8 @@ headermap(
 gen_includes(
   name = "fabric_activityindicator_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4496,7 +5205,6 @@ objc_library(
     ":fabric_activityindicator_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -4526,6 +5234,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_attributedstring_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/attributedstring/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_attributedstring_hdrs",
   srcs = glob(
     glob(
@@ -4535,10 +5268,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/attributedstring/**/*.h",
-        "fabric/attributedstring/**/*.h",
-        "fabric/attributedstring/**/*.hpp",
-        "fabric/attributedstring/**/*.hxx"
+        "ReactCommon/fabric/attributedstring/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -4567,6 +5297,7 @@ headermap(
   name = "fabric_attributedstring_hmap",
   namespace = "fabric/attributedstring",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_attributedstring_union_hdrs"
   ],
   deps = [
@@ -4579,6 +5310,8 @@ headermap(
 gen_includes(
   name = "fabric_attributedstring_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4618,7 +5351,6 @@ objc_library(
     ":fabric_attributedstring_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -4648,6 +5380,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/core/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_core_hdrs",
   srcs = glob(
     glob(
@@ -4657,10 +5414,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/core/**/*.h",
-        "fabric/core/**/*.h",
-        "fabric/core/**/*.hpp",
-        "fabric/core/**/*.hxx"
+        "ReactCommon/fabric/core/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -4689,6 +5443,7 @@ headermap(
   name = "fabric_core_hmap",
   namespace = "fabric/core",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_core_union_hdrs"
   ],
   deps = [
@@ -4701,6 +5456,8 @@ headermap(
 gen_includes(
   name = "fabric_core_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4740,7 +5497,6 @@ objc_library(
     ":fabric_core_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -4770,6 +5526,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_debug_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/debug/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_debug_hdrs",
   srcs = glob(
     glob(
@@ -4779,10 +5560,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/debug/**/*.h",
-        "fabric/debug/**/*.h",
-        "fabric/debug/**/*.hpp",
-        "fabric/debug/**/*.hxx"
+        "ReactCommon/fabric/debug/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -4811,6 +5589,7 @@ headermap(
   name = "fabric_debug_hmap",
   namespace = "fabric/debug",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_debug_union_hdrs"
   ],
   deps = [
@@ -4823,6 +5602,8 @@ headermap(
 gen_includes(
   name = "fabric_debug_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4862,7 +5643,6 @@ objc_library(
     ":fabric_debug_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -4892,6 +5672,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_graphics_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/graphics/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_graphics_hdrs",
   srcs = glob(
     glob(
@@ -4901,10 +5706,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/graphics/**/*.h",
-        "fabric/graphics/**/*.h",
-        "fabric/graphics/**/*.hpp",
-        "fabric/graphics/**/*.hxx"
+        "ReactCommon/fabric/graphics/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -4933,6 +5735,7 @@ headermap(
   name = "fabric_graphics_hmap",
   namespace = "fabric/graphics",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_graphics_union_hdrs"
   ],
   deps = [
@@ -4945,6 +5748,8 @@ headermap(
 gen_includes(
   name = "fabric_graphics_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -4984,7 +5789,6 @@ objc_library(
     ":fabric_graphics_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5014,6 +5818,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_scrollview_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/scrollview/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_scrollview_hdrs",
   srcs = glob(
     glob(
@@ -5023,10 +5852,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/scrollview/**/*.h",
-        "fabric/scrollview/**/*.h",
-        "fabric/scrollview/**/*.hpp",
-        "fabric/scrollview/**/*.hxx"
+        "ReactCommon/fabric/scrollview/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5055,6 +5881,7 @@ headermap(
   name = "fabric_scrollview_hmap",
   namespace = "fabric/scrollview",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_scrollview_union_hdrs"
   ],
   deps = [
@@ -5067,6 +5894,8 @@ headermap(
 gen_includes(
   name = "fabric_scrollview_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5106,7 +5935,6 @@ objc_library(
     ":fabric_scrollview_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5136,6 +5964,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_text_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/text/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_text_hdrs",
   srcs = glob(
     glob(
@@ -5145,10 +5998,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/text/**/*.h",
-        "fabric/text/**/*.h",
-        "fabric/text/**/*.hpp",
-        "fabric/text/**/*.hxx"
+        "ReactCommon/fabric/text/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5177,6 +6027,7 @@ headermap(
   name = "fabric_text_hmap",
   namespace = "fabric/text",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_text_union_hdrs"
   ],
   deps = [
@@ -5189,6 +6040,8 @@ headermap(
 gen_includes(
   name = "fabric_text_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5228,7 +6081,6 @@ objc_library(
     ":fabric_text_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5258,6 +6110,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_textlayoutmanager_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/textlayoutmanager/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_textlayoutmanager_hdrs",
   srcs = glob(
     glob(
@@ -5267,10 +6144,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/textlayoutmanager/**/*.h",
-        "fabric/textlayoutmanager/**/*.h",
-        "fabric/textlayoutmanager/**/*.hpp",
-        "fabric/textlayoutmanager/**/*.hxx"
+        "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5299,6 +6173,7 @@ headermap(
   name = "fabric_textlayoutmanager_hmap",
   namespace = "fabric/textlayoutmanager",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_textlayoutmanager_union_hdrs"
   ],
   deps = [
@@ -5311,6 +6186,8 @@ headermap(
 gen_includes(
   name = "fabric_textlayoutmanager_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5351,7 +6228,6 @@ objc_library(
     ":fabric_textlayoutmanager_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5381,6 +6257,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_uimanager_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/uimanager/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_uimanager_hdrs",
   srcs = glob(
     glob(
@@ -5390,10 +6291,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/uimanager/**/*.h",
-        "fabric/uimanager/**/*.h",
-        "fabric/uimanager/**/*.hpp",
-        "fabric/uimanager/**/*.hxx"
+        "ReactCommon/fabric/uimanager/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5422,6 +6320,7 @@ headermap(
   name = "fabric_uimanager_hmap",
   namespace = "fabric/uimanager",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_uimanager_union_hdrs"
   ],
   deps = [
@@ -5434,6 +6333,8 @@ headermap(
 gen_includes(
   name = "fabric_uimanager_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5473,7 +6374,6 @@ objc_library(
     ":fabric_uimanager_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5503,6 +6403,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fabric_view_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/view/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_view_hdrs",
   srcs = glob(
     glob(
@@ -5512,10 +6437,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/view/**/*.h",
-        "fabric/view/**/*.h",
-        "fabric/view/**/*.hpp",
-        "fabric/view/**/*.hxx"
+        "ReactCommon/fabric/view/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5544,6 +6466,7 @@ headermap(
   name = "fabric_view_hmap",
   namespace = "fabric/view",
   hdrs = [
+    "React_package_hdrs",
     ":fabric_view_union_hdrs"
   ],
   deps = [
@@ -5557,6 +6480,8 @@ headermap(
 gen_includes(
   name = "fabric_view_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5597,7 +6522,6 @@ objc_library(
     ":fabric_view_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5628,6 +6552,31 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTFabricSample_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/fabric/sample/**/*.h"
+      ],
+      exclude = [
+        "**/tests/*.h",
+        "**/tests/*.hpp",
+        "**/tests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
     glob(
@@ -5637,10 +6586,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "ReactCommon/fabric/sample/**/*.h",
-        "fabric/sample/**/*.h",
-        "fabric/sample/**/*.hpp",
-        "fabric/sample/**/*.hxx"
+        "ReactCommon/fabric/sample/**/*.h"
       ],
       exclude = [
         "**/tests/*.h",
@@ -5669,6 +6615,7 @@ headermap(
   name = "RCTFabricSample_hmap",
   namespace = "fabric/sample",
   hdrs = [
+    "React_package_hdrs",
     ":RCTFabricSample_union_hdrs"
   ],
   deps = [
@@ -5681,6 +6628,8 @@ headermap(
 gen_includes(
   name = "RCTFabricSample_includes",
   include = [
+    "Vendor/React/ReactCommon",
+    "Vendor/Folly",
     "Vendor/React/pod_support/Headers/Public/"
   ]
 )
@@ -5720,7 +6669,6 @@ objc_library(
     ":RCTFabricSample_includes"
   ],
   copts = [
-    "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
     "-std=c++14"
   ] + select(
@@ -5748,6 +6696,26 @@ acknowledged_target(
     "//Vendor/Folly:Folly_acknowledgement"
   ],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "ART_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "ART_hdrs",
@@ -5784,6 +6752,7 @@ headermap(
   name = "ART_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":ART_union_hdrs"
   ],
   deps = [
@@ -5849,6 +6818,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTActionSheet_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
     glob(
@@ -5883,6 +6872,7 @@ headermap(
   name = "RCTActionSheet_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTActionSheet_union_hdrs"
   ],
   deps = [
@@ -5948,6 +6938,28 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTAnimation_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/NativeAnimation/*.h",
+        "Libraries/NativeAnimation/Drivers/*.h",
+        "Libraries/NativeAnimation/Nodes/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
     glob(
@@ -5959,10 +6971,7 @@ filegroup(
       [
         "Libraries/NativeAnimation/*.h",
         "Libraries/NativeAnimation/Drivers/*.h",
-        "Libraries/NativeAnimation/Nodes/*.h",
-        "RCTAnimation/**/*.h",
-        "RCTAnimation/**/*.hpp",
-        "RCTAnimation/**/*.hxx"
+        "Libraries/NativeAnimation/Nodes/*.h"
       ],
       exclude_directories = 1
     ),
@@ -5987,6 +6996,7 @@ headermap(
   name = "RCTAnimation_hmap",
   namespace = "RCTAnimation",
   hdrs = [
+    "React_package_hdrs",
     ":RCTAnimation_union_hdrs"
   ],
   deps = [
@@ -6054,6 +7064,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTBlob_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTBlob_cxx_hdrs",
   srcs = glob(
     glob(
@@ -6088,6 +7118,7 @@ headermap(
   name = "RCTBlob_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTBlob_cxx_union_hdrs"
   ],
   deps = [
@@ -6203,6 +7234,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTBlob_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
     glob(
@@ -6238,6 +7289,7 @@ headermap(
   name = "RCTBlob_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTBlob_union_hdrs"
   ],
   deps = [
@@ -6347,6 +7399,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTCameraRoll_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/CameraRoll/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
     glob(
@@ -6382,6 +7454,7 @@ headermap(
   name = "RCTCameraRoll_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTCameraRoll_union_hdrs"
   ],
   deps = [
@@ -6449,6 +7522,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTGeolocation_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
     glob(
@@ -6483,6 +7576,7 @@ headermap(
   name = "RCTGeolocation_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTGeolocation_union_hdrs"
   ],
   deps = [
@@ -6548,6 +7642,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTImage_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
     glob(
@@ -6583,6 +7697,7 @@ headermap(
   name = "RCTImage_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTImage_union_hdrs"
   ],
   deps = [
@@ -6656,6 +7771,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTNetwork_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTNetwork_cxx_hdrs",
   srcs = glob(
     glob(
@@ -6690,6 +7825,7 @@ headermap(
   name = "RCTNetwork_cxx_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTNetwork_cxx_union_hdrs"
   ],
   deps = [
@@ -6774,6 +7910,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTNetwork_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
     glob(
@@ -6809,6 +7965,7 @@ headermap(
   name = "RCTNetwork_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTNetwork_union_hdrs"
   ],
   deps = [
@@ -6887,6 +8044,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTPushNotification_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
     glob(
@@ -6921,6 +8098,7 @@ headermap(
   name = "RCTPushNotification_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTPushNotification_union_hdrs"
   ],
   deps = [
@@ -6986,6 +8164,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTSettings_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
     glob(
@@ -7020,6 +8218,7 @@ headermap(
   name = "RCTSettings_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTSettings_union_hdrs"
   ],
   deps = [
@@ -7085,6 +8284,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTText_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
     glob(
@@ -7119,6 +8338,7 @@ headermap(
   name = "RCTText_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTText_union_hdrs"
   ],
   deps = [
@@ -7184,6 +8404,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTVibration_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
     glob(
@@ -7218,6 +8458,7 @@ headermap(
   name = "RCTVibration_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTVibration_union_hdrs"
   ],
   deps = [
@@ -7283,6 +8524,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTWebSocket_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
     glob(
@@ -7319,6 +8580,7 @@ headermap(
   name = "RCTWebSocket_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTWebSocket_union_hdrs"
   ],
   deps = [
@@ -7425,6 +8687,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "fishhook_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/fishhook/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
     glob(
@@ -7434,10 +8716,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/fishhook/*.h",
-        "fishhook/**/*.h",
-        "fishhook/**/*.hpp",
-        "fishhook/**/*.hxx"
+        "Libraries/fishhook/*.h"
       ],
       exclude_directories = 1
     ),
@@ -7461,6 +8740,7 @@ headermap(
   name = "fishhook_hmap",
   namespace = "fishhook",
   hdrs = [
+    "React_package_hdrs",
     ":fishhook_union_hdrs"
   ],
   deps = [],
@@ -7565,6 +8845,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTLinkingIOS_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
     glob(
@@ -7599,6 +8899,7 @@ headermap(
   name = "RCTLinkingIOS_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTLinkingIOS_union_hdrs"
   ],
   deps = [
@@ -7664,6 +8965,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTTest_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/RCTTest/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
     glob(
@@ -7698,6 +9019,7 @@ headermap(
   name = "RCTTest_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTTest_union_hdrs"
   ],
   deps = [
@@ -7766,6 +9088,18 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "_ignore_me_subspec_for_linting__direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "_ignore_me_subspec_for_linting__hdrs",
   srcs = glob(
     [
@@ -7793,6 +9127,7 @@ headermap(
   name = "_ignore_me_subspec_for_linting__hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":_ignore_me_subspec_for_linting__union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -35,6 +35,62 @@ config_setting(
   }
 )
 filegroup(
+  name = "React_package_hdrs",
+  srcs = [
+    "React_direct_hdrs",
+    "Core_direct_hdrs",
+    "ART_direct_hdrs",
+    "RCTActionSheet_direct_hdrs",
+    "RCTAdSupport_direct_hdrs",
+    "RCTGeolocation_direct_hdrs",
+    "RCTImage_direct_hdrs",
+    "RCTNetwork_direct_hdrs",
+    "RCTPushNotification_direct_hdrs",
+    "RCTSettings_direct_hdrs",
+    "RCTText_direct_hdrs",
+    "RCTVibration_direct_hdrs",
+    "RCTWebSocket_direct_hdrs",
+    "RCTLinkingIOS_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PATENTS/**/*.h",
+        "PATENTS/**/*.hpp",
+        "PATENTS/**/*.hxx",
+        "lint/**/*.h",
+        "lint/**/*.hpp",
+        "lint/**/*.hxx",
+        "node_modules/**/*.h",
+        "node_modules/**/*.hpp",
+        "node_modules/**/*.hxx",
+        "packager/**/*.h",
+        "packager/**/*.hpp",
+        "packager/**/*.hxx",
+        "react-native-cli/**/*.h",
+        "react-native-cli/**/*.hpp",
+        "react-native-cli/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "React_hdrs",
   srcs = glob(
     glob(
@@ -74,6 +130,7 @@ headermap(
   name = "React_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":React_hdrs"
   ],
   deps = [
@@ -126,6 +183,49 @@ acknowledged_target(
   name = "React_acknowledgement",
   deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PATENTS/**/*.h",
+        "PATENTS/**/*.hpp",
+        "PATENTS/**/*.hxx",
+        "React/**/*.h",
+        "lint/**/*.h",
+        "lint/**/*.hpp",
+        "lint/**/*.hxx",
+        "node_modules/**/*.h",
+        "node_modules/**/*.hpp",
+        "node_modules/**/*.hxx",
+        "packager/**/*.h",
+        "packager/**/*.hpp",
+        "packager/**/*.hxx",
+        "react-native-cli/**/*.h",
+        "react-native-cli/**/*.hpp",
+        "react-native-cli/**/*.hxx"
+      ],
+      exclude = [
+        "**/__tests__/*.h",
+        "**/__tests__/*.hpp",
+        "**/__tests__/*.hxx",
+        "IntegrationTests/*.h",
+        "IntegrationTests/*.hpp",
+        "IntegrationTests/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "Core_hdrs",
@@ -184,6 +284,7 @@ headermap(
   name = "Core_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],
@@ -328,6 +429,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "ART_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ART_hdrs",
   srcs = glob(
     glob(
@@ -337,22 +458,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/ART/**/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/ART/**/*.h"
       ],
       exclude_directories = 1
     ),
@@ -377,6 +483,7 @@ headermap(
   name = "ART_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":ART_union_hdrs"
   ],
   deps = [
@@ -442,6 +549,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTActionSheet_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
     glob(
@@ -451,22 +578,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/ActionSheetIOS/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/ActionSheetIOS/*.h"
       ],
       exclude_directories = 1
     ),
@@ -491,6 +603,7 @@ headermap(
   name = "RCTActionSheet_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTActionSheet_union_hdrs"
   ],
   deps = [
@@ -556,6 +669,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTAdSupport_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/AdSupport/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
     glob(
@@ -565,22 +698,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/AdSupport/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/AdSupport/*.h"
       ],
       exclude_directories = 1
     ),
@@ -605,6 +723,7 @@ headermap(
   name = "RCTAdSupport_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTAdSupport_union_hdrs"
   ],
   deps = [
@@ -670,6 +789,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTGeolocation_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
     glob(
@@ -679,22 +818,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Geolocation/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Geolocation/*.h"
       ],
       exclude_directories = 1
     ),
@@ -719,6 +843,7 @@ headermap(
   name = "RCTGeolocation_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTGeolocation_union_hdrs"
   ],
   deps = [
@@ -784,6 +909,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTImage_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
     glob(
@@ -793,22 +938,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Image/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Image/*.h"
       ],
       exclude_directories = 1
     ),
@@ -833,6 +963,7 @@ headermap(
   name = "RCTImage_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTImage_union_hdrs"
   ],
   deps = [
@@ -898,6 +1029,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTNetwork_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
     glob(
@@ -907,22 +1058,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Network/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Network/*.h"
       ],
       exclude_directories = 1
     ),
@@ -947,6 +1083,7 @@ headermap(
   name = "RCTNetwork_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTNetwork_union_hdrs"
   ],
   deps = [
@@ -1012,6 +1149,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTPushNotification_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
     glob(
@@ -1021,22 +1178,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/PushNotificationIOS/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/PushNotificationIOS/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1061,6 +1203,7 @@ headermap(
   name = "RCTPushNotification_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTPushNotification_union_hdrs"
   ],
   deps = [
@@ -1126,6 +1269,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTSettings_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
     glob(
@@ -1135,22 +1298,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Settings/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Settings/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1175,6 +1323,7 @@ headermap(
   name = "RCTSettings_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTSettings_union_hdrs"
   ],
   deps = [
@@ -1240,6 +1389,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTText_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
     glob(
@@ -1249,22 +1418,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Text/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Text/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1289,6 +1443,7 @@ headermap(
   name = "RCTText_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTText_union_hdrs"
   ],
   deps = [
@@ -1354,6 +1509,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTVibration_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
     glob(
@@ -1363,22 +1538,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/Vibration/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/Vibration/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1403,6 +1563,7 @@ headermap(
   name = "RCTVibration_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTVibration_union_hdrs"
   ],
   deps = [
@@ -1468,6 +1629,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTWebSocket_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
     glob(
@@ -1477,22 +1658,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/WebSocket/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/WebSocket/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1517,6 +1683,7 @@ headermap(
   name = "RCTWebSocket_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTWebSocket_union_hdrs"
   ],
   deps = [
@@ -1582,6 +1749,26 @@ acknowledged_target(
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "RCTLinkingIOS_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
     glob(
@@ -1591,22 +1778,7 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Libraries/LinkingIOS/*.h",
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
+        "Libraries/LinkingIOS/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1631,6 +1803,7 @@ headermap(
   name = "RCTLinkingIOS_hmap",
   namespace = "React",
   hdrs = [
+    "React_package_hdrs",
     ":RCTLinkingIOS_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -36,6 +36,38 @@ config_setting(
   }
 )
 filegroup(
+  name = "SFHFKeychainUtils_package_hdrs",
+  srcs = [
+    "SFHFKeychainUtils_cxx_direct_hdrs",
+    "SFHFKeychainUtils_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SFHFKeychainUtils_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
     glob(
@@ -71,6 +103,7 @@ headermap(
   name = "SFHFKeychainUtils_cxx_hmap",
   namespace = "SFHFKeychainUtils",
   hdrs = [
+    "SFHFKeychainUtils_package_hdrs",
     ":SFHFKeychainUtils_cxx_union_hdrs"
   ],
   deps = [],
@@ -161,6 +194,28 @@ swift_library(
   data = []
 )
 filegroup(
+  name = "SFHFKeychainUtils_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
     glob(
@@ -188,6 +243,7 @@ headermap(
   name = "SFHFKeychainUtils_hmap",
   namespace = "SFHFKeychainUtils",
   hdrs = [
+    "SFHFKeychainUtils_package_hdrs",
     ":SFHFKeychainUtils_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "SPUserResizableView+Pion_package_hdrs",
+  srcs = [
+    "SPUserResizableView+Pion_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SPUserResizableView+Pion_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SPUserResizableView/SPUserResizableView.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "SPUserResizableView+Pion_hmap",
   namespace = "SPUserResizableView+Pion",
   hdrs = [
+    "SPUserResizableView+Pion_package_hdrs",
     ":SPUserResizableView+Pion_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -35,6 +35,13 @@ config_setting(
     "apple_platform_type": "watchos"
   }
 )
+filegroup(
+  name = "SevenSwitch_package_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 swift_library(
   name = "SevenSwitch",
   srcs = glob(

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "SlackTextViewController_package_hdrs",
+  srcs = [
+    "SlackTextViewController_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SlackTextViewController_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "SlackTextViewController_hmap",
   namespace = "SlackTextViewController",
   hdrs = [
+    "SlackTextViewController_package_hdrs",
     ":SlackTextViewController_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "Smartling_package_hdrs",
+  srcs = [
+    "Smartling_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Smartling_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "Smartling_hmap",
   namespace = "Smartling",
   hdrs = [
+    "Smartling_package_hdrs",
     ":Smartling_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -36,6 +36,36 @@ config_setting(
   }
 )
 filegroup(
+  name = "Stripe_package_hdrs",
+  srcs = [
+    "Stripe_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Stripe_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Stripe/*.h",
+        "Stripe/PublicHeaders/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
     glob(
@@ -60,6 +90,7 @@ headermap(
   name = "Stripe_hmap",
   namespace = "Stripe",
   hdrs = [
+    "Stripe_package_hdrs",
     ":Stripe_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -35,6 +35,28 @@ config_setting(
   }
 )
 filegroup(
+  name = "TestArcPatternsWithExcludes_package_hdrs",
+  srcs = [
+    "TestArcPatternsWithExcludes_direct_hdrs",
+    "Core_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "TestArcPatternsWithExcludes_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = glob(
     [
@@ -52,6 +74,7 @@ headermap(
   name = "TestArcPatternsWithExcludes_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "TestArcPatternsWithExcludes_package_hdrs",
     ":FBSDKCoreKit_hdrs"
   ],
   deps = [
@@ -140,6 +163,86 @@ acknowledged_target(
   name = "TestArcPatternsWithExcludes_acknowledgement",
   deps = [],
   value = "//Vendor/TestArcPatternsWithExcludes/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Core_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "**/*.h"
+          ],
+          exclude = [
+            "CORE_EXCLUDE/**/*.h",
+            "CORE_EXCLUDE_IOS/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "**/*.h"
+          ],
+          exclude = [
+            "CORE_EXCLUDE/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "**/*.h"
+          ],
+          exclude = [
+            "CORE_EXCLUDE/**/*.h",
+            "CORE_EXCLUDE_TV/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "**/*.h"
+          ],
+          exclude = [
+            "CORE_EXCLUDE/**/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "Core_hdrs",
@@ -235,6 +338,7 @@ headermap(
   name = "Core_hmap",
   namespace = "FBSDKCoreKit",
   hdrs = [
+    "TestArcPatternsWithExcludes_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -35,21 +35,40 @@ config_setting(
   }
 )
 filegroup(
+  name = "Texture_package_hdrs",
+  srcs = [
+    "Texture_direct_hdrs",
+    "Core_cxx_direct_hdrs",
+    "Core_direct_hdrs",
+    "PINRemoteImage_direct_hdrs",
+    "IGListKit_direct_hdrs",
+    "Yoga_direct_hdrs",
+    "MapKit_direct_hdrs",
+    "Photos_direct_hdrs",
+    "AssetsLibrary_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Texture_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Texture_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ) + [
     ":AssetsLibrary_hdrs",
@@ -65,6 +84,7 @@ headermap(
   name = "Texture_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":Texture_hdrs"
   ],
   deps = [
@@ -128,6 +148,28 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/TextKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
     glob(
@@ -137,9 +179,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx",
         "Base/*.h",
         "Source/**/*.h",
         "Source/TextKit/*.h"
@@ -166,6 +205,7 @@ headermap(
   name = "Core_cxx_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":Core_cxx_union_hdrs"
   ],
   deps = [],
@@ -243,6 +283,28 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/TextKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -252,9 +314,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx",
         "Base/*.h",
         "Source/**/*.h",
         "Source/TextKit/*.h"
@@ -282,6 +341,7 @@ headermap(
   name = "Core_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [
@@ -354,21 +414,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "PINRemoteImage_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINRemoteImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -390,6 +452,7 @@ headermap(
   name = "PINRemoteImage_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":PINRemoteImage_union_hdrs"
   ],
   deps = [
@@ -454,21 +517,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "IGListKit_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -490,6 +555,7 @@ headermap(
   name = "IGListKit_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":IGListKit_union_hdrs"
   ],
   deps = [
@@ -551,21 +617,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Yoga_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Yoga_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -587,6 +655,7 @@ headermap(
   name = "Yoga_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":Yoga_union_hdrs"
   ],
   deps = [
@@ -650,21 +719,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "MapKit_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "MapKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -686,6 +757,7 @@ headermap(
   name = "MapKit_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":MapKit_union_hdrs"
   ],
   deps = [
@@ -748,21 +820,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Photos_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Photos_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -784,6 +858,7 @@ headermap(
   name = "Photos_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":Photos_union_hdrs"
   ],
   deps = [
@@ -846,21 +921,23 @@ acknowledged_target(
   value = "//Vendor/Texture/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "AssetsLibrary_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "AssetsLibrary_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "AsyncDisplayKit/**/*.h",
-        "AsyncDisplayKit/**/*.hpp",
-        "AsyncDisplayKit/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -882,6 +959,7 @@ headermap(
   name = "AssetsLibrary_hmap",
   namespace = "AsyncDisplayKit",
   hdrs = [
+    "Texture_package_hdrs",
     ":AssetsLibrary_union_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -36,6 +36,38 @@ config_setting(
   }
 )
 filegroup(
+  name = "UICollectionViewLeftAlignedLayout_package_hdrs",
+  srcs = [
+    "UICollectionViewLeftAlignedLayout_cxx_direct_hdrs",
+    "UICollectionViewLeftAlignedLayout_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "UICollectionViewLeftAlignedLayout_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
     glob(
@@ -71,6 +103,7 @@ headermap(
   name = "UICollectionViewLeftAlignedLayout_cxx_hmap",
   namespace = "UICollectionViewLeftAlignedLayout",
   hdrs = [
+    "UICollectionViewLeftAlignedLayout_package_hdrs",
     ":UICollectionViewLeftAlignedLayout_cxx_union_hdrs"
   ],
   deps = [],
@@ -158,6 +191,28 @@ swift_library(
   data = []
 )
 filegroup(
+  name = "UICollectionViewLeftAlignedLayout_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
     glob(
@@ -185,6 +240,7 @@ headermap(
   name = "UICollectionViewLeftAlignedLayout_hmap",
   namespace = "UICollectionViewLeftAlignedLayout",
   hdrs = [
+    "UICollectionViewLeftAlignedLayout_package_hdrs",
     ":UICollectionViewLeftAlignedLayout_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "Weixin_package_hdrs",
+  srcs = [
+    "Weixin_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Weixin_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SDK1.6.2/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "Weixin_hmap",
   namespace = "Weixin",
   hdrs = [
+    "Weixin_package_hdrs",
     ":Weixin_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -35,6 +35,40 @@ config_setting(
   }
 )
 filegroup(
+  name = "ZipArchive_package_hdrs",
+  srcs = [
+    "ZipArchive_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "ZipArchive_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h",
+        "minizip/crypt.h",
+        "minizip/ioapi.h",
+        "minizip/mztools.h",
+        "minizip/unzip.h",
+        "minizip/zip.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
     glob(
@@ -63,6 +97,7 @@ headermap(
   name = "ZipArchive_hmap",
   namespace = "ZipArchive",
   hdrs = [
+    "ZipArchive_package_hdrs",
     ":ZipArchive_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -35,6 +35,37 @@ config_setting(
   }
 )
 filegroup(
+  name = "boost-for-react-native_package_hdrs",
+  srcs = [
+    "boost-for-react-native_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "boost-for-react-native_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "boost/**/*.h",
+        "boost/**/*.hpp",
+        "boost/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
     glob(
@@ -60,6 +91,7 @@ headermap(
   name = "boost-for-react-native_hmap",
   namespace = "boost",
   hdrs = [
+    "boost-for-react-native_package_hdrs",
     ":boost-for-react-native_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -35,6 +35,42 @@ config_setting(
   }
 )
 filegroup(
+  name = "glog_package_hdrs",
+  srcs = [
+    "glog_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "glog_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/*.h",
+        "src/base/*.h",
+        "src/glog/*.h"
+      ],
+      exclude = [
+        "src/windows/**/*.h",
+        "src/windows/**/*.hpp",
+        "src/windows/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "glog_hdrs",
   srcs = glob(
     glob(
@@ -44,9 +80,6 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "glog/**/*.h",
-        "glog/**/*.hpp",
-        "glog/**/*.hxx",
         "src/*.h",
         "src/base/*.h",
         "src/glog/*.h"
@@ -68,6 +101,7 @@ headermap(
   name = "glog_hmap",
   namespace = "glog",
   hdrs = [
+    "glog_package_hdrs",
     ":glog_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -35,6 +35,29 @@ config_setting(
   }
 )
 filegroup(
+  name = "googleapis_package_hdrs",
+  srcs = [
+    "googleapis_direct_hdrs",
+    "Messages_direct_hdrs",
+    "Services_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "googleapis_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "googleapis_hdrs",
   srcs = glob(
     [
@@ -53,6 +76,7 @@ headermap(
   name = "googleapis_hmap",
   namespace = "googleapis",
   hdrs = [
+    "googleapis_package_hdrs",
     ":googleapis_hdrs"
   ],
   deps = [
@@ -115,6 +139,26 @@ acknowledged_target(
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Messages_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbobjc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Messages_hdrs",
   srcs = glob(
     glob(
@@ -148,10 +192,11 @@ headermap(
   name = "Messages_hmap",
   namespace = "googleapis",
   hdrs = [
+    "googleapis_package_hdrs",
     ":Messages_union_hdrs"
   ],
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin"
+    "//Vendor/Protobuf:Protobuf"
   ],
   visibility = [
     "//visibility:public"
@@ -170,6 +215,12 @@ objc_library(
     [
       "google/**/*.pbobjc.m"
     ],
+    exclude = glob(
+      [
+        "google/**/*.pbrpc.m"
+      ],
+      exclude_directories = 1
+    ),
     exclude_directories = 1
   ),
   hdrs = [
@@ -180,7 +231,7 @@ objc_library(
     []
   ),
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
+    "//Vendor/Protobuf:Protobuf",
     ":Messages_includes"
   ],
   copts = [
@@ -207,9 +258,29 @@ objc_library(
 acknowledged_target(
   name = "Messages_acknowledgement",
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin_acknowledgement"
+    "//Vendor/Protobuf:Protobuf_acknowledgement"
   ],
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Services_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbrpc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
 )
 filegroup(
   name = "Services_hdrs",
@@ -235,7 +306,8 @@ filegroup(
   name = "Services_union_hdrs",
   srcs = [
     "Services_hdrs",
-    "googleapis_hdrs"
+    "googleapis_hdrs",
+    ":Messages_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -245,10 +317,12 @@ headermap(
   name = "Services_hmap",
   namespace = "googleapis",
   hdrs = [
+    "googleapis_package_hdrs",
     ":Services_union_hdrs"
   ],
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin"
+    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
+    ":Messages"
   ],
   visibility = [
     "//visibility:public"
@@ -282,7 +356,8 @@ objc_library(
     )
   ),
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
+    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
+    ":Messages",
     ":Services_includes"
   ],
   copts = [
@@ -309,7 +384,7 @@ objc_library(
 acknowledged_target(
   name = "Services_acknowledgement",
   deps = [
-    "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin_acknowledgement"
+    "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC_acknowledgement"
   ],
   value = "//Vendor/googleapis/pod_support_buildable:acknowledgement_fragment"
 )

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -36,6 +36,28 @@ config_setting(
   }
 )
 filegroup(
+  name = "iOSSnapshotTestCase_package_hdrs",
+  srcs = [
+    "iOSSnapshotTestCase_direct_hdrs",
+    "Core_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "iOSSnapshotTestCase_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iOSSnapshotTestCase_hdrs",
   srcs = glob(
     [
@@ -51,6 +73,7 @@ headermap(
   name = "iOSSnapshotTestCase_hmap",
   namespace = "FBSnapshotTestCase",
   hdrs = [
+    "iOSSnapshotTestCase_package_hdrs",
     ":iOSSnapshotTestCase_hdrs"
   ],
   deps = [
@@ -111,6 +134,30 @@ acknowledged_target(
   value = "//Vendor/iOSSnapshotTestCase/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSnapshotTestCase/**/*.h",
+        "FBSnapshotTestCase/*.h",
+        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -148,6 +195,7 @@ headermap(
   name = "Core_hmap",
   namespace = "FBSnapshotTestCase",
   hdrs = [
+    "iOSSnapshotTestCase_package_hdrs",
     ":Core_union_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -36,6 +36,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "iRate_package_hdrs",
+  srcs = [
+    "iRate_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "iRate_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "iRate/iRate.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iRate_hdrs",
   srcs = glob(
     glob(
@@ -59,6 +88,7 @@ headermap(
   name = "iRate_hmap",
   namespace = "iRate",
   hdrs = [
+    "iRate_package_hdrs",
     ":iRate_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -35,6 +35,35 @@ config_setting(
   }
 )
 filegroup(
+  name = "kingpin_package_hdrs",
+  srcs = [
+    "kingpin_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "kingpin_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "kingpin/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
     glob(
@@ -58,6 +87,7 @@ headermap(
   name = "kingpin_hmap",
   namespace = "kingpin",
   hdrs = [
+    "kingpin_package_hdrs",
     ":kingpin_hdrs"
   ],
   deps = [],

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -35,6 +35,36 @@ config_setting(
   }
 )
 filegroup(
+  name = "pop_package_hdrs",
+  srcs = [
+    "pop_cxx_direct_hdrs",
+    "pop_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "pop_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "pop_cxx_hdrs",
   srcs = glob(
     glob(
@@ -68,6 +98,7 @@ headermap(
   name = "pop_cxx_hmap",
   namespace = "pop",
   hdrs = [
+    "pop_package_hdrs",
     ":pop_cxx_union_hdrs"
   ],
   deps = [],
@@ -144,6 +175,26 @@ acknowledged_target(
   value = "//Vendor/pop/pod_support_buildable:acknowledgement_fragment"
 )
 filegroup(
+  name = "pop_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "pop_hdrs",
   srcs = glob(
     glob(
@@ -169,6 +220,7 @@ headermap(
   name = "pop_hmap",
   namespace = "pop",
   hdrs = [
+    "pop_package_hdrs",
     ":pop_hdrs"
   ],
   deps = [

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -37,6 +37,100 @@ config_setting(
   }
 )
 filegroup(
+  name = "youtube-ios-player-helper_package_hdrs",
+  srcs = [
+    "youtube-ios-player-helper_cxx_direct_hdrs",
+    "youtube-ios-player-helper_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "youtube-ios-player-helper_cxx_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude = [
+            "Classes/osx/**/*.h",
+            "Classes/osx/**/*.hpp",
+            "Classes/osx/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude = [
+            "Classes/ios/**/*.h",
+            "Classes/ios/**/*.hpp",
+            "Classes/ios/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "youtube-ios-player-helper_cxx_hdrs",
   srcs = select(
     {
@@ -134,6 +228,7 @@ headermap(
   name = "youtube-ios-player-helper_cxx_hmap",
   namespace = "youtube-ios-player-helper",
   hdrs = [
+    "youtube-ios-player-helper_package_hdrs",
     ":youtube-ios-player-helper_cxx_union_hdrs"
   ],
   deps = [],
@@ -348,6 +443,90 @@ swift_library(
   data = []
 )
 filegroup(
+  name = "youtube-ios-player-helper_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude = [
+            "Classes/osx/**/*.h",
+            "Classes/osx/**/*.hpp",
+            "Classes/osx/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":osxCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude = [
+            "Classes/ios/**/*.h",
+            "Classes/ios/**/*.hpp",
+            "Classes/ios/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      ":watchosCase": glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "youtube-ios-player-helper_hdrs",
   srcs = select(
     {
@@ -437,6 +616,7 @@ headermap(
   name = "youtube-ios-player-helper_hmap",
   namespace = "youtube-ios-player-helper",
   hdrs = [
+    "youtube-ios-player-helper_package_hdrs",
     ":youtube-ios-player-helper_hdrs"
   ],
   deps = [

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build-test: pod_test build archive init-sandbox
 	cd Examples/BasiciOS && make all
 	cd Examples/PINRemoteImage && make all
 	cd Examples/Texture && make all
+	cd Examples/ChildPodspec && make all
 
 build-example: EXAMPLE=Examples/PINCache.podspec.json
 build-example: CONFIG = debug

--- a/Sources/PodToBUILD/PodSpec.swift
+++ b/Sources/PodToBUILD/PodSpec.swift
@@ -355,7 +355,7 @@ public func ExtractValue<T>(fromJSON JSON: Any?) throws -> T {
 // Pods intermixes arrays and strings all over
 // Coerce to a more sane type, since we don't care about the
 // original input
-fileprivate func strings(fromJSON JSONValue: Any? = nil) -> [String] {
+public func strings(fromJSON JSONValue: Any? = nil) -> [String] {
     if let str = JSONValue as? String {
         return [str]
     }

--- a/Sources/PodToBUILD/RuleUtils.swift
+++ b/Sources/PodToBUILD/RuleUtils.swift
@@ -134,7 +134,7 @@ public func getDependencyName(fromPodDepName podDepName: String, podName: String
     if results.count > 1 && results[0] == podName {
         // This is a local subspec reference
         let join = results[1 ... results.count - 1].joined(separator: "/")
-        return ":\(bazelLabel(fromString: join))"
+        return ":\(getNamePrefix() + bazelLabel(fromString: join))"
     } else {
         if results.count > 1 {
             let join = results[1 ... results.count - 1].joined(separator: "/")

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -218,35 +218,137 @@ public enum RepoActions {
         let podspecName = CommandLine.arguments[1]
         if buildOptions.path != "." && buildOptions.childPaths.count == 0 {
             // Write an alias BUILD file that points to the source directory
-            let visibility = SkylarkNode.functionCall(name: "package",
-                arguments: [
-                    .named(name: "default_visibility",
-                           value: .list([.string("//visibility:public")]))
-                ])
-            let alias = Alias(name: podspecName,
-                actual: "//" + buildOptions.path + ":" + podspecName)
-            let acknowledgmentAlias = Alias(name: podspecName + "_acknowledgement",
-                actual: "//" + buildOptions.path + ":" + podspecName + "_acknowledgement")
-            let compiler = SkylarkCompiler(.lines([
-                    visibility.toSkylark(),
-                    alias.toSkylark(),
-                    acknowledgmentAlias.toSkylark()
-            ]))
-            shell.write(value: compiler.run(), toPath:
-                BazelConstants.buildFileURL())
-            return
+            // this supports naming conventions of //Vendor|external/Podname
+            initializeAliasDirectory(shell: shell, podspecName: podspecName,
+                buildOptions: buildOptions)
+        } else {
+            initializePodspecDirectory(shell: shell, podspecName: podspecName,
+                buildOptions: buildOptions)
+        }
+    }
+
+    static func getJSONPodspec(shell: ShellContext, podspecName: String, path: String, childPaths: [String]) -> JSONDict {
+        let jsonData: Data
+
+        // Check the path and child paths
+        let podspecPath = "\(path)/\(podspecName).podspec"
+        let currentDirectoryPath = FileManager.default.currentDirectoryPath
+        if FileManager.default.fileExists(atPath: "\(podspecPath).json") {
+            jsonData = shell.command("/bin/cat", arguments: [podspecPath + ".json"]).standardOutputData
+        } else if FileManager.default.fileExists(atPath: podspecPath) {
+            // This uses the current environment's cocoapods installation.
+            let whichPod = shell.shellOut("which pod").standardOutputAsString
+            if whichPod.isEmpty {
+                fatalError("RepoTools requires a cocoapod installation on host")
+            }
+            let podBin = whichPod.components(separatedBy: "\n")[0]
+            let podResult = shell.command(podBin, arguments: ["ipc", "spec", podspecPath])
+            guard podResult.terminationStatus == 0 else {
+                fatalError("""
+                        PodSpec decoding failed \(podResult.terminationStatus)
+                        stdout: \(podResult.standardOutputAsString)
+                        stderr: \(podResult.standardErrorAsString)
+                """)
+            }
+            jsonData = podResult.standardOutputData
+        } else {
+            fatalError("Missing podspec ( \(podspecPath) ) inside \(currentDirectoryPath)")
         }
 
-        initializePodspecDirectory(shell: shell, podspecName: podspecName,
-                buildOptions: buildOptions)
-        let currentDirectoryPath = FileManager.default.currentDirectoryPath
-        // Child podspec logic - initializes a child pod, for a given Podspec url
+        guard let JSONFile = try? JSONSerialization.jsonObject(with: jsonData, options:
+            JSONSerialization.ReadingOptions.allowFragments) as AnyObject,
+            let JSONPodspec = JSONFile as? JSONDict
+        else {
+            fatalError("Invalid JSON Podspec: (look inside \(currentDirectoryPath))")
+        }
+        return JSONPodspec
+    }
+
+    private static func updatePodspec(podspec: JSONDict, relPath: String) -> JSONDict {
+        guard relPath.count > 0 else {
+            return podspec
+        }
+
+        // TODO: we need to apply this to a few more fields. Consider
+        // factoring this out to podspec instead of hacking the JSON
+        var mPodspec = podspec
+        mPodspec["source_files"] = strings(fromJSON:
+            mPodspec["source_files"]).map { relPath + "/" + $0 }       
+        var subspecs2: [JSONDict] = mPodspec["subspecs"] as? [JSONDict] ?? []
+        mPodspec["subspecs"] = subspecs2.map {
+            arg -> JSONDict in
+            return updatePodspec(podspec: arg, relPath: relPath)
+        }
+        return mPodspec
+    }
+
+    private static func initializeAliasDirectory(shell: ShellContext, podspecName: String,buildOptions: BuildOptions) {
+        let visibility = SkylarkNode.functionCall(name: "package",
+            arguments: [
+                .named(name: "default_visibility",
+                       value: .list([.string("//visibility:public")]))
+            ])
+
+        let parts = buildOptions.path.split(separator: "/")
+        let addName = getNamePrefix()
+        let JSONPodspec = getJSONPodspec(shell: shell, podspecName:
+                                      podspecName, path: "../../" + buildOptions.path,
+                                      childPaths: buildOptions.childPaths)
+        guard let podSpec = try? PodSpec(JSONPodspec: JSONPodspec) else {
+            fatalError("Cant read in podspec")
+        }
+        let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions:
+            buildOptions, assimilate: true)
+
+        let actualPath = parts[0] + "/" + parts[1]
+        let aliases = buildFile.skylarkConvertibles.compactMap {
+            convertible -> SkylarkNode? in
+            guard let target = convertible as? BazelTarget else {
+                return nil
+            }
+            guard target.name != "" else {
+                return nil
+            }
+            let name = target.name
+            let head = buildOptions.podName + "_"
+            let getName: () -> String = {
+                if let headIdx = name.range(of: head) {
+                    return String(name[headIdx.upperBound...])
+                } else {
+                    return name
+                }
+            }
+            let alias = Alias(name: getName(),
+                actual: "//" + actualPath + ":" + name)
+            return alias.toSkylark()
+        }
+
+        let lines = [visibility] + aliases
+        let compiler = SkylarkCompiler(lines)
+        shell.write(value: compiler.run(), toPath:
+            BazelConstants.buildFileURL())
+    }
+
+    private static func initializePodspecDirectory(shell: ShellContext, podspecName: String,buildOptions: BuildOptions) {
+        let workspaceRootPath: String
+        if buildOptions.path != "." && buildOptions.childPaths.count == 0 {
+            workspaceRootPath = "../..\(buildOptions.path)"
+        } else {
+            workspaceRootPath =  "."
+        }
+        let JSONPodspec = getJSONPodspec(shell: shell, podspecName:
+            podspecName, path: workspaceRootPath,
+            childPaths: buildOptions.childPaths)
         var childInfoIter = buildOptions.childPaths.makeIterator()
+        // Batch create several symlinks for Pod style includes
+        let currentDirectoryPath = FileManager.default.currentDirectoryPath
+        var childBuildFiles: [PodBuildFile] = []
         while let childInfo = childInfoIter.next() {
             let childName = childInfo
             guard let childPath = childInfoIter.next() else {
-                fatalError("Invalid path in update_pods.py")
+                fatalError("Invalid child path")
             }
+
             let childBuildOptions = BasicBuildOptions(
                 podName: childName,
                 path: childPath,
@@ -260,72 +362,24 @@ public enum RepoActions {
                 alwaysSplitRules: buildOptions.alwaysSplitRules,
                 vendorize: buildOptions.vendorize,
                 childPaths: buildOptions.childPaths)
-            let absPath = "\(currentDirectoryPath)/../../\(childPath)"
-            guard
-            FileManager.default.changeCurrentDirectoryPath(
-                absPath) else {
-                fatalError("Can't change path to child subspec path: " + String(describing: absPath))
+
+            // We need to drop off the childpath passed in. e.g. Vendor/React
+            // as the source files in the podspec are relative to the podspec
+            let relChildPath = String(childPath.split(separator: "/")
+                .dropFirst().dropFirst().joined(separator: "/") )
+            let childJSONPodspec = getJSONPodspec(shell: shell, podspecName:
+                  childName, path: currentDirectoryPath + "/" + relChildPath,
+                  childPaths: buildOptions.childPaths)
+            guard let podSpec = try? PodSpec(JSONPodspec: childJSONPodspec) else {
+                fatalError("Cant read in podspec")
+
             }
-
-            initializePodspecDirectory(shell: shell, podspecName: childName,
-                buildOptions: childBuildOptions)
-            guard FileManager.default.changeCurrentDirectoryPath(currentDirectoryPath) else {
-                fatalError("Can't change path back to original directory after genning subspec")
-            }
+            let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions: childBuildOptions, assimilate: true)
+            childBuildFiles.append(buildFile)
         }
-    }
-
-    private static func initializePodspecDirectory(shell: ShellContext, podspecName: String,buildOptions: BuildOptions) {
-        // This uses the current environment's cocoapods installation.
-        let whichPod = shell.shellOut("which pod").standardOutputAsString
-        if whichPod.isEmpty {
-            fatalError("RepoTools requires a cocoapod installation on host")
-        }
-
-        // make json data
-        let jsonData: Data
-        let hasFile: (String) -> Bool = { file in
-            // did you know that [ is the name of the binary that tests stuff!
-            return shell.command("/bin/[",
-                          arguments: ["-e", file, "]"]).terminationStatus == 0
-        }
-
-        let workspaceRootPath: String
-        if buildOptions.path != "." && buildOptions.childPaths.count == 0 {
-            workspaceRootPath = "../..\(buildOptions.path)"
-        } else {
-            workspaceRootPath =  "."
-        }
-
-        let podspecPath = "\(workspaceRootPath)/\(podspecName).podspec"
-        if hasFile("\(podspecPath).json") {
-            jsonData = shell.command("/bin/cat", arguments: [podspecName + ".podspec.json"]).standardOutputData
-        } else if hasFile(podspecPath) {
-            let podBin = whichPod.components(separatedBy: "\n")[0]
-            let podResult = shell.command(podBin, arguments: ["ipc", "spec", podspecName + ".podspec"])
-            guard podResult.terminationStatus == 0 else {
-                fatalError("""
-                        PodSpec decoding failed \(podResult.terminationStatus)
-                        stdout: \(podResult.standardOutputAsString)
-                        stderr: \(podResult.standardErrorAsString)
-                """)
-            }
-            jsonData = podResult.standardOutputData
-        } else {
-            fatalError("Missing podspec ( \(podspecPath) )")
-        }
-
-        guard let JSONFile = try? JSONSerialization.jsonObject(with: jsonData, options:
-            JSONSerialization.ReadingOptions.allowFragments) as AnyObject,
-            let JSONPodspec = JSONFile as? JSONDict
-        else {
-            fatalError("Invalid JSON Podspec: (look inside \(FileManager.default.currentDirectoryPath))")
-        }
-
         guard let podSpec = try? PodSpec(JSONPodspec: JSONPodspec) else {
             fatalError("Cant read in podspec")
         }
-
         shell.dir(PodSupportSystemPublicHeaderDir)
         shell.dir(PodSupportDir + "Headers/Private/")
         shell.dir(PodSupportBuidableDir)
@@ -335,8 +389,6 @@ public enum RepoActions {
         // - Put them into the public header directory
         let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions: buildOptions)
 
-        // Batch create several symlinks for Pod style includes
-        let currentDirectoryPath = FileManager.default.currentDirectoryPath
         // ideally this check should introspec the podspecs value.
         if buildOptions.generateHeaderMap == false {
             let objcLibraries: [ObjcLibrary] = buildFile.skylarkConvertibles.compactMap { $0 as? ObjcLibrary }
@@ -407,24 +459,12 @@ public enum RepoActions {
             to: "\(PodSupportBuidableDir)/\(BazelConstants.buildFilePath)")
 
         // Write the root BUILD file
-        let buildFileSkylarkCompiler = SkylarkCompiler(buildFile.toSkylark())
+        let buildFileSkylarkCompiler = SkylarkCompiler([
+            .lines([buildFile.toSkylark()])
+        ] + childBuildFiles.map { $0.toSkylark() })
         let buildFileOut = buildFileSkylarkCompiler.run()
-
-        // When there is a "child" podspec adjacent to a parent, concat the
-        // "child" BUILD file into the parents
-        if PodBuildFile.shouldAssimilate(buildOptions: buildOptions) {
-            let fileUpdater = try! FileHandle(forWritingTo:
+        shell.write(value: buildFileOut, toPath:
                 BazelConstants.buildFileURL())
-            fileUpdater.seekToEndOfFile()
-            fileUpdater.write("\n".data(using: .utf8)!)
-            if let data = buildFileOut.data(using: .utf8) {
-                fileUpdater.write(data)
-            }
-            fileUpdater.closeFile()
-        } else {
-            shell.write(value: buildFileOut, toPath:
-                BazelConstants.buildFileURL())
-        }
     }
 
     // Assume the directory structure relative to the pod root

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -264,24 +264,6 @@ public enum RepoActions {
         return JSONPodspec
     }
 
-    private static func updatePodspec(podspec: JSONDict, relPath: String) -> JSONDict {
-        guard relPath.count > 0 else {
-            return podspec
-        }
-
-        // TODO: we need to apply this to a few more fields. Consider
-        // factoring this out to podspec instead of hacking the JSON
-        var mPodspec = podspec
-        mPodspec["source_files"] = strings(fromJSON:
-            mPodspec["source_files"]).map { relPath + "/" + $0 }       
-        var subspecs2: [JSONDict] = mPodspec["subspecs"] as? [JSONDict] ?? []
-        mPodspec["subspecs"] = subspecs2.map {
-            arg -> JSONDict in
-            return updatePodspec(podspec: arg, relPath: relPath)
-        }
-        return mPodspec
-    }
-
     private static func initializeAliasDirectory(shell: ShellContext, podspecName: String,buildOptions: BuildOptions) {
         let visibility = SkylarkNode.functionCall(name: "package",
             arguments: [

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -71,7 +71,8 @@ class PodWorkspace(object):
         for pod in self.pods:
             if pod.url and pod.url.startswith("Vendor"):
                 parent_pod = pod.url.split("/")[1]
-                invocation_info_by_target[parent_pod].add_child_pod(pod)
+                if parent_pod != pod.target_name:
+                    invocation_info_by_target[parent_pod].add_child_pod(pod)
 
         for pod in self.pods:
             _update_repo_impl(invocation_info_by_target[pod.target_name])


### PR DESCRIPTION
This PR combines the child build files into the parents, which was introduced
in a previous PR and is mainly used for pods like react native

Simply put:
- a parent podspec may glob paths included in a child dir
- a child may depend on a target defined in a parent podspec

These constraints aren't currently supported in Bazel, unfortunately.

This is covered in the build test, Examples/ChildPodspec which is also
added onto the CI

As described in #134