### PR TITLE
Cleanup header symlinking

### DIFF
--- a/Sources/PodToBUILD/MultiPlatform.swift
+++ b/Sources/PodToBUILD/MultiPlatform.swift
@@ -183,6 +183,17 @@ public struct AttrSet<T: AttrSetConstraint>: Monoid, SkylarkConvertible, EmptyAw
         return multi(basic(self.basic), self.multi)
     }
 
+    public func trivialize<U>(into accum: U, _ transform: ((inout U, T) -> Void)) -> U {
+        var mutAccum = accum
+        self.basic.map { transform(&mutAccum, $0) }
+        let multi = self.multi
+        multi.ios.map { transform(&mutAccum, $0) }
+        multi.tvos.map { transform(&mutAccum, $0) }
+        multi.osx.map { transform(&mutAccum, $0) }
+        multi.watchos.map { transform(&mutAccum, $0) }
+        return mutAccum
+    }
+
     public func zip<U>(_ other: AttrSet<U>) -> AttrSet<AttrTuple<T,U>> {
         return AttrSet<AttrTuple<T,U>>(
             basic: AttrTuple(self.basic, other.basic),

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -91,7 +91,7 @@ public struct ConfigSetting: BazelTarget {
 // https://github.com/bazelbuild/rules_apple/blob/818e795208ae3ca1cf1501205549d46e6bc88d73/doc/rules-general.md#apple_static_framework_import
 public struct AppleStaticFrameworkImport: BazelTarget {
     public let name: String // A unique name for this rule.
-    let frameworkImports: AttrSet<[String]> // The list of files under a .framework directory which are provided to Objective-C targets that depend on this target.
+    public let frameworkImports: AttrSet<[String]> // The list of files under a .framework directory which are provided to Objective-C targets that depend on this target.
 
     public var acknowledged: Bool {
         return true


### PR DESCRIPTION
For when we don't use a headermap, we use this instead. The current code
added a few less directories than the original code.

Additionally, it cleans up the algorithms to use `trivialize:`