### PR TITLE
Use cocoapods default prefix header

### DIFF
--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -83,35 +83,6 @@ def acknowledged_target(name,
         visibility=["//visibility:public"]
     )
 
-# pch_with_name_hint
-#
-#   Take in a name hint and return the PCH with that name
-#
-# Parameters
-#
-#   hint - Suggestion of pch file name. If any part of this is in a PCH
-#   filename it will match
-#
-#   sources - a list of source file patterns with pch extensions to search
-
-
-def pch_with_name_hint(hint, sources):
-    # Recursive glob the sources directories and the root directory
-    candidates = native.glob(["*.pch", hint + "/*.pch"] + sources)
-    if len(candidates) == 0:
-        return None
-
-    # We want to get the candidates in order of lowest to highest
-    for candidate in candidates:
-        if hint in candidate:
-            return candidate
-    # It is a convention in iOS/OSX development to use a PCH
-    # with the name of the target.
-    # This is a hack because, the recursive glob may find some
-    # arbitrary PCH.
-    return None
-
-
 def _make_module_map(pod_name, module_name, deps, is_system):
     # Up some dirs to the compilation root
     # bazel-out/ios_x86_64-fastbuild/genfiles/external/__Pod__

--- a/Examples/React/Podfile.lock
+++ b/Examples/React/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.63.0)
-  - FBReactNativeSpec (0.63.0):
+  - FBLazyVector (0.63.1)
+  - FBReactNativeSpec (0.63.1):
     - Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.0)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
+    - RCTRequired (= 0.63.1)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
   - Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -19,232 +19,232 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - RCTRequired (0.63.0)
-  - RCTTypeSafety (0.63.0):
-    - FBLazyVector (= 0.63.0)
+  - RCTRequired (0.63.1)
+  - RCTTypeSafety (0.63.1):
+    - FBLazyVector (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.0)
-    - React-Core (= 0.63.0)
-  - React (0.63.0):
-    - React-Core (= 0.63.0)
-    - React-Core/DevSupport (= 0.63.0)
-    - React-Core/RCTWebSocket (= 0.63.0)
-    - React-RCTActionSheet (= 0.63.0)
-    - React-RCTAnimation (= 0.63.0)
-    - React-RCTBlob (= 0.63.0)
-    - React-RCTImage (= 0.63.0)
-    - React-RCTLinking (= 0.63.0)
-    - React-RCTNetwork (= 0.63.0)
-    - React-RCTSettings (= 0.63.0)
-    - React-RCTText (= 0.63.0)
-    - React-RCTVibration (= 0.63.0)
-  - React-callinvoker (0.63.0)
-  - React-Core (0.63.0):
-    - Folly (= 2020.01.13.00)
-    - glog
-    - React-Core/Default (= 0.63.0)
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
-    - Yoga
-  - React-Core/CoreModulesHeaders (0.63.0):
+    - RCTRequired (= 0.63.1)
+    - React-Core (= 0.63.1)
+  - React (0.63.1):
+    - React-Core (= 0.63.1)
+    - React-Core/DevSupport (= 0.63.1)
+    - React-Core/RCTWebSocket (= 0.63.1)
+    - React-RCTActionSheet (= 0.63.1)
+    - React-RCTAnimation (= 0.63.1)
+    - React-RCTBlob (= 0.63.1)
+    - React-RCTImage (= 0.63.1)
+    - React-RCTLinking (= 0.63.1)
+    - React-RCTNetwork (= 0.63.1)
+    - React-RCTSettings (= 0.63.1)
+    - React-RCTText (= 0.63.1)
+    - React-RCTVibration (= 0.63.1)
+  - React-callinvoker (0.63.1)
+  - React-Core (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
-    - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-Core/Default (= 0.63.1)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/Default (0.63.0):
-    - Folly (= 2020.01.13.00)
-    - glog
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
-    - Yoga
-  - React-Core/DevSupport (0.63.0):
-    - Folly (= 2020.01.13.00)
-    - glog
-    - React-Core/Default (= 0.63.0)
-    - React-Core/RCTWebSocket (= 0.63.0)
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
-    - React-jsinspector (= 0.63.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.0):
+  - React-Core/CoreModulesHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.0):
+  - React-Core/Default (0.63.1):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
+    - Yoga
+  - React-Core/DevSupport (0.63.1):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default (= 0.63.1)
+    - React-Core/RCTWebSocket (= 0.63.1)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
+    - React-jsinspector (= 0.63.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.0):
+  - React-Core/RCTAnimationHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.0):
+  - React-Core/RCTBlobHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.0):
+  - React-Core/RCTImageHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.0):
+  - React-Core/RCTLinkingHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.0):
+  - React-Core/RCTNetworkHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.0):
+  - React-Core/RCTSettingsHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.0):
+  - React-Core/RCTTextHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
     - React-Core/Default
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.0):
+  - React-Core/RCTVibrationHeaders (0.63.1):
     - Folly (= 2020.01.13.00)
     - glog
-    - React-Core/Default (= 0.63.0)
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-jsiexecutor (= 0.63.0)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
     - Yoga
-  - React-CoreModules (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+  - React-Core/RCTWebSocket (0.63.1):
     - Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core/CoreModulesHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-RCTImage (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-cxxreact (0.63.0):
+    - glog
+    - React-Core/Default (= 0.63.1)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-jsiexecutor (= 0.63.1)
+    - Yoga
+  - React-CoreModules (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core/CoreModulesHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-RCTImage (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-cxxreact (0.63.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2020.01.13.00)
     - glog
-    - React-callinvoker (= 0.63.0)
-    - React-jsinspector (= 0.63.0)
-  - React-jsi (0.63.0):
+    - React-callinvoker (= 0.63.1)
+    - React-jsinspector (= 0.63.1)
+  - React-jsi (0.63.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2020.01.13.00)
     - glog
-    - React-jsi/Default (= 0.63.0)
-  - React-jsi/Default (0.63.0):
+    - React-jsi/Default (= 0.63.1)
+  - React-jsi/Default (0.63.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2020.01.13.00)
     - glog
-  - React-jsiexecutor (0.63.0):
+  - React-jsiexecutor (0.63.1):
     - DoubleConversion
     - Folly (= 2020.01.13.00)
     - glog
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
-  - React-jsinspector (0.63.0)
-  - React-RCTActionSheet (0.63.0):
-    - React-Core/RCTActionSheetHeaders (= 0.63.0)
-  - React-RCTAnimation (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
+  - React-jsinspector (0.63.1)
+  - React-RCTActionSheet (0.63.1):
+    - React-Core/RCTActionSheetHeaders (= 0.63.1)
+  - React-RCTAnimation (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core/RCTAnimationHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTBlob (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core/RCTAnimationHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTBlob (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.0)
-    - React-Core/RCTWebSocket (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-RCTNetwork (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTImage (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - React-Core/RCTBlobHeaders (= 0.63.1)
+    - React-Core/RCTWebSocket (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-RCTNetwork (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTImage (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core/RCTImageHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - React-RCTNetwork (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTLinking (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
-    - React-Core/RCTLinkingHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTNetwork (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core/RCTImageHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - React-RCTNetwork (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTLinking (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
+    - React-Core/RCTLinkingHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTNetwork (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core/RCTNetworkHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTSettings (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core/RCTNetworkHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTSettings (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.0)
-    - React-Core/RCTSettingsHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - React-RCTText (0.63.0):
-    - React-Core/RCTTextHeaders (= 0.63.0)
-  - React-RCTVibration (0.63.0):
-    - FBReactNativeSpec (= 0.63.0)
+    - RCTTypeSafety (= 0.63.1)
+    - React-Core/RCTSettingsHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - React-RCTText (0.63.1):
+    - React-Core/RCTTextHeaders (= 0.63.1)
+  - React-RCTVibration (0.63.1):
+    - FBReactNativeSpec (= 0.63.1)
     - Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.0)
-    - React-jsi (= 0.63.0)
-    - ReactCommon/turbomodule/core (= 0.63.0)
-  - ReactCommon/turbomodule/core (0.63.0):
+    - React-Core/RCTVibrationHeaders (= 0.63.1)
+    - React-jsi (= 0.63.1)
+    - ReactCommon/turbomodule/core (= 0.63.1)
+  - ReactCommon/turbomodule/core (0.63.1):
     - DoubleConversion
     - Folly (= 2020.01.13.00)
     - glog
-    - React-callinvoker (= 0.63.0)
-    - React-Core (= 0.63.0)
-    - React-cxxreact (= 0.63.0)
-    - React-jsi (= 0.63.0)
+    - React-callinvoker (= 0.63.1)
+    - React-Core (= 0.63.1)
+    - React-cxxreact (= 0.63.1)
+    - React-jsi (= 0.63.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -338,31 +338,31 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  FBLazyVector: 6f1045c66f816849b33c4ff28930b611e89059a0
-  FBReactNativeSpec: e856d5103d749483f86f53afafd8df4ed8a776bd
+  FBLazyVector: a50434c875bd42f2b1c99c712bda892a1dc659c7
+  FBReactNativeSpec: 393853a536428e05a9da00b6290042f09809b15b
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 33e83f39bad84f1081891026367203d6a254761a
-  RCTRequired: e46bb77db03887b3e200d34b08515c804669db99
-  RCTTypeSafety: 270fed6675c42f80fb87b47d626ef3cede1505e6
-  React: e008906ff1328f9bccb345ff4f7826397ad223fc
-  React-callinvoker: f547824e0a626f4bce516ee65f548004b0784e7e
-  React-Core: 1c28d2ecde60ded3fe42d8db4f684afb8709757b
-  React-CoreModules: 8e6139e59f5347e2cf3ceb63e4532fb5b4b39a2d
-  React-cxxreact: 98fef06e1ca59eb075ef5bc4c6f256d5c6840936
-  React-jsi: 254710f3a97e587427bfbf3011dacec2af66a1fc
-  React-jsiexecutor: 0e0cb4e170ca72d4bb1179843d08dcbea3d100ac
-  React-jsinspector: fc661eff8edbfb7e22119382c13f33bcadde0f3c
-  React-RCTActionSheet: aadd91a1d6cbfae50dd41f140004f816e9e47ade
-  React-RCTAnimation: 7fa2ef6c0ef1e3f0b7d2261c827ec94412deb5e6
-  React-RCTBlob: ccbbc70295aee3a76a70323b48f63fb7a7fcffd6
-  React-RCTImage: d94eb3080b37a4527ade4dd5f9f1289b7ba68089
-  React-RCTLinking: ddd2a1ddb699bade352d4747d5652f4c425c747a
-  React-RCTNetwork: 4590b11cc6e99eb01a48f1c03bcadfb8b792d005
-  React-RCTSettings: 9197a492268a088c5213ef8a08cfc60b7a141369
-  React-RCTText: ba503bf4cce41881ca258ba789c33e017955efdd
-  React-RCTVibration: 77ab1cf4a5eb854b88ad5ed3e9d8509ed124525e
-  ReactCommon: f63556ee9e41e9802257228237e5e660451a03cf
-  Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
+  RCTRequired: d9b1a9e6fa097744ca3ede59f86a35096df7202b
+  RCTTypeSafety: c227cd061983e9e964115afbc4e8730d6a6f1395
+  React: 86e972a20967ee4137aa19dc48319405927c2e94
+  React-callinvoker: 87ee376c25277d74e164ff036b27084e343f3e69
+  React-Core: f5ec03baf7ed58d9f3ee04a8f84e4c97ee8bf4c9
+  React-CoreModules: 958898aa8c069280e866e35a2f29480a81fcf335
+  React-cxxreact: 90de76b9b51575668ad7fd4e33a5a8c143beecc2
+  React-jsi: b32a31da32e030f30bbf9a8d3a9c8325df9e793f
+  React-jsiexecutor: 7ab9cdcdd18d57652fb041f8a147fe9658d4e00a
+  React-jsinspector: 2e28bb487e42dda6c94dbfa0c648d1343767a0fb
+  React-RCTActionSheet: 1702a1a85e550b5c36e2e03cb2bd3adea053de95
+  React-RCTAnimation: ddda576010a878865a4eab83a78acd92176ef6a1
+  React-RCTBlob: 34334384284c81577409d5205bd2b9ff594d8ab6
+  React-RCTImage: e2a661266dca295cffb33909cc64675a2efedb26
+  React-RCTLinking: cd39b9b5e9cbb9e827854e30dfa92d7db074cea8
+  React-RCTNetwork: 16939b7e4058d6f662b304a1f61689e249a2bfcc
+  React-RCTSettings: 24726a62de0c326f9ebfc3838898a501b87ce711
+  React-RCTText: 4f95d322b7e6da72817284abf8a2cdcec18b9cd8
+  React-RCTVibration: f3a9123c244f35c40d3c9f3ec3f0b9e5717bb292
+  ReactCommon: 2905859f84a94a381bb0d8dd3921ccb1a0047cb8
+  Yoga: d5bd05a2b6b94c52323745c2c2b64557c8c66f64
 
 PODFILE CHECKSUM: 2b89daabd5eca2c25b3d551f2e421e69a395664d
 

--- a/Examples/React/bootstrap.sh
+++ b/Examples/React/bootstrap.sh
@@ -4,7 +4,7 @@ set -x
 # Note: on this release, there's an issue with this commit.
 # this should be patched on somehow
 # https://github.com/facebook/react-native/pull/28946
-VERSION="0.63.0"
+VERSION="0.63.1"
 
 cleanup() {
     rm -rf react-native-${VERSION}.*

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":Adjust_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Adjust",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Adjust-prefix.pch",
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -244,15 +240,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Adjust",
-    glob(
-      [
-        "Adjust/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Adjust-prefix.pch",
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -377,15 +365,7 @@ objc_library(
   hdrs = [
     ":Sociomantic_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Adjust",
-    glob(
-      [
-        "plugin/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Adjust-prefix.pch",
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -511,15 +491,7 @@ objc_library(
   hdrs = [
     ":Criteo_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Adjust",
-    glob(
-      [
-        "plugin/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Adjust-prefix.pch",
   sdk_frameworks = [
     "SystemConfiguration"
   ],
@@ -645,15 +617,7 @@ objc_library(
   hdrs = [
     ":Trademob_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Adjust",
-    glob(
-      [
-        "plugin/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Adjust-prefix.pch",
   sdk_frameworks = [
     "SystemConfiguration"
   ],

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -266,15 +265,7 @@ objc_library(
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "FBSDKCoreKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -1580,15 +1571,7 @@ objc_library(
   hdrs = [
     ":Basics_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "FBSDKCoreKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -3035,15 +3018,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "FBSDKCoreKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":Bolts_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Bolts",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Bolts-prefix.pch",
   deps = [
     ":AppLinks",
     ":Tasks",
@@ -240,15 +236,7 @@ objc_library(
   hdrs = [
     ":Tasks_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Bolts",
-    glob(
-      [
-        "Bolts/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Bolts-prefix.pch",
   deps = [
     ":Tasks_includes"
   ],
@@ -407,31 +395,7 @@ objc_library(
   hdrs = [
     ":AppLinks_hdrs"
   ],
-  pch = select(
-    {
-      "//conditions:default": pch_with_name_hint(
-        "Bolts",
-        glob(
-          [
-            "Bolts/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":osxCase": pch_with_name_hint(
-        "Bolts",
-        []
-      ),
-      ":tvosCase": pch_with_name_hint(
-        "Bolts",
-        []
-      ),
-      ":watchosCase": pch_with_name_hint(
-        "Bolts",
-        []
-      )
-    }
-  ),
+  pch = "pod_support/Headers/Private/Bolts-prefix.pch",
   deps = [
     ":Tasks",
     ":AppLinks_includes"

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -114,10 +113,7 @@ objc_library(
   hdrs = [
     ":Braintree_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   deps = [
     ":Card",
     ":Core",
@@ -282,15 +278,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeCore/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "AddressBook"
   ],
@@ -409,15 +397,7 @@ objc_library(
   hdrs = [
     ":Apple-Pay_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeApplePay/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "PassKit"
   ],
@@ -550,15 +530,7 @@ objc_library(
   hdrs = [
     ":Card_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeCard/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   deps = [
     ":Core",
     ":Card_includes"
@@ -673,15 +645,7 @@ objc_library(
   hdrs = [
     ":DataCollector_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeDataCollector/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   deps = [
     ":Core",
     ":DataCollector_VendoredLibraries",
@@ -811,15 +775,7 @@ objc_library(
   hdrs = [
     ":PayPal_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreePayPal/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   deps = [
     ":Core",
     ":PayPalOneTouch",
@@ -936,15 +892,7 @@ objc_library(
   hdrs = [
     ":Venmo_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeVenmo/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   deps = [
     ":Core",
     ":PayPalDataCollector",
@@ -1089,15 +1037,7 @@ objc_library(
   hdrs = [
     ":UI_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeUI/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -1221,15 +1161,7 @@ objc_library(
   hdrs = [
     ":UnionPay_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreeUnionPay/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -1363,15 +1295,7 @@ objc_library(
   hdrs = [
     ":3D-Secure_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "Braintree3DSecure/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -1502,15 +1426,7 @@ objc_library(
   hdrs = [
     ":PayPalOneTouch_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreePayPal/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -1648,15 +1564,7 @@ objc_library(
   hdrs = [
     ":PayPalDataCollector_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreePayPal/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",
@@ -1802,15 +1710,7 @@ objc_library(
   hdrs = [
     ":PayPalUtils_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Braintree",
-    glob(
-      [
-        "BraintreePayPal/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Braintree-prefix.pch",
   sdk_frameworks = [
     "MessageUI",
     "SystemConfiguration",

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":Branch_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Branch",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Branch-prefix.pch",
   deps = [
     ":Core",
     ":without-IDFA",
@@ -217,15 +213,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Branch",
-    glob(
-      [
-        "Branch-SDK/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Branch-prefix.pch",
   sdk_frameworks = [
     "AdSupport",
     "CoreTelephony",
@@ -343,15 +331,7 @@ objc_library(
   hdrs = [
     ":without-IDFA_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Branch",
-    glob(
-      [
-        "Branch-SDK/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Branch-prefix.pch",
   sdk_frameworks = [
     "CoreTelephony",
     "MobileCoreServices"

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -175,15 +174,7 @@ objc_library(
   hdrs = [
     ":Calabash_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Calabash",
-    glob(
-      [
-        "calabash.framework/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Calabash-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -318,10 +309,7 @@ objc_library(
   hdrs = [
     ":Calabash_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Calabash",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Calabash-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -109,10 +108,7 @@ objc_library(
   hdrs = [
     ":CardIO_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "CardIO",
-    []
-  ),
+  pch = "pod_support/Headers/Private/CardIO-prefix.pch",
   sdk_frameworks = [
     "Accelerate",
     "AVFoundation",

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -102,10 +101,7 @@ objc_library(
   hdrs = [
     ":CocoaLumberjack_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "CocoaLumberjack",
-    []
-  ),
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
   deps = [
     ":Default",
     ":Extensions",
@@ -223,15 +219,7 @@ objc_library(
   hdrs = [
     ":Default_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "CocoaLumberjack",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
   deps = [
     ":Default_includes"
   ],
@@ -339,15 +327,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "CocoaLumberjack",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
   deps = [
     ":Core_includes"
   ],
@@ -458,15 +438,7 @@ objc_library(
   hdrs = [
     ":Extensions_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "CocoaLumberjack",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
   deps = [
     ":Default",
     ":Extensions_includes"
@@ -638,31 +610,7 @@ objc_library(
   hdrs = [
     ":CLI_hdrs"
   ],
-  pch = select(
-    {
-      "//conditions:default": pch_with_name_hint(
-        "CocoaLumberjack",
-        []
-      ),
-      ":osxCase": pch_with_name_hint(
-        "CocoaLumberjack",
-        glob(
-          [
-            "Classes/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":tvosCase": pch_with_name_hint(
-        "CocoaLumberjack",
-        []
-      ),
-      ":watchosCase": pch_with_name_hint(
-        "CocoaLumberjack",
-        []
-      )
-    }
-  ),
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
   deps = select(
     {
       "//conditions:default": [],

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":ColorCube_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "ColorCube",
-    glob(
-      [
-        "ColorCube/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/ColorCube-prefix.pch",
   deps = [
     ":ColorCube_includes"
   ],

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -94,10 +93,7 @@ objc_library(
   hdrs = [
     ":EarlGrey_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "EarlGrey",
-    []
-  ),
+  pch = "pod_support/Headers/Private/EarlGrey-prefix.pch",
   sdk_frameworks = [
     "CoreData",
     "CoreFoundation",

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -217,15 +216,7 @@ objc_library(
   hdrs = [
     ":FBAllocationTracker_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBAllocationTracker",
-    glob(
-      [
-        "FBAllocationTracker/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBAllocationTracker-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],
@@ -417,15 +408,7 @@ objc_library(
   hdrs = [
     ":FBAllocationTracker_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBAllocationTracker",
-    glob(
-      [
-        "FBAllocationTracker/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBAllocationTracker-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -883,15 +882,7 @@ objc_library(
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "FBSDKCoreKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -115,15 +114,7 @@ objc_library(
   hdrs = [
     ":FBSDKLoginKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKLoginKit",
-    glob(
-      [
-        "FBSDKLoginKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKLoginKit-prefix.pch",
   weak_sdk_frameworks = [
     "Accounts",
     "CoreLocation",

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKMessengerShareKit",
-    glob(
-      [
-        "FBSDKMessengerShareKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FBSDKMessengerShareKit-prefix.pch",
   deps = [
     ":FBSDKMessengerShareKit_includes"
   ],

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -260,36 +259,7 @@ objc_library(
   hdrs = [
     ":FBSDKShareKit_hdrs"
   ],
-  pch = select(
-    {
-      "//conditions:default": pch_with_name_hint(
-        "FBSDKShareKit",
-        glob(
-          [
-            "FBSDKShareKit/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":osxCase": pch_with_name_hint(
-        "FBSDKShareKit",
-        []
-      ),
-      ":tvosCase": pch_with_name_hint(
-        "FBSDKShareKit",
-        glob(
-          [
-            "FBSDKShareKit/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":watchosCase": pch_with_name_hint(
-        "FBSDKShareKit",
-        []
-      )
-    }
-  ),
+  pch = "pod_support/Headers/Private/FBSDKShareKit-prefix.pch",
   weak_sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":FLAnimatedImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FLAnimatedImage",
-    glob(
-      [
-        "FLAnimatedImage/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FLAnimatedImage-prefix.pch",
   sdk_frameworks = [
     "QuartzCore",
     "ImageIO",

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":FLEX_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FLEX",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FLEX-prefix.pch",
   sdk_frameworks = [
     "Foundation",
     "UIKit",

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -101,10 +100,7 @@ objc_library(
   hdrs = [
     ":FMDB_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    []
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     ":standard",
     ":FMDB_includes"
@@ -221,15 +217,7 @@ objc_library(
   hdrs = [
     ":standard_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   sdk_dylibs = [
     "sqlite3"
   ],
@@ -343,15 +331,7 @@ objc_library(
   hdrs = [
     ":FTS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     ":standard",
     ":FTS_includes"
@@ -438,10 +418,7 @@ objc_library(
   hdrs = [
     ":standalone_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    []
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     ":standalone_includes"
   ],
@@ -556,15 +533,7 @@ objc_library(
   hdrs = [
     ":standalone_default_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     "//Vendor/sqlite3:sqlite3",
     ":standalone_default_includes"
@@ -685,15 +654,7 @@ objc_library(
   hdrs = [
     ":standalone_FTS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     "//Vendor/sqlite3:fts",
     ":standalone_FTS_includes"
@@ -811,15 +772,7 @@ objc_library(
   hdrs = [
     ":SQLCipher_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FMDB",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/FMDB-prefix.pch",
   deps = [
     "//Vendor/SQLCipher:SQLCipher",
     ":SQLCipher_includes"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -131,15 +130,7 @@ objc_library(
   hdrs = [
     ":Folly_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Folly",
-    glob(
-      [
-        "folly/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Folly-prefix.pch",
   sdk_dylibs = [
     "stdc++"
   ],

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -2,7 +2,6 @@ load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -115,10 +114,7 @@ objc_library(
   hdrs = [
     ":GoogleAppIndexing_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleAppIndexing",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleAppIndexing-prefix.pch",
   sdk_frameworks = [
     "CoreText",
     "SafariServices"

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -95,10 +94,7 @@ objc_library(
   hdrs = [
     ":GoogleAppUtilities_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleAppUtilities",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleAppUtilities-prefix.pch",
   deps = [
     "//Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities",
     ":GoogleAppUtilities_VendoredFrameworks",

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -96,10 +95,7 @@ objc_library(
   hdrs = [
     ":GoogleAuthUtilities_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleAuthUtilities",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleAuthUtilities-prefix.pch",
   sdk_frameworks = [
     "Security",
     "SystemConfiguration"

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -95,10 +94,7 @@ objc_library(
   hdrs = [
     ":GoogleNetworkingUtilities_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleNetworkingUtilities",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleNetworkingUtilities-prefix.pch",
   sdk_frameworks = [
     "Security"
   ],

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -2,7 +2,6 @@ load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":GoogleSignIn_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleSignIn",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleSignIn-prefix.pch",
   sdk_frameworks = [
     "CoreText",
     "SafariServices",

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -94,10 +93,7 @@ objc_library(
   hdrs = [
     ":GoogleSymbolUtilities_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleSymbolUtilities",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleSymbolUtilities-prefix.pch",
   deps = [
     ":GoogleSymbolUtilities_VendoredFrameworks",
     ":GoogleSymbolUtilities_includes"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -95,10 +94,7 @@ objc_library(
   hdrs = [
     ":GoogleUtilities_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "GoogleUtilities",
-    []
-  ),
+  pch = "pod_support/Headers/Private/GoogleUtilities-prefix.pch",
   sdk_frameworks = [
     "AddressBook",
     "CoreGraphics"

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":IBActionSheet_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "IBActionSheet",
-    glob(
-      [
-        "IBActionSheetSample/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/IBActionSheet-prefix.pch",
   sdk_frameworks = [
     "QuartzCore"
   ],

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":IGListKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "IGListKit",
-    []
-  ),
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -305,15 +301,7 @@ objc_library(
   hdrs = [
     ":Diffing_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "IGListKit",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -500,15 +488,7 @@ objc_library(
   hdrs = [
     ":Diffing_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "IGListKit",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -726,36 +706,7 @@ objc_library(
   hdrs = [
     ":Default_cxx_hdrs"
   ],
-  pch = select(
-    {
-      "//conditions:default": pch_with_name_hint(
-        "IGListKit",
-        glob(
-          [
-            "Source/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":osxCase": pch_with_name_hint(
-        "IGListKit",
-        []
-      ),
-      ":tvosCase": pch_with_name_hint(
-        "IGListKit",
-        glob(
-          [
-            "Source/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":watchosCase": pch_with_name_hint(
-        "IGListKit",
-        []
-      )
-    }
-  ),
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [
@@ -967,36 +918,7 @@ objc_library(
   hdrs = [
     ":Default_hdrs"
   ],
-  pch = select(
-    {
-      "//conditions:default": pch_with_name_hint(
-        "IGListKit",
-        glob(
-          [
-            "Source/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":osxCase": pch_with_name_hint(
-        "IGListKit",
-        []
-      ),
-      ":tvosCase": pch_with_name_hint(
-        "IGListKit",
-        glob(
-          [
-            "Source/**/*.pch"
-          ],
-          exclude_directories = 1
-        )
-      ),
-      ":watchosCase": pch_with_name_hint(
-        "IGListKit",
-        []
-      )
-    }
-  ),
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":KVOController_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KVOController",
-    glob(
-      [
-        "FBKVOController/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/KVOController-prefix.pch",
   deps = [
     ":KVOController_includes"
   ],

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:apple.bzl', 'apple_static_framework_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -110,10 +109,7 @@ objc_library(
   hdrs = [
     ":KakaoOpenSDK_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KakaoOpenSDK",
-    []
-  ),
+  pch = "pod_support/Headers/Private/KakaoOpenSDK-prefix.pch",
   deps = [
     ":KakaoLink",
     ":KakaoLink_VendoredFrameworks",
@@ -209,10 +205,7 @@ objc_library(
   hdrs = [
     ":KakaoOpenSDK_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KakaoOpenSDK",
-    []
-  ),
+  pch = "pod_support/Headers/Private/KakaoOpenSDK-prefix.pch",
   sdk_frameworks = [
     "UIKit",
     "WebKit"
@@ -322,10 +315,7 @@ objc_library(
   hdrs = [
     ":KakaoNavi_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KakaoOpenSDK",
-    []
-  ),
+  pch = "pod_support/Headers/Private/KakaoOpenSDK-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -434,10 +424,7 @@ objc_library(
   hdrs = [
     ":KakaoLink_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KakaoOpenSDK",
-    []
-  ),
+  pch = "pod_support/Headers/Private/KakaoOpenSDK-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -546,10 +533,7 @@ objc_library(
   hdrs = [
     ":KakaoS2_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "KakaoOpenSDK",
-    []
-  ),
+  pch = "pod_support/Headers/Private/KakaoOpenSDK-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":Masonry_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Masonry",
-    glob(
-      [
-        "Masonry/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Masonry-prefix.pch",
   sdk_frameworks = select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -141,15 +140,7 @@ objc_library(
   hdrs = [
     ":1PasswordExtension_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "1PasswordExtension",
-    glob(
-      [
-        "*.pch/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/OnePasswordExtension-prefix.pch",
   sdk_frameworks = [
     "Foundation",
     "MobileCoreServices",

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -99,10 +98,7 @@ objc_library(
   hdrs = [
     ":PINCache_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINCache",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINCache-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],
@@ -233,15 +229,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINCache",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINCache-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],
@@ -352,15 +340,7 @@ objc_library(
   hdrs = [
     ":Arc-exception-safe_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINCache",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINCache-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -130,15 +129,7 @@ objc_library(
   hdrs = [
     ":PINOperation_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINOperation",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINOperation-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],
@@ -245,15 +236,7 @@ objc_library(
   hdrs = [
     ":PINOperation_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINOperation",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINOperation-prefix.pch",
   sdk_frameworks = [
     "Foundation"
   ],

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -104,10 +103,7 @@ objc_library(
   hdrs = [
     ":PINRemoteImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   deps = [
     ":FLAnimatedImage",
     ":PINCache",
@@ -241,15 +237,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   sdk_frameworks = [
     "ImageIO",
     "Accelerate"
@@ -345,10 +333,7 @@ objc_library(
   hdrs = [
     ":iOS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],
@@ -441,10 +426,7 @@ objc_library(
   hdrs = [
     ":OSX_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   sdk_frameworks = [
     "Cocoa",
     "CoreServices"
@@ -538,10 +520,7 @@ objc_library(
   hdrs = [
     ":tvOS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   deps = [
     ":iOS",
     ":tvOS_includes"
@@ -654,15 +633,7 @@ objc_library(
   hdrs = [
     ":FLAnimatedImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   deps = [
     "//Vendor/FLAnimatedImage:FLAnimatedImage",
     ":Core",
@@ -756,10 +727,7 @@ objc_library(
   hdrs = [
     ":WebP_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    []
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   deps = [
     "//Vendor/libwebp:libwebp",
     ":Core",
@@ -877,15 +845,7 @@ objc_library(
   hdrs = [
     ":PINCache_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PINRemoteImage",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PINRemoteImage-prefix.pch",
   deps = [
     "//Vendor/PINCache:PINCache",
     ":Core",

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":PaymentKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "PaymentKit",
-    glob(
-      [
-        "PaymentKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/PaymentKit-prefix.pch",
   deps = [
     ":PaymentKit_includes"
   ],

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":RadarKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "RadarKit",
-    glob(
-      [
-        "RadarKit/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "RadarKit-Prefix.pch",
   sdk_frameworks = [
     "Foundation",
     "SystemConfiguration"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -140,10 +139,7 @@ objc_library(
   hdrs = [
     ":React_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    []
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":React_includes"
@@ -1861,15 +1857,7 @@ objc_library(
   hdrs = [
     ":Core_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -3279,15 +3267,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -3417,15 +3397,7 @@ objc_library(
   hdrs = [
     ":CxxBridge_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
@@ -3550,15 +3522,7 @@ objc_library(
   hdrs = [
     ":CxxBridge_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":Core",
@@ -3709,15 +3673,7 @@ objc_library(
   hdrs = [
     ":DevSupport_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTWebSocket",
@@ -3872,15 +3828,7 @@ objc_library(
   hdrs = [
     ":DevSupport_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":DevSupport_cxx",
@@ -4037,15 +3985,7 @@ objc_library(
   hdrs = [
     ":RCTFabric_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -4195,15 +4135,7 @@ objc_library(
   hdrs = [
     ":RCTFabric_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -4325,15 +4257,7 @@ objc_library(
   hdrs = [
     ":tvOS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":tvOS_includes"
@@ -4478,15 +4402,7 @@ objc_library(
   hdrs = [
     ":jschelpers_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -4636,15 +4552,7 @@ objc_library(
   hdrs = [
     ":jsinspector_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":jsinspector_includes"
   ],
@@ -4791,15 +4699,7 @@ objc_library(
   hdrs = [
     ":PrivateDatabase_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":PrivateDatabase_includes"
   ],
@@ -4955,15 +4855,7 @@ objc_library(
   hdrs = [
     ":cxxreact_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     "//Vendor/boost-for-react-native:boost-for-react-native",
@@ -5059,10 +4951,7 @@ objc_library(
   hdrs = [
     ":fabric_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    []
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":fabric_includes"
   ],
@@ -5194,15 +5083,7 @@ objc_library(
   hdrs = [
     ":fabric_activityindicator_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_activityindicator_includes"
@@ -5340,15 +5221,7 @@ objc_library(
   hdrs = [
     ":fabric_attributedstring_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_attributedstring_includes"
@@ -5486,15 +5359,7 @@ objc_library(
   hdrs = [
     ":fabric_core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_core_includes"
@@ -5632,15 +5497,7 @@ objc_library(
   hdrs = [
     ":fabric_debug_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_debug_includes"
@@ -5778,15 +5635,7 @@ objc_library(
   hdrs = [
     ":fabric_graphics_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_graphics_includes"
@@ -5924,15 +5773,7 @@ objc_library(
   hdrs = [
     ":fabric_scrollview_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_scrollview_includes"
@@ -6070,15 +5911,7 @@ objc_library(
   hdrs = [
     ":fabric_text_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_text_includes"
@@ -6217,15 +6050,7 @@ objc_library(
   hdrs = [
     ":fabric_textlayoutmanager_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_textlayoutmanager_includes"
@@ -6363,15 +6188,7 @@ objc_library(
   hdrs = [
     ":fabric_uimanager_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":fabric_uimanager_includes"
@@ -6510,15 +6327,7 @@ objc_library(
   hdrs = [
     ":fabric_view_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     "//Vendor/Yoga:Yoga",
@@ -6658,15 +6467,7 @@ objc_library(
   hdrs = [
     ":RCTFabricSample_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "ReactCommon/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     "//Vendor/Folly:Folly",
     ":RCTFabricSample_includes"
@@ -6783,15 +6584,7 @@ objc_library(
   hdrs = [
     ":ART_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":ART_includes"
@@ -6903,15 +6696,7 @@ objc_library(
   hdrs = [
     ":RCTActionSheet_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTActionSheet_includes"
@@ -7029,15 +6814,7 @@ objc_library(
   hdrs = [
     ":RCTAnimation_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTAnimation_includes"
@@ -7196,15 +6973,7 @@ objc_library(
   hdrs = [
     ":RCTBlob_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTBlob_cxx_includes"
@@ -7363,15 +7132,7 @@ objc_library(
   hdrs = [
     ":RCTBlob_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTBlob_cxx",
@@ -7486,15 +7247,7 @@ objc_library(
   hdrs = [
     ":RCTCameraRoll_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTImage",
@@ -7607,15 +7360,7 @@ objc_library(
   hdrs = [
     ":RCTGeolocation_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTGeolocation_includes"
@@ -7735,15 +7480,7 @@ objc_library(
   hdrs = [
     ":RCTImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTNetwork",
@@ -7872,15 +7609,7 @@ objc_library(
   hdrs = [
     ":RCTNetwork_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTNetwork_cxx_includes"
@@ -8008,15 +7737,7 @@ objc_library(
   hdrs = [
     ":RCTNetwork_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTNetwork_cxx",
@@ -8129,15 +7850,7 @@ objc_library(
   hdrs = [
     ":RCTPushNotification_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTPushNotification_includes"
@@ -8249,15 +7962,7 @@ objc_library(
   hdrs = [
     ":RCTSettings_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTSettings_includes"
@@ -8369,15 +8074,7 @@ objc_library(
   hdrs = [
     ":RCTText_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTText_includes"
@@ -8489,15 +8186,7 @@ objc_library(
   hdrs = [
     ":RCTVibration_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTVibration_includes"
@@ -8650,15 +8339,7 @@ objc_library(
   hdrs = [
     ":RCTWebSocket_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTBlob",
@@ -8811,15 +8492,7 @@ objc_library(
   hdrs = [
     ":fishhook_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":fishhook_includes"
   ],
@@ -8930,15 +8603,7 @@ objc_library(
   hdrs = [
     ":RCTLinkingIOS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTLinkingIOS_includes"
@@ -9050,15 +8715,7 @@ objc_library(
   hdrs = [
     ":RCTTest_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "XCTest"
   ],
@@ -9153,10 +8810,7 @@ objc_library(
   hdrs = [
     ":_ignore_me_subspec_for_linting__hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    []
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":CxxBridge",

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -152,10 +151,7 @@ objc_library(
   hdrs = [
     ":React_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    []
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":React_includes"
@@ -389,15 +385,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "React/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   sdk_frameworks = [
     "JavaScriptCore"
   ],
@@ -511,15 +499,7 @@ objc_library(
   hdrs = [
     ":ART_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":ART_includes"
@@ -631,15 +611,7 @@ objc_library(
   hdrs = [
     ":RCTActionSheet_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTActionSheet_includes"
@@ -751,15 +723,7 @@ objc_library(
   hdrs = [
     ":RCTAdSupport_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTAdSupport_includes"
@@ -871,15 +835,7 @@ objc_library(
   hdrs = [
     ":RCTGeolocation_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTGeolocation_includes"
@@ -991,15 +947,7 @@ objc_library(
   hdrs = [
     ":RCTImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTImage_includes"
@@ -1111,15 +1059,7 @@ objc_library(
   hdrs = [
     ":RCTNetwork_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTNetwork_includes"
@@ -1231,15 +1171,7 @@ objc_library(
   hdrs = [
     ":RCTPushNotification_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTPushNotification_includes"
@@ -1351,15 +1283,7 @@ objc_library(
   hdrs = [
     ":RCTSettings_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTSettings_includes"
@@ -1471,15 +1395,7 @@ objc_library(
   hdrs = [
     ":RCTText_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTText_includes"
@@ -1591,15 +1507,7 @@ objc_library(
   hdrs = [
     ":RCTVibration_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTVibration_includes"
@@ -1711,15 +1619,7 @@ objc_library(
   hdrs = [
     ":RCTWebSocket_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTWebSocket_includes"
@@ -1831,15 +1731,7 @@ objc_library(
   hdrs = [
     ":RCTLinkingIOS_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "React",
-    glob(
-      [
-        "Libraries/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
     ":RCTLinkingIOS_includes"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -175,15 +174,7 @@ objc_library(
   hdrs = [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "SFHFKeychainUtils",
-    glob(
-      [
-        "security/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/SFHFKeychainUtils-prefix.pch",
   sdk_frameworks = [
     "Security"
   ],
@@ -311,10 +302,7 @@ objc_library(
   hdrs = [
     ":SFHFKeychainUtils_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "SFHFKeychainUtils",
-    []
-  ),
+  pch = "pod_support/Headers/Private/SFHFKeychainUtils-prefix.pch",
   sdk_frameworks = [
     "Security"
   ],

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "SPUserResizableView+Pion",
-    glob(
-      [
-        "SPUserResizableView/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/SPUserResizableView+Pion-prefix.pch",
   deps = [
     ":SPUserResizableView+Pion_includes"
   ],

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":SlackTextViewController_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "SlackTextViewController",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/SlackTextViewController-prefix.pch",
   deps = [
     ":SlackTextViewController_includes"
   ],

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -107,10 +106,7 @@ objc_library(
   hdrs = [
     ":Smartling_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Smartling",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Smartling-prefix.pch",
   sdk_frameworks = [
     "UIKit"
   ],

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_resource_bundle')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -116,15 +115,7 @@ objc_library(
   hdrs = [
     ":Stripe_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Stripe",
-    glob(
-      [
-        "Stripe/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Stripe-prefix.pch",
   sdk_frameworks = [
     "Foundation",
     "Security",

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -127,15 +126,7 @@ objc_library(
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "POD_REQUIRES_ARC/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/TestArcPatternsWithExcludes-prefix.pch",
   deps = [
     ":Core",
     ":TestArcPatternsWithExcludes_includes"
@@ -588,15 +579,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "FBSDKCoreKit",
-    glob(
-      [
-        "POD_REQUIRES_ARC/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/TestArcPatternsWithExcludes-prefix.pch",
   deps = [
     ":Core_includes"
   ],

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -109,10 +108,7 @@ objc_library(
   hdrs = [
     ":Texture_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -238,15 +234,7 @@ objc_library(
   hdrs = [
     ":Core_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    glob(
-      [
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -370,16 +358,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    glob(
-      [
-        "Base/**/*.pch",
-        "Source/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -476,10 +455,7 @@ objc_library(
   hdrs = [
     ":PINRemoteImage_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -578,10 +554,7 @@ objc_library(
   hdrs = [
     ":IGListKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -678,10 +651,7 @@ objc_library(
   hdrs = [
     ":Yoga_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -779,10 +749,7 @@ objc_library(
   hdrs = [
     ":MapKit_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_frameworks = [
     "MapKit"
   ],
@@ -880,10 +847,7 @@ objc_library(
   hdrs = [
     ":Photos_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_frameworks = [
     "Photos"
   ],
@@ -981,10 +945,7 @@ objc_library(
   hdrs = [
     ":AssetsLibrary_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Texture",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Texture-prefix.pch",
   sdk_frameworks = [
     "AssetsLibrary"
   ],

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -141,15 +140,7 @@ objc_library(
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "UICollectionViewLeftAlignedLayout",
-    glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/UICollectionViewLeftAlignedLayout-prefix.pch",
   deps = [
     ":UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
@@ -274,15 +265,7 @@ objc_library(
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "UICollectionViewLeftAlignedLayout",
-    glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/UICollectionViewLeftAlignedLayout-prefix.pch",
   deps = [
     ":UICollectionViewLeftAlignedLayout_cxx",
     ":UICollectionViewLeftAlignedLayout_swift",

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -109,10 +108,7 @@ objc_library(
   hdrs = [
     ":Weixin_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "Weixin",
-    []
-  ),
+  pch = "pod_support/Headers/Private/Weixin-prefix.pch",
   sdk_frameworks = [
     "CoreTelephony",
     "SystemConfiguration"

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -128,10 +127,7 @@ objc_library(
   hdrs = [
     ":ZipArchive_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "ZipArchive",
-    []
-  ),
+  pch = "pod_support/Headers/Private/ZipArchive-prefix.pch",
   sdk_dylibs = [
     "z"
   ],

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -111,10 +110,7 @@ objc_library(
   hdrs = [
     ":boost-for-react-native_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "boost-for-react-native",
-    []
-  ),
+  pch = "pod_support/Headers/Private/boost-for-react-native-prefix.pch",
   deps = [
     ":boost-for-react-native_includes"
   ],

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -143,15 +142,7 @@ objc_library(
   hdrs = [
     ":glog_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "glog",
-    glob(
-      [
-        "src/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/glog-prefix.pch",
   sdk_dylibs = [
     "stdc++"
   ],

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -100,10 +99,7 @@ objc_library(
   hdrs = [
     ":googleapis_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "googleapis",
-    []
-  ),
+  pch = "pod_support/Headers/Private/googleapis-prefix.pch",
   deps = [
     "//Vendor/!ProtoCompiler-gRPCPlugin:!ProtoCompiler-gRPCPlugin",
     ":Messages",
@@ -226,10 +222,7 @@ objc_library(
   hdrs = [
     ":Messages_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "googleapis",
-    []
-  ),
+  pch = "pod_support/Headers/Private/googleapis-prefix.pch",
   deps = [
     "//Vendor/Protobuf:Protobuf",
     ":Messages_includes"
@@ -346,15 +339,7 @@ objc_library(
   hdrs = [
     ":Services_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "googleapis",
-    glob(
-      [
-        "google/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/googleapis-prefix.pch",
   deps = [
     "//Vendor/gRPC-ProtoRPC:gRPC-ProtoRPC",
     ":Messages",

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -95,10 +94,7 @@ objc_library(
   hdrs = [
     ":iOSSnapshotTestCase_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "iOSSnapshotTestCase",
-    []
-  ),
+  pch = "pod_support/Headers/Private/iOSSnapshotTestCase-prefix.pch",
   sdk_frameworks = [
     "XCTest",
     "UIKit",
@@ -222,15 +218,7 @@ objc_library(
   hdrs = [
     ":Core_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "iOSSnapshotTestCase",
-    glob(
-      [
-        "FBSnapshotTestCase/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/iOSSnapshotTestCase-prefix.pch",
   sdk_frameworks = [
     "XCTest",
     "UIKit",

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -1,7 +1,6 @@
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -114,15 +113,7 @@ objc_library(
   hdrs = [
     ":iRate_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "iRate",
-    glob(
-      [
-        "iRate/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/iRate-prefix.pch",
   deps = [
     ":iRate_includes"
   ],

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":kingpin_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "kingpin",
-    glob(
-      [
-        "kingpin/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/kingpin-prefix.pch",
   sdk_frameworks = [
     "MapKit",
     "CoreLocation"

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -131,15 +130,7 @@ objc_library(
   hdrs = [
     ":pop_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "pop",
-    glob(
-      [
-        "pop/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/pop-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],
@@ -248,15 +239,7 @@ objc_library(
   hdrs = [
     ":pop_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "pop",
-    glob(
-      [
-        "pop/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/pop-prefix.pch",
   sdk_dylibs = [
     "c++"
   ],

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -1,6 +1,5 @@
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -113,15 +112,7 @@ objc_library(
   hdrs = [
     ":yoga_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "yoga",
-    glob(
-      [
-        "yoga/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/yoga-prefix.pch",
   deps = [
     ":yoga_includes"
   ],

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -2,7 +2,6 @@ load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
-  "pch_with_name_hint",
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
@@ -362,15 +361,7 @@ objc_library(
   hdrs = [
     ":youtube-ios-player-helper_cxx_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "youtube-ios-player-helper",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/youtube-ios-player-helper-prefix.pch",
   deps = [
     ":youtube-ios-player-helper_cxx_includes"
   ],
@@ -701,15 +692,7 @@ objc_library(
   hdrs = [
     ":youtube-ios-player-helper_hdrs"
   ],
-  pch = pch_with_name_hint(
-    "youtube-ios-player-helper",
-    glob(
-      [
-        "Classes/**/*.pch"
-      ],
-      exclude_directories = 1
-    )
-  ),
+  pch = "pod_support/Headers/Private/youtube-ios-player-helper-prefix.pch",
   deps = [
     ":youtube-ios-player-helper_cxx",
     ":youtube-ios-player-helper_swift",

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ build-test: pod_test build archive init-sandbox
 	cd Examples/Texture && make all
 	cd Examples/ChildPodspec && make all
 	cd Examples/ArcSplitting && make all
+	cd Examples/React && make all
 
 build-example: EXAMPLE=Examples/PINCache.podspec.json
 build-example: CONFIG = debug

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -63,7 +63,6 @@ public func makePrefixNodes() -> SkylarkNode {
     let lineNodes = [
         SkylarkNode.functionCall(name: "load", arguments: [
             .basic(.string(extFile)),
-            .basic(.string("pch_with_name_hint")),
             .basic(.string("acknowledged_target")),
             .basic(.string("gen_module_map")),
             .basic(.string("gen_includes")),

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -304,7 +304,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         } + includePodHeaderDirs()
         self.headerName = headerName
 
-        // If the suspec has a prefix header than use that
+        // If the subspec has a prefix header than use that
         let prefixHeaderFile: AttrSet<Either<Bool, String>?> = spec.attr(\.prefixHeaderFile)
         let prefixHeaderContents: AttrSet<String?> = spec.attr(\.prefixHeaderContents)
         let defaultPrefixHeader =

--- a/Sources/PodToBUILD/PodSpec.swift
+++ b/Sources/PodToBUILD/PodSpec.swift
@@ -101,6 +101,8 @@ public enum PodSpecField: String {
     case sourceFiles = "source_files"
     case publicHeaders = "public_header_files"
     case privateHeaders = "private_header_files"
+    case prefixHeaderFile = "prefix_header_file"
+    case prefixHeaderContents = "prefix_header_contents"
     case preservePaths = "preserve_paths"
     case compilerFlags = "compiler_flags"
     case libraries
@@ -148,6 +150,8 @@ public protocol PodSpecRepresentable {
     var requiresArc: Either<Bool, [String]>? { get }
     var publicHeaders: [String] { get }
     var privateHeaders: [String] { get }
+    var prefixHeaderContents: String? { get }
+    var prefixHeaderFile: Either<Bool, String>? { get }
     var preservePaths: [String] { get }
     var defaultSubspecs: [String] { get }
 }
@@ -175,6 +179,11 @@ public struct PodSpec: PodSpecRepresentable {
 
     public let publicHeaders: [String]
     public let privateHeaders: [String]
+
+    // lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb:170
+    public let prefixHeaderFile: Either<Bool, String>?
+    public let prefixHeaderContents: String?
+
     public let preservePaths: [String]
 
     public let vendoredFrameworks: [String]
@@ -217,6 +226,12 @@ public struct PodSpec: PodSpecRepresentable {
         sourceFiles = strings(fromJSON: fieldMap[.sourceFiles])
         publicHeaders = strings(fromJSON: fieldMap[.publicHeaders])
         privateHeaders = strings(fromJSON: fieldMap[.privateHeaders])
+
+        prefixHeaderFile  = (fieldMap[.prefixHeaderFile] as? Bool).map{ .left($0) } ?? // try a bool
+	        (fieldMap[.prefixHeaderFile] as? String).map { .right($0) } // try a string
+
+        prefixHeaderContents = fieldMap[.prefixHeaderContents] as? String
+
         preservePaths = strings(fromJSON: fieldMap[.preservePaths])
         compilerFlags = strings(fromJSON: fieldMap[.compilerFlags])
         libraries = strings(fromJSON: fieldMap[.libraries])

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -356,6 +356,10 @@ public enum RepoActions {
         } else {
             workspaceRootPath =  "."
         }
+        shell.dir(PodSupportSystemPublicHeaderDir)
+        shell.dir(PodSupportDir + "Headers/Private/")
+        shell.dir(PodSupportBuidableDir)
+
         let JSONPodspec = getJSONPodspec(shell: shell, podspecName:
             podspecName, path: workspaceRootPath,
             childPaths: buildOptions.childPaths)
@@ -403,10 +407,6 @@ public enum RepoActions {
         guard let podSpec = try? PodSpec(JSONPodspec: JSONPodspec) else {
             fatalError("Cant read in podspec")
         }
-        shell.dir(PodSupportSystemPublicHeaderDir)
-        shell.dir(PodSupportDir + "Headers/Private/")
-        shell.dir(PodSupportBuidableDir)
-
         writeDefaultPrefixHeader(shell: shell, buildOptions: buildOptions)
         writeSpecPrefixHeader(shell: shell, podSpec: podSpec)
 


### PR DESCRIPTION
The current search logic didn't write the default prefix header which is
required for some cocoapods. It follows the logic defined in
lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb:170

Additonally, this was discovered when updating to react native and there
was a required fix for bazel here, which we won't need to keep up with
https://github.com/facebook/react-native/pull/28946