### PR TITLE
Rework module maps

### DIFF
--- a/Examples/PodSpecs/FBSDKCoreKit.7.1.0.podspec.json
+++ b/Examples/PodSpecs/FBSDKCoreKit.7.1.0.podspec.json
@@ -1,0 +1,120 @@
+{
+  "name": "FBSDKCoreKit",
+  "version": "7.1.1",
+  "summary": "Official Facebook SDK for iOS to access Facebook Platform core features",
+  "description": "The Facebook SDK for iOS CoreKit framework provides:\n* App Events (for App Analytics)\n* Graph API Access and Error Recovery\n* Working with Access Tokens and User Profiles",
+  "homepage": "https://developers.facebook.com/docs/ios/",
+  "license": {
+    "type": "Facebook Platform License",
+    "file": "LICENSE"
+  },
+  "authors": "Facebook",
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "10.0"
+  },
+  "source": {
+    "git": "https://github.com/facebook/facebook-ios-sdk.git",
+    "tag": "v7.1.1"
+  },
+  "ios": {
+    "weak_frameworks": [
+      "Accelerate",
+      "Accounts",
+      "Social",
+      "Security",
+      "QuartzCore",
+      "CoreGraphics",
+      "UIKit",
+      "Foundation",
+      "AudioToolbox"
+    ]
+  },
+  "tvos": {
+    "weak_frameworks": [
+      "CoreLocation",
+      "Security",
+      "QuartzCore",
+      "CoreGraphics",
+      "UIKit",
+      "Foundation",
+      "AudioToolbox"
+    ]
+  },
+  "requires_arc": [
+    "FBSDKCoreKit/FBSDKCoreKit/*",
+    "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*",
+    "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*"
+  ],
+  "default_subspecs": [
+    "Core",
+    "Basics"
+  ],
+  "swift_versions": "5.0",
+  "pod_target_xcconfig": {
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) FBSDKCOCOAPODS=1",
+    "DEFINES_MODULE": "YES"
+  },
+  "user_target_xcconfig": {
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) FBSDKCOCOAPODS=1"
+  },
+  "libraries": [
+    "c++",
+    "stdc++"
+  ],
+  "subspecs": [
+    {
+      "name": "Basics",
+      "source_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.{h,m}",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}"
+      ],
+      "public_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+      ],
+      "private_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h"
+      ],
+      "libraries": "z"
+    },
+    {
+      "name": "Core",
+      "dependencies": {
+        "FBSDKCoreKit/Basics": [
+
+        ]
+      },
+      "exclude_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*",
+        "FBSDKCoreKit/FBSDKCoreKit/Swift/Exports.swift"
+      ],
+      "source_files": "FBSDKCoreKit/FBSDKCoreKit/**/*.{h,hpp,m,mm,swift}",
+      "public_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h"
+      ],
+      "private_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h"
+      ],
+      "resources": "FacebookSDKStrings.bundle",
+      "libraries": [
+        "c++",
+        "stdc++"
+      ]
+    }
+  ],
+  "swift_version": "5.0"
+}

--- a/Examples/PodSpecs/ObjcParentWithSwiftSubspecs.podspec.json
+++ b/Examples/PodSpecs/ObjcParentWithSwiftSubspecs.podspec.json
@@ -1,0 +1,37 @@
+{
+  "name": "ObjcParentWithSwiftSubspecs",
+  "version": "0.0.1",
+  "summary": "A summary",
+  "description": "A description",
+  "homepage": "http://p",
+  "license": "MIT",
+  "authors": {
+    "Jerry Marino": "i@jerrymarino.com"
+  },
+  "source": {
+    "git": "http://p/ChildPodspec.git",
+    "tag": "0.0.1"
+  },
+  "source_files": "Sources/**/*.{h,m}",
+  "public_headers": "Sources/**/*.{h}",
+  "exclude_files": "Classes/Exclude",
+  "swift_versions": "5",
+  "platforms": {
+    "osx": null,
+    "ios": null,
+    "tvos": null,
+    "watchos": null
+  },
+  "subspecs": [
+    {
+      "name": "Default",
+      "source_files": "Sources/**/*.swift"
+    },
+    {
+      "name": "Subspec",
+      "source_files": "**/*.swift",
+      "public_headers": "Sources/**/*.{h}"
+    }
+  ],
+  "swift_version": "5"
+}

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -59,6 +59,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Adjust_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Adjust_hdrs",
   srcs = glob(
     [
@@ -156,6 +165,19 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Adjust/*.h",
+      "Adjust/ADJAdditions/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -303,6 +325,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Sociomantic_public_hdrs",
+  srcs = glob(
+    [
+      "plugin/Sociomantic/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
     glob(
@@ -429,6 +465,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Criteo_public_hdrs",
+  srcs = glob(
+    [
+      "plugin/Criteo/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
     glob(
@@ -550,6 +600,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Trademob_public_hdrs",
+  srcs = glob(
+    [
+      "plugin/Trademob/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -58,6 +58,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FBSDKCoreKit_public_hdrs",
+  srcs = [
+    ":Basics_public_hdrs",
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = glob(
     [
@@ -335,6 +345,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Basics_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -1652,7 +1674,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
@@ -1675,7 +1700,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
@@ -1695,7 +1723,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/*.h",
@@ -1747,7 +1778,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
@@ -1766,6 +1800,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Basics_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = select(
     {
@@ -1777,7 +1827,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
@@ -1800,7 +1853,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
@@ -1820,7 +1876,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/*.h",
@@ -1872,7 +1931,10 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -57,6 +57,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Bolts_public_hdrs",
+  srcs = [
+    ":AppLinks_public_hdrs",
+    ":Tasks_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Bolts_hdrs",
   srcs = glob(
     [
@@ -142,6 +152,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Tasks_public_hdrs",
+  srcs = glob(
+    [
+      "Bolts/Common/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -276,7 +298,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "Bolts/iOS/**/*.h"
+            "Bolts/iOS/**/*.h",
+            "Bolts/iOS/*.h"
           ],
           exclude_directories = 1
         ),
@@ -307,6 +330,24 @@ filegroup(
   ]
 )
 filegroup(
+  name = "AppLinks_public_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "Bolts/iOS/*.h"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ) + [
+    ":Tasks_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "AppLinks_hdrs",
   srcs = select(
     {
@@ -318,7 +359,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "Bolts/iOS/**/*.h"
+            "Bolts/iOS/**/*.h",
+            "Bolts/iOS/*.h"
           ],
           exclude_directories = 1
         ),

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -68,6 +68,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Braintree_public_hdrs",
+  srcs = [
+    ":Card_public_hdrs",
+    ":Core_public_hdrs",
+    ":PayPal_public_hdrs",
+    ":UI_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Braintree_hdrs",
   srcs = glob(
     [
@@ -157,10 +169,23 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeCore/**/*.h"
+        "BraintreeCore/**/*.h",
+        "BraintreeCore/Public/*.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeCore/Public/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -177,7 +202,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeCore/**/*.h"
+        "BraintreeCore/**/*.h",
+        "BraintreeCore/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -324,12 +350,27 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeApplePay/**/*.h"
+        "BraintreeApplePay/**/*.h",
+        "BraintreeApplePay/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Apple-Pay_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeApplePay/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -344,7 +385,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeApplePay/**/*.h"
+        "BraintreeApplePay/**/*.h",
+        "BraintreeApplePay/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -441,12 +483,27 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeCard/**/*.h"
+        "BraintreeCard/**/*.h",
+        "BraintreeCard/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Card_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeCard/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -461,7 +518,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeCard/**/*.h"
+        "BraintreeCard/**/*.h",
+        "BraintreeCard/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -571,12 +629,27 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeDataCollector/**/*.h"
+        "BraintreeDataCollector/**/*.h",
+        "BraintreeDataCollector/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "DataCollector_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeDataCollector/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -591,7 +664,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeDataCollector/**/*.h"
+        "BraintreeDataCollector/**/*.h",
+        "BraintreeDataCollector/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -710,6 +784,21 @@ filegroup(
   ]
 )
 filegroup(
+  name = "PayPal_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreePayPal/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":PayPalOneTouch_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
     glob(
@@ -817,12 +906,28 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeVenmo/**/*.h"
+        "BraintreeVenmo/**/*.h",
+        "BraintreeVenmo/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Venmo_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeVenmo/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":PayPalDataCollector_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -837,7 +942,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeVenmo/**/*.h"
+        "BraintreeVenmo/**/*.h",
+        "BraintreeVenmo/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -962,12 +1068,28 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeUI/**/*.h"
+        "BraintreeUI/**/*.h",
+        "BraintreeUI/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "UI_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeUI/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Card_public_hdrs",
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -982,7 +1104,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeUI/**/*.h"
+        "BraintreeUI/**/*.h",
+        "BraintreeUI/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1086,12 +1209,28 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeUnionPay/**/*.h"
+        "BraintreeUnionPay/**/*.h",
+        "BraintreeUnionPay/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "UnionPay_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreeUnionPay/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Card_public_hdrs",
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1106,7 +1245,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreeUnionPay/**/*.h"
+        "BraintreeUnionPay/**/*.h",
+        "BraintreeUnionPay/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1220,12 +1360,28 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Braintree3DSecure/**/*.h"
+        "Braintree3DSecure/**/*.h",
+        "Braintree3DSecure/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "3D-Secure_public_hdrs",
+  srcs = glob(
+    [
+      "Braintree3DSecure/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Card_public_hdrs",
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1240,7 +1396,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Braintree3DSecure/**/*.h"
+        "Braintree3DSecure/**/*.h",
+        "Braintree3DSecure/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1343,12 +1500,29 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalOneTouch/**/*.h"
+        "BraintreePayPal/PayPalOneTouch/**/*.h",
+        "BraintreePayPal/PayPalOneTouch/Public/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PayPalOneTouch_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreePayPal/PayPalOneTouch/Public/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":PayPalDataCollector_public_hdrs",
+    ":PayPalUtils_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1363,7 +1537,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalOneTouch/**/*.h"
+        "BraintreePayPal/PayPalOneTouch/**/*.h",
+        "BraintreePayPal/PayPalOneTouch/Public/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1477,12 +1652,30 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalDataCollector/**/*.h"
+        "BraintreePayPal/PayPalDataCollector/**/*.h",
+        "BraintreePayPal/PayPalDataCollector/Public/*.h",
+        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PayPalDataCollector_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreePayPal/PayPalDataCollector/Public/*.h",
+      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":PayPalUtils_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1497,7 +1690,9 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalDataCollector/**/*.h"
+        "BraintreePayPal/PayPalDataCollector/**/*.h",
+        "BraintreePayPal/PayPalDataCollector/Public/*.h",
+        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
       ],
       exclude_directories = 1
     ),
@@ -1624,10 +1819,23 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalUtils/**/*.h"
+        "BraintreePayPal/PayPalUtils/**/*.h",
+        "BraintreePayPal/PayPalUtils/Public/*.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PayPalUtils_public_hdrs",
+  srcs = glob(
+    [
+      "BraintreePayPal/PayPalUtils/Public/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -1644,7 +1852,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "BraintreePayPal/PayPalUtils/**/*.h"
+        "BraintreePayPal/PayPalUtils/**/*.h",
+        "BraintreePayPal/PayPalUtils/Public/*.h"
       ],
       exclude_directories = 1
     ),

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -57,6 +57,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Branch_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs",
+    ":without-IDFA_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Branch_hdrs",
   srcs = glob(
     [
@@ -144,6 +154,23 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ],
+    exclude = [
+      "Branch-SDK/Fabric/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -262,6 +289,23 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "without-IDFA_public_hdrs",
+  srcs = glob(
+    [
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ],
+    exclude = [
+      "Branch-SDK/Fabric/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -67,6 +67,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Calabash_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
     glob(
@@ -171,6 +185,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
     ":Calabash_cxx_hdrs"
   ],
@@ -251,6 +266,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Calabash_public_hdrs",
+  srcs = glob(
+    [
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Calabash_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
     glob(
@@ -306,6 +337,7 @@ objc_library(
     ],
     exclude_directories = 1
   ),
+  module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
     ":Calabash_hdrs"
   ],
@@ -349,4 +381,28 @@ acknowledged_target(
   name = "Calabash_acknowledgement",
   deps = [],
   value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
+)
+gen_module_map(
+  "Calabash_extended_module_map_module_map_file",
+  "Calabash_extended_module_map",
+  "Calabash",
+  [
+    "Calabash_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  "Calabash_module_map_module_map_file",
+  "Calabash_module_map",
+  "Calabash",
+  [
+    "Calabash_extended_module_map_module_map_file",
+    "Calabash_public_hdrs"
+  ],
+  module_map_name = "Calabash.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
 )

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "CardIO_public_hdrs",
+  srcs = glob(
+    [
+      "CardIO/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -41,7 +40,8 @@ filegroup(
     "Default_direct_hdrs",
     "Core_direct_hdrs",
     "Extensions_direct_hdrs",
-    "CLI_direct_hdrs"
+    "CLI_direct_hdrs",
+    "Swift_direct_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -55,6 +55,16 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "CocoaLumberjack_public_hdrs",
+  srcs = [
+    ":Default_public_hdrs",
+    ":Extensions_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -146,6 +156,19 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Default_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/CocoaLumberjack.h",
+      "Classes/DD*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -268,6 +291,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/DD*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = glob(
     glob(
@@ -371,6 +406,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Extensions_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/Extensions/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Default_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -503,6 +552,30 @@ filegroup(
         ],
         exclude_directories = 1
       )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "CLI_public_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": [],
+      ":osxCase": glob(
+        [
+          "Classes/CLI/*.h"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ) + select(
+    {
+      "//conditions:default": [],
+      ":osxCase": [
+        ":Default_public_hdrs"
+      ]
     }
   ),
   visibility = [
@@ -645,19 +718,102 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "Swift",
+filegroup(
+  name = "Swift_direct_hdrs",
   srcs = glob(
     [
-      "Classes/CocoaLumberjack.swift"
+      "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
   ),
-  deps = [
-    ":Default"
-  ],
-  data = [],
   visibility = [
     "//visibility:public"
   ]
+)
+filegroup(
+  name = "Swift_public_hdrs",
+  srcs = [
+    ":Default_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Swift_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Swift_union_hdrs",
+  srcs = [
+    "Swift_hdrs",
+    "CocoaLumberjack_hdrs",
+    ":Default_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Swift_hmap",
+  namespace = "CocoaLumberjack",
+  hdrs = [
+    "CocoaLumberjack_package_hdrs",
+    ":Swift_union_hdrs"
+  ],
+  deps = [
+    ":Default"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Swift_includes",
+  include = [
+    "Vendor/CocoaLumberjack/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Swift",
+  enable_modules = 0,
+  hdrs = [
+    ":Swift_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/CocoaLumberjack-prefix.pch",
+  deps = [
+    ":Default",
+    ":Swift_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
+  ] + [
+    "-fmodule-name=CocoaLumberjack"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Swift_acknowledgement",
+  deps = [],
+  value = "//Vendor/CocoaLumberjack/pod_support_buildable:acknowledgement_fragment"
 )

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "ColorCube_public_hdrs",
+  srcs = glob(
+    [
+      "ColorCube/ColorCube/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "EarlGrey_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "EarlGrey_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -56,10 +56,27 @@ filegroup(
       [
         "FBAllocationTracker/**/*.h",
         "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx"
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBAllocationTracker_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -78,7 +95,10 @@ filegroup(
       [
         "FBAllocationTracker/**/*.h",
         "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx"
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
       ],
       exclude_directories = 1
     ),
@@ -213,6 +233,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
     ":FBAllocationTracker_cxx_hdrs"
   ],
@@ -278,12 +299,31 @@ filegroup(
       [
         "FBAllocationTracker/**/*.h",
         "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx"
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBAllocationTracker_public_hdrs",
+  srcs = glob(
+    [
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":FBAllocationTracker_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -300,7 +340,10 @@ filegroup(
       [
         "FBAllocationTracker/**/*.h",
         "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx"
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
       ],
       exclude_directories = 1
     ),
@@ -405,6 +448,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
     ":FBAllocationTracker_hdrs"
   ],
@@ -443,4 +487,28 @@ acknowledged_target(
   name = "FBAllocationTracker_acknowledgement",
   deps = [],
   value = "//Vendor/FBAllocationTracker/pod_support_buildable:acknowledgement_fragment"
+)
+gen_module_map(
+  "FBAllocationTracker_extended_module_map_module_map_file",
+  "FBAllocationTracker_extended_module_map",
+  "FBAllocationTracker",
+  [
+    "FBAllocationTracker_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  "FBAllocationTracker_module_map_module_map_file",
+  "FBAllocationTracker_module_map",
+  "FBAllocationTracker",
+  [
+    "FBAllocationTracker_extended_module_map_module_map_file",
+    "FBAllocationTracker_public_hdrs"
+  ],
+  module_map_name = "FBAllocationTracker.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
 )

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -1,0 +1,1969 @@
+load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
+load(
+  "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
+  "acknowledged_target",
+  "gen_module_map",
+  "gen_includes",
+  "headermap"
+)
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://docs.bazel.build/versions/master/be/general.html#config_setting
+config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+)
+config_setting(
+  name = "osxCase",
+  values = {
+    "apple_platform_type": "macos"
+  }
+)
+config_setting(
+  name = "tvosCase",
+  values = {
+    "apple_platform_type": "tvos"
+  }
+)
+config_setting(
+  name = "watchosCase",
+  values = {
+    "apple_platform_type": "watchos"
+  }
+)
+filegroup(
+  name = "FBSDKCoreKit_package_hdrs",
+  srcs = [
+    "FBSDKCoreKit_direct_hdrs",
+    "Basics_direct_hdrs",
+    "Core_cxx_direct_hdrs",
+    "Core_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_public_hdrs",
+  srcs = [
+    ":Basics_public_hdrs",
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Basics_hdrs",
+    ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKCoreKit_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":FBSDKCoreKit_hdrs"
+  ],
+  deps = [
+    ":Basics",
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "FBSDKCoreKit_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "FBSDKCoreKit",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  hdrs = [
+    ":FBSDKCoreKit_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accelerate",
+        "Accounts",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "c++",
+    "stdc++"
+  ],
+  deps = [
+    ":Basics",
+    ":Core",
+    ":FBSDKCoreKit_includes"
+  ],
+  copts = [
+    "-DFBSDKCOCOAPODS=1",
+    "-DFBSDKCOCOAPODS=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ] + [
+    "-fmodule-name=FBSDKCoreKit"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "FBSDKCoreKit_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Basics_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Basics_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ],
+    exclude = [
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Basics_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Basics_union_hdrs",
+  srcs = [
+    "Basics_hdrs",
+    "FBSDKCoreKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Basics_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":Basics_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Basics_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Basics",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m"
+        ],
+        exclude = glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+        ],
+        exclude_directories = 1
+      ) + glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+        ],
+        exclude = glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m"
+          ],
+          exclude = glob(
+            [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+            ],
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+            ],
+            exclude_directories = 1
+          ) + glob(
+            [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ],
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  hdrs = [
+    ":Basics_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accelerate",
+        "Accounts",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "z"
+  ],
+  deps = [
+    ":Basics_includes"
+  ],
+  copts = [
+    "-DFBSDKCOCOAPODS=1",
+    "-DFBSDKCOCOAPODS=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ] + [
+    "-fmodule-name=FBSDKCoreKit"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Basics_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+apple_bundle_import(
+  name = "Core_Bundle_FacebookSDKStrings",
+  bundle_imports = glob(
+    [
+      "FacebookSDKStrings.bundle/**"
+    ],
+    exclude_directories = 1
+  )
+)
+acknowledged_target(
+  name = "Core_Bundle_FacebookSDKStrings_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Core_cxx_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+    ],
+    exclude = [
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Basics_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_union_hdrs",
+  srcs = [
+    "Core_cxx_hdrs",
+    "FBSDKCoreKit_hdrs",
+    ":Basics_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_cxx_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":Core_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Basics"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Core_cxx_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Core_cxx",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+        ] + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+      ] + glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+        ],
+        exclude = glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.mm"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+          ] + glob(
+            [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ],
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+              "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
+  hdrs = [
+    ":Core_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accelerate",
+        "Accounts",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "c++",
+    "stdc++"
+  ],
+  deps = [
+    ":Basics",
+    ":Core_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14",
+    "-DFBSDKCOCOAPODS=1",
+    "-DFBSDKCOCOAPODS=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ] + [
+    "-fmodule-name=FBSDKCoreKit"
+  ],
+  data = [
+    ":Core_Bundle_FacebookSDKStrings"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Core_cxx_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Core_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+    ],
+    exclude = [
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Basics_public_hdrs",
+    ":Core_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_union_hdrs",
+  srcs = [
+    "Core_hdrs",
+    "FBSDKCoreKit_hdrs",
+    ":Basics_hdrs",
+    ":Core_cxx_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Core_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":Core_union_hdrs"
+  ],
+  deps = [
+    ":Basics",
+    ":Core_cxx"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Core_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Core",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
+        exclude = [
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+      ],
+      exclude = [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude = glob(
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+          "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+        ],
+        exclude = glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.S",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.c",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cc",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cpp",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.cxx",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
+            "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
+  hdrs = [
+    ":Core_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accelerate",
+        "Accounts",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "c++",
+    "stdc++"
+  ],
+  deps = [
+    ":Basics",
+    ":Core_cxx",
+    ":Core_includes"
+  ],
+  copts = [
+    "-DFBSDKCOCOAPODS=1",
+    "-DFBSDKCOCOAPODS=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ] + [
+    "-fmodule-name=FBSDKCoreKit"
+  ],
+  data = [
+    ":Core_Bundle_FacebookSDKStrings"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Core_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -55,7 +55,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
@@ -76,7 +77,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude_directories = 1
         ),
@@ -90,7 +92,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
@@ -133,13 +136,26 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude_directories = 1
         ),
         exclude_directories = 1
       )
     }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.h"
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -157,7 +173,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
@@ -178,7 +195,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude_directories = 1
         ),
@@ -192,7 +210,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude = [
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
@@ -235,7 +254,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h"
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
           exclude_directories = 1
         ),

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -52,10 +52,23 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
+        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+        "FBSDKLoginKit/FBSDKLoginKit/*.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKLoginKit_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKLoginKit/FBSDKLoginKit/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -72,7 +85,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h"
+        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+        "FBSDKLoginKit/FBSDKLoginKit/*.h"
       ],
       exclude_directories = 1
     ),

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -52,10 +52,23 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKMessengerShareKit_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -72,7 +85,8 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h"
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
       ],
       exclude_directories = 1
     ),

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -54,7 +54,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKShareKit/FBSDKShareKit/**/*.h"
+            "FBSDKShareKit/FBSDKShareKit/**/*.h",
+            "FBSDKShareKit/FBSDKShareKit/*.h"
           ],
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
@@ -120,6 +121,44 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FBSDKShareKit_public_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "FBSDKShareKit/FBSDKShareKit/*.h"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        [
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKShareKit_hdrs",
   srcs = select(
     {
@@ -131,7 +170,8 @@ filegroup(
           exclude_directories = 1
         ) + glob(
           [
-            "FBSDKShareKit/FBSDKShareKit/**/*.h"
+            "FBSDKShareKit/FBSDKShareKit/**/*.h",
+            "FBSDKShareKit/FBSDKShareKit/*.h"
           ],
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FLAnimatedImage_public_hdrs",
+  srcs = glob(
+    [
+      "FLAnimatedImage/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -52,10 +52,25 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Classes/**/*.h"
+        "Classes/**/*.h",
+        "Classes/**/FLEXManager.h",
+        "Classes/FLEX.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FLEX_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/**/FLEXManager.h",
+      "Classes/FLEX.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -72,7 +87,9 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "Classes/**/*.h"
+        "Classes/**/*.h",
+        "Classes/**/FLEXManager.h",
+        "Classes/FLEX.h"
       ],
       exclude_directories = 1
     ),

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -61,6 +61,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FMDB_public_hdrs",
+  srcs = [
+    ":standard_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FMDB_hdrs",
   srcs = glob(
     [
@@ -143,6 +152,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "standard_public_hdrs",
+  srcs = glob(
+    [
+      "src/fmdb/FM*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -269,6 +290,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FTS_public_hdrs",
+  srcs = glob(
+    [
+      "src/extra/fts3/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":standard_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FTS_hdrs",
   srcs = glob(
     glob(
@@ -373,6 +408,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "standalone_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standalone_hdrs",
   srcs = glob(
     [
@@ -462,6 +504,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "standalone_default_public_hdrs",
+  srcs = glob(
+    [
+      "src/fmdb/FM*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -588,6 +642,19 @@ filegroup(
   ]
 )
 filegroup(
+  name = "standalone_FTS_public_hdrs",
+  srcs = glob(
+    [
+      "src/extra/fts3/*.h",
+      "src/fmdb/FM*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "standalone_FTS_hdrs",
   srcs = glob(
     glob(
@@ -701,6 +768,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SQLCipher_public_hdrs",
+  srcs = glob(
+    [
+      "src/fmdb/FM*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -36,13 +36,15 @@ config_setting(
 )
 filegroup(
   name = "FolioReaderKit_package_hdrs",
-  srcs = [],
+  srcs = [
+    "FolioReaderKit_direct_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
 )
 swift_library(
-  name = "FolioReaderKit",
+  name = "FolioReaderKit_swift",
   srcs = glob(
     [
       "Source/**/*.swift",
@@ -73,4 +75,145 @@ swift_library(
   visibility = [
     "//visibility:public"
   ]
+)
+filegroup(
+  name = "FolioReaderKit_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FolioReaderKit_public_hdrs",
+  srcs = glob(
+    [
+      "Source/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FolioReaderKit_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FolioReaderKit_hmap",
+  namespace = "FolioReaderKit",
+  hdrs = [
+    "FolioReaderKit_package_hdrs",
+    ":FolioReaderKit_hdrs"
+  ],
+  deps = [
+    "//Vendor/AEXML:AEXML",
+    "//Vendor/FontBlaster:FontBlaster",
+    "//Vendor/JSQWebViewController:JSQWebViewController",
+    "//Vendor/MenuItemKit:MenuItemKit",
+    "//Vendor/RealmSwift:RealmSwift",
+    "//Vendor/SSZipArchive:SSZipArchive",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "FolioReaderKit_includes",
+  include = [
+    "Vendor/FolioReaderKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "FolioReaderKit",
+  enable_modules = 0,
+  hdrs = [
+    ":FolioReaderKit_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FolioReaderKit-prefix.pch",
+  sdk_dylibs = [
+    "z"
+  ],
+  deps = [
+    "//Vendor/AEXML:AEXML",
+    "//Vendor/FontBlaster:FontBlaster",
+    "//Vendor/JSQWebViewController:JSQWebViewController",
+    "//Vendor/MenuItemKit:MenuItemKit",
+    "//Vendor/RealmSwift:RealmSwift",
+    "//Vendor/SSZipArchive:SSZipArchive",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition",
+    ":FolioReaderKit_swift",
+    ":FolioReaderKit_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FolioReaderKit/pod_support/Headers/Public/FolioReaderKit/"
+  ] + [
+    "-fmodule-name=FolioReaderKit"
+  ],
+  data = glob(
+    [
+      "Source/**/*.css",
+      "Source/**/*.js",
+      "Source/Resources/*.xcassets",
+      "Source/Resources/Fonts/**/*.otf",
+      "Source/Resources/Fonts/**/*.ttf"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "FolioReaderKit_acknowledgement",
+  deps = [
+    "//Vendor/AEXML:AEXML_acknowledgement",
+    "//Vendor/FontBlaster:FontBlaster_acknowledgement",
+    "//Vendor/JSQWebViewController:JSQWebViewController_acknowledgement",
+    "//Vendor/MenuItemKit:MenuItemKit_acknowledgement",
+    "//Vendor/RealmSwift:RealmSwift_acknowledgement",
+    "//Vendor/SSZipArchive:SSZipArchive_acknowledgement",
+    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition_acknowledgement"
+  ],
+  value = "//Vendor/FolioReaderKit/pod_support_buildable:acknowledgement_fragment"
 )

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -65,6 +65,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Folly_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Folly_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -67,6 +67,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleAppIndexing_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleAppUtilities_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAppUtilities_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleAuthUtilities_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleAuthUtilities_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleNetworkingUtilities_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleNetworkingUtilities_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -57,6 +57,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleSignIn_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleSignIn_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleSymbolUtilities_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleSymbolUtilities_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -56,6 +56,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "GoogleUtilities_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "GoogleUtilities_hdrs",
   srcs = glob(
     [

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "IBActionSheet_public_hdrs",
+  srcs = glob(
+    [
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -59,6 +59,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "IGListKit_public_hdrs",
+  srcs = [
+    ":Default_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
     [
@@ -158,6 +167,21 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Diffing_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Source/Common/**/*.h"
+    ],
+    exclude = [
+      "Source/Common/Internal/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -366,6 +390,23 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Diffing_public_hdrs",
+  srcs = glob(
+    [
+      "Source/Common/**/*.h"
+    ],
+    exclude = [
+      "Source/Common/Internal/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Diffing_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -588,6 +629,38 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Default_cxx_public_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "Source/**/*.h"
+        ],
+        exclude = [
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        [
+          "Source/**/*.h"
+        ],
+        exclude = [
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ) + [
+    ":Diffing_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Default_cxx_hdrs",
   srcs = select(
     {
@@ -805,6 +878,39 @@ filegroup(
       )
     }
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Default_public_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "Source/**/*.h"
+        ],
+        exclude = [
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ],
+        exclude_directories = 1
+      ),
+      ":tvosCase": glob(
+        [
+          "Source/**/*.h"
+        ],
+        exclude = [
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ],
+        exclude_directories = 1
+      )
+    }
+  ) + [
+    ":Default_cxx_public_hdrs",
+    ":Diffing_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "KVOController_public_hdrs",
+  srcs = glob(
+    [
+      "FBKVOController/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -60,6 +60,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "KakaoOpenSDK_public_hdrs",
+  srcs = [
+    ":KakaoLink_public_hdrs",
+    ":KakaoNavi_public_hdrs",
+    ":KakaoOpenSDK_public_hdrs",
+    ":KakaoS2_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoOpenSDK_hdrs",
   srcs = glob(
     [
@@ -153,6 +165,13 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "KakaoOpenSDK_public_hdrs",
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
@@ -268,6 +287,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "KakaoNavi_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoNavi_hdrs",
   srcs = glob(
     [
@@ -377,6 +403,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "KakaoLink_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "KakaoLink_hdrs",
   srcs = glob(
     [
@@ -481,6 +514,13 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "KakaoS2_public_hdrs",
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Masonry_public_hdrs",
+  srcs = glob(
+    [
+      "Masonry/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -1,0 +1,373 @@
+load(
+  "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
+  "acknowledged_target",
+  "gen_module_map",
+  "gen_includes",
+  "headermap"
+)
+# Add a config setting release for compilation mode
+# Assume that people are using `opt` for release mode
+# see the bazel user manual for more information
+# https://docs.bazel.build/versions/master/be/general.html#config_setting
+config_setting(
+  name = "release",
+  values = {
+    "compilation_mode": "opt"
+  }
+)
+config_setting(
+  name = "osxCase",
+  values = {
+    "apple_platform_type": "macos"
+  }
+)
+config_setting(
+  name = "tvosCase",
+  values = {
+    "apple_platform_type": "tvos"
+  }
+)
+config_setting(
+  name = "watchosCase",
+  values = {
+    "apple_platform_type": "watchos"
+  }
+)
+filegroup(
+  name = "ObjcParentWithSwiftSubspecs_package_hdrs",
+  srcs = [
+    "ObjcParentWithSwiftSubspecs_direct_hdrs",
+    "Default_direct_hdrs",
+    "Subspec_direct_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "ObjcParentWithSwiftSubspecs_direct_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Sources/**/*.h"
+      ],
+      exclude = [
+        "Classes/Exclude/**/*.h",
+        "Classes/Exclude/**/*.hpp",
+        "Classes/Exclude/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "ObjcParentWithSwiftSubspecs_public_hdrs",
+  srcs = glob(
+    [
+      "Sources/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Default_public_hdrs",
+    ":Subspec_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "ObjcParentWithSwiftSubspecs_hdrs",
+  srcs = glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Sources/**/*.h"
+      ],
+      exclude = [
+        "Classes/Exclude/**/*.h",
+        "Classes/Exclude/**/*.hpp",
+        "Classes/Exclude/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ) + [
+    ":Default_hdrs",
+    ":Subspec_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "ObjcParentWithSwiftSubspecs_hmap",
+  namespace = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_package_hdrs",
+    ":ObjcParentWithSwiftSubspecs_hdrs"
+  ],
+  deps = [
+    ":Default",
+    ":Subspec"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "ObjcParentWithSwiftSubspecs_includes",
+  include = [
+    "Vendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "ObjcParentWithSwiftSubspecs",
+  enable_modules = 0,
+  srcs = glob(
+    [
+      "Sources/**/*.m"
+    ],
+    exclude = [
+      "Classes/Exclude/**/*.S",
+      "Classes/Exclude/**/*.c",
+      "Classes/Exclude/**/*.cc",
+      "Classes/Exclude/**/*.cpp",
+      "Classes/Exclude/**/*.cxx",
+      "Classes/Exclude/**/*.m",
+      "Classes/Exclude/**/*.mm",
+      "Classes/Exclude/**/*.s"
+    ],
+    exclude_directories = 1
+  ),
+  hdrs = [
+    ":ObjcParentWithSwiftSubspecs_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
+  deps = [
+    ":Default",
+    ":Subspec",
+    ":ObjcParentWithSwiftSubspecs_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
+  ] + [
+    "-fmodule-name=ObjcParentWithSwiftSubspecs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "ObjcParentWithSwiftSubspecs_acknowledgement",
+  deps = [],
+  value = "//Vendor/ObjcParentWithSwiftSubspecs/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Default_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Default_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Default_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Default_union_hdrs",
+  srcs = [
+    "Default_hdrs",
+    "ObjcParentWithSwiftSubspecs_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Default_hmap",
+  namespace = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_package_hdrs",
+    ":Default_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Default_includes",
+  include = [
+    "Vendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Default",
+  enable_modules = 0,
+  hdrs = [
+    ":Default_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
+  deps = [
+    ":Default_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
+  ] + [
+    "-fmodule-name=ObjcParentWithSwiftSubspecs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Default_acknowledgement",
+  deps = [],
+  value = "//Vendor/ObjcParentWithSwiftSubspecs/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "Subspec_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Subspec_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Subspec_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Subspec_union_hdrs",
+  srcs = [
+    "Subspec_hdrs",
+    "ObjcParentWithSwiftSubspecs_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "Subspec_hmap",
+  namespace = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_package_hdrs",
+    ":Subspec_union_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "Subspec_includes",
+  include = [
+    "Vendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "Subspec",
+  enable_modules = 0,
+  hdrs = [
+    ":Subspec_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
+  deps = [
+    ":Subspec_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
+  ] + [
+    "-fmodule-name=ObjcParentWithSwiftSubspecs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "Subspec_acknowledgement",
+  deps = [],
+  value = "//Vendor/ObjcParentWithSwiftSubspecs/pod_support_buildable:acknowledgement_fragment"
+)

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -69,6 +69,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "OnePasswordExtension_public_hdrs",
+  srcs = glob(
+    [
+      "*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -57,6 +57,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "PINCache_public_hdrs",
+  srcs = [
+    ":Arc-exception-safe_public_hdrs",
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
     [
@@ -155,6 +165,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Source/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -281,6 +303,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Arc-exception-safe_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -64,6 +64,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "PINOperation_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Source/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
     glob(
@@ -178,6 +190,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINOperation_public_hdrs",
+  srcs = glob(
+    [
+      "Source/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":PINOperation_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -62,6 +62,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "PINRemoteImage_public_hdrs",
+  srcs = [
+    ":FLAnimatedImage_public_hdrs",
+    ":PINCache_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PINRemoteImage_hdrs",
   srcs = glob(
     [
@@ -151,6 +161,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Source/Classes/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -285,6 +307,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "iOS_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iOS_hdrs",
   srcs = glob(
     [
@@ -373,6 +404,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "OSX_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -472,6 +512,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "tvOS_public_hdrs",
+  srcs = [
+    ":iOS_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
     [
@@ -565,6 +614,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FLAnimatedImage_public_hdrs",
+  srcs = glob(
+    [
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -678,6 +741,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "WebP_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "WebP_hdrs",
   srcs = glob(
     [
@@ -777,6 +849,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINCache_public_hdrs",
+  srcs = glob(
+    [
+      "Source/Classes/PINCache/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "PaymentKit_public_hdrs",
+  srcs = glob(
+    [
+      "PaymentKit/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RadarKit_public_hdrs",
+  srcs = glob(
+    [
+      "RadarKit/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -95,6 +94,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -345,6 +353,18 @@ filegroup(
         exclude_directories = 1
       )
     }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "React/**/*.h"
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2079,6 +2099,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "React/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Core_hdrs",
   srcs = select(
     {
@@ -3326,6 +3360,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "CxxBridge_cxx_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs",
+    ":cxxreact_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
     glob(
@@ -3450,6 +3494,17 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "CxxBridge_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs",
+    ":CxxBridge_cxx_public_hdrs",
+    ":cxxreact_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -3584,6 +3639,26 @@ filegroup(
   ]
 )
 filegroup(
+  name = "DevSupport_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTWebSocket_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
     glob(
@@ -3670,6 +3745,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
     ":DevSupport_cxx_hdrs"
   ],
@@ -3706,24 +3782,6 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "DevSupport_swift",
-  srcs = glob(
-    [
-      "React/DevSupport/*.swift",
-      "React/Inspector/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [
-    ":Core",
-    ":RCTWebSocket"
-  ],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "DevSupport_direct_hdrs",
   srcs = glob(
@@ -3745,6 +3803,27 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "DevSupport_public_hdrs",
+  srcs = glob(
+    [
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":DevSupport_cxx_public_hdrs",
+    ":RCTWebSocket_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -3825,6 +3904,7 @@ objc_library(
     ],
     exclude_directories = 1
   ),
+  module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
     ":DevSupport_hdrs"
   ],
@@ -3832,7 +3912,6 @@ objc_library(
   deps = [
     ":Core",
     ":DevSupport_cxx",
-    ":DevSupport_swift",
     ":RCTWebSocket",
     ":DevSupport_includes"
   ],
@@ -3881,6 +3960,21 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTFabric_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "React/Fabric/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":fabric_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -4050,6 +4144,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTFabric_public_hdrs",
+  srcs = glob(
+    [
+      "React/Fabric/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTFabric_cxx_public_hdrs",
+    ":fabric_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
     glob(
@@ -4195,6 +4305,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "tvOS_public_hdrs",
+  srcs = glob(
+    [
+      "React/**/RCTTV*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
     glob(
@@ -4302,6 +4426,15 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "jschelpers_public_hdrs",
+  srcs = [
+    ":PrivateDatabase_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -4461,6 +4594,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "jsinspector_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "jsinspector_hdrs",
   srcs = glob(
     glob(
@@ -4598,6 +4738,13 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PrivateDatabase_public_hdrs",
+  srcs = [],
   visibility = [
     "//visibility:public"
   ]
@@ -4755,6 +4902,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "cxxreact_public_hdrs",
+  srcs = [
+    ":jschelpers_public_hdrs",
+    ":jsinspector_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "cxxreact_hdrs",
   srcs = glob(
     glob(
@@ -4906,6 +5063,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_hdrs",
   srcs = glob(
     [
@@ -4998,6 +5162,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "fabric_activityindicator_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/activityindicator/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -5143,6 +5319,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_attributedstring_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/attributedstring/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_attributedstring_hdrs",
   srcs = glob(
     glob(
@@ -5274,6 +5462,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "fabric_core_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/core/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -5419,6 +5619,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_debug_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/debug/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_debug_hdrs",
   srcs = glob(
     glob(
@@ -5550,6 +5762,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "fabric_graphics_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/graphics/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -5695,6 +5919,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_scrollview_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/scrollview/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_scrollview_hdrs",
   srcs = glob(
     glob(
@@ -5833,6 +6069,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_text_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/text/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_text_hdrs",
   srcs = glob(
     glob(
@@ -5964,6 +6212,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "fabric_textlayoutmanager_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/textlayoutmanager/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -6110,6 +6370,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fabric_uimanager_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/uimanager/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fabric_uimanager_hdrs",
   srcs = glob(
     glob(
@@ -6241,6 +6513,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "fabric_view_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/view/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -6389,6 +6673,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTFabricSample_public_hdrs",
+  srcs = glob(
+    [
+      "ReactCommon/fabric/sample/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
     glob(
@@ -6522,6 +6818,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "ART_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/ART/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ART_hdrs",
   srcs = glob(
     glob(
@@ -6629,6 +6939,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTActionSheet_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/ActionSheetIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -6748,6 +7072,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTAnimation_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
     glob(
@@ -6859,6 +7199,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTBlob_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Blob/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -7026,6 +7380,21 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTBlob_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Blob/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTBlob_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
     glob(
@@ -7183,6 +7552,21 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTCameraRoll_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/CameraRoll/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTImage_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
     glob(
@@ -7298,6 +7682,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTGeolocation_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Geolocation/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
     glob(
@@ -7405,6 +7803,21 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTImage_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Image/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTNetwork_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -7526,6 +7939,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTNetwork_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Network/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -7662,6 +8089,21 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTNetwork_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Network/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTNetwork_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
     glob(
@@ -7788,6 +8230,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTPushNotification_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/PushNotificationIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
     glob(
@@ -7895,6 +8351,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTSettings_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Settings/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -8012,6 +8482,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTText_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Text/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
     glob(
@@ -8124,6 +8608,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTVibration_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Vibration/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
     glob(
@@ -8231,6 +8729,22 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTWebSocket_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/WebSocket/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs",
+    ":RCTBlob_public_hdrs",
+    ":fishhook_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -8391,6 +8905,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "fishhook_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/fishhook/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
     glob(
@@ -8541,6 +9067,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTLinkingIOS_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/LinkingIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
     glob(
@@ -8653,6 +9193,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTTest_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/RCTTest/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
     glob(
@@ -8755,6 +9309,16 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "_ignore_me_subspec_for_linting__public_hdrs",
+  srcs = [
+    ":Core_public_hdrs",
+    ":CxxBridge_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -90,6 +90,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "React_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "React_hdrs",
   srcs = glob(
     glob(
@@ -217,6 +226,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "React/**/*.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -437,6 +458,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "ART_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/ART/**/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ART_hdrs",
   srcs = glob(
     glob(
@@ -544,6 +579,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTActionSheet_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/ActionSheetIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -661,6 +710,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTAdSupport_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/AdSupport/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
     glob(
@@ -768,6 +831,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTGeolocation_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Geolocation/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -885,6 +962,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTImage_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Image/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
     glob(
@@ -992,6 +1083,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTNetwork_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Network/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1109,6 +1214,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTPushNotification_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/PushNotificationIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
     glob(
@@ -1216,6 +1335,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTSettings_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Settings/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1333,6 +1466,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTText_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Text/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
     glob(
@@ -1440,6 +1587,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTVibration_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/Vibration/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -1557,6 +1718,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "RCTWebSocket_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/WebSocket/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
     glob(
@@ -1664,6 +1839,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "RCTLinkingIOS_public_hdrs",
+  srcs = glob(
+    [
+      "Libraries/LinkingIOS/*.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -67,6 +67,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "SFHFKeychainUtils_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
     glob(
@@ -171,6 +185,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
@@ -244,6 +259,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "SFHFKeychainUtils_public_hdrs",
+  srcs = glob(
+    [
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":SFHFKeychainUtils_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
     glob(
@@ -299,6 +330,7 @@ objc_library(
     ],
     exclude_directories = 1
   ),
+  module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
     ":SFHFKeychainUtils_hdrs"
   ],
@@ -334,4 +366,28 @@ acknowledged_target(
   name = "SFHFKeychainUtils_acknowledgement",
   deps = [],
   value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
+)
+gen_module_map(
+  "SFHFKeychainUtils_extended_module_map_module_map_file",
+  "SFHFKeychainUtils_extended_module_map",
+  "SFHFKeychainUtils",
+  [
+    "SFHFKeychainUtils_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  "SFHFKeychainUtils_module_map_module_map_file",
+  "SFHFKeychainUtils_module_map",
+  "SFHFKeychainUtils",
+  [
+    "SFHFKeychainUtils_extended_module_map_module_map_file",
+    "SFHFKeychainUtils_public_hdrs"
+  ],
+  module_map_name = "SFHFKeychainUtils.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
 )

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "SPUserResizableView+Pion_public_hdrs",
+  srcs = glob(
+    [
+      "SPUserResizableView/SPUserResizableView.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -36,13 +36,15 @@ config_setting(
 )
 filegroup(
   name = "SevenSwitch_package_hdrs",
-  srcs = [],
+  srcs = [
+    "SevenSwitch_direct_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
 )
 swift_library(
-  name = "SevenSwitch",
+  name = "SevenSwitch_swift",
   srcs = glob(
     [
       "SevenSwitch.swift"
@@ -57,4 +59,92 @@ swift_library(
   visibility = [
     "//visibility:public"
   ]
+)
+filegroup(
+  name = "SevenSwitch_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SevenSwitch_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SevenSwitch_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SevenSwitch_hmap",
+  namespace = "SevenSwitch",
+  hdrs = [
+    "SevenSwitch_package_hdrs",
+    ":SevenSwitch_hdrs"
+  ],
+  deps = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "SevenSwitch_includes",
+  include = [
+    "Vendor/SevenSwitch/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "SevenSwitch",
+  enable_modules = 0,
+  hdrs = [
+    ":SevenSwitch_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/SevenSwitch-prefix.pch",
+  sdk_frameworks = [
+    "UIKit",
+    "QuartzCore"
+  ],
+  deps = [
+    ":SevenSwitch_swift",
+    ":SevenSwitch_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/SevenSwitch/pod_support/Headers/Public/SevenSwitch/"
+  ] + [
+    "-fmodule-name=SevenSwitch"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "SevenSwitch_acknowledgement",
+  deps = [],
+  value = "//Vendor/SevenSwitch/pod_support_buildable:acknowledgement_fragment"
 )

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "SlackTextViewController_public_hdrs",
+  srcs = glob(
+    [
+      "Source/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Smartling_public_hdrs",
+  srcs = glob(
+    [
+      "*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -65,6 +65,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Stripe_public_hdrs",
+  srcs = glob(
+    [
+      "Stripe/PublicHeaders/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -56,6 +56,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "TestArcPatternsWithExcludes_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "FBSDKCoreKit_hdrs",
   srcs = glob(
     [
@@ -230,6 +239,18 @@ filegroup(
         exclude_directories = 1
       )
     }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "**/*.h"
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Texture_public_hdrs",
+  srcs = [
+    ":AssetsLibrary_public_hdrs",
+    ":MapKit_public_hdrs",
+    ":PINRemoteImage_public_hdrs",
+    ":Photos_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Texture_hdrs",
   srcs = glob(
     [
@@ -155,10 +167,35 @@ filegroup(
       [
         "Base/*.h",
         "Source/**/*.h",
-        "Source/TextKit/*.h"
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -177,7 +214,14 @@ filegroup(
       [
         "Base/*.h",
         "Source/**/*.h",
-        "Source/TextKit/*.h"
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
       ],
       exclude_directories = 1
     ),
@@ -282,12 +326,39 @@ filegroup(
       [
         "Base/*.h",
         "Source/**/*.h",
-        "Source/TextKit/*.h"
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Core_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -304,7 +375,14 @@ filegroup(
       [
         "Base/*.h",
         "Source/**/*.h",
-        "Source/TextKit/*.h"
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
       ],
       exclude_directories = 1
     ),
@@ -400,6 +478,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "PINRemoteImage_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -505,6 +592,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "IGListKit_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "IGListKit_hdrs",
   srcs = glob(
     [
@@ -597,6 +693,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Yoga_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -701,6 +806,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "MapKit_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "MapKit_hdrs",
   srcs = glob(
     [
@@ -799,6 +913,15 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Photos_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Photos_hdrs",
   srcs = glob(
     [
@@ -892,6 +1015,15 @@ filegroup(
     ],
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "AssetsLibrary_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -67,6 +67,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "UICollectionViewLeftAlignedLayout_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
     glob(
@@ -137,6 +151,7 @@ objc_library(
     ),
     exclude_directories = 1
   ),
+  module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
@@ -207,6 +222,22 @@ filegroup(
   ]
 )
 filegroup(
+  name = "UICollectionViewLeftAlignedLayout_public_hdrs",
+  srcs = glob(
+    [
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":UICollectionViewLeftAlignedLayout_cxx_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
     glob(
@@ -262,6 +293,7 @@ objc_library(
     ],
     exclude_directories = 1
   ),
+  module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_hdrs"
   ],
@@ -294,4 +326,28 @@ acknowledged_target(
   name = "UICollectionViewLeftAlignedLayout_acknowledgement",
   deps = [],
   value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
+)
+gen_module_map(
+  "UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
+  "UICollectionViewLeftAlignedLayout_extended_module_map",
+  "UICollectionViewLeftAlignedLayout",
+  [
+    "UICollectionViewLeftAlignedLayout_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  "UICollectionViewLeftAlignedLayout_module_map_module_map_file",
+  "UICollectionViewLeftAlignedLayout_module_map",
+  "UICollectionViewLeftAlignedLayout",
+  [
+    "UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
+    "UICollectionViewLeftAlignedLayout_public_hdrs"
+  ],
+  module_map_name = "UICollectionViewLeftAlignedLayout.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
 )

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "Weixin_public_hdrs",
+  srcs = glob(
+    [
+      "SDK1.6.2/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -68,6 +68,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "ZipArchive_public_hdrs",
+  srcs = glob(
+    [
+      "*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -65,6 +65,13 @@ filegroup(
   ]
 )
 filegroup(
+  name = "boost-for-react-native_public_hdrs",
+  srcs = [],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -70,6 +70,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "glog_public_hdrs",
+  srcs = glob(
+    [
+      "src/glog/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "glog_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -57,6 +57,16 @@ filegroup(
   ]
 )
 filegroup(
+  name = "googleapis_public_hdrs",
+  srcs = [
+    ":Messages_public_hdrs",
+    ":Services_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "googleapis_hdrs",
   srcs = glob(
     [
@@ -148,6 +158,18 @@ filegroup(
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Messages_public_hdrs",
+  srcs = glob(
+    [
+      "google/**/*.pbobjc.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -271,6 +293,20 @@ filegroup(
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Services_public_hdrs",
+  srcs = glob(
+    [
+      "google/**/*.pbrpc.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":Messages_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -38,7 +37,8 @@ filegroup(
   name = "iOSSnapshotTestCase_package_hdrs",
   srcs = [
     "iOSSnapshotTestCase_direct_hdrs",
-    "Core_direct_hdrs"
+    "Core_direct_hdrs",
+    "SwiftSupport_direct_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -57,13 +57,24 @@ filegroup(
   ]
 )
 filegroup(
+  name = "iOSSnapshotTestCase_public_hdrs",
+  srcs = [
+    ":SwiftSupport_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iOSSnapshotTestCase_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
-  ),
+  ) + [
+    ":SwiftSupport_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -143,10 +154,32 @@ filegroup(
         "FBSnapshotTestCase/*.h",
         "FBSnapshotTestCase/Categories/UIImage+Compare.h",
         "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
+        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+        "FBSnapshotTestCase/FBSnapshotTestCase.h",
+        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+        "FBSnapshotTestCase/FBSnapshotTestController.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "Core_public_hdrs",
+  srcs = glob(
+    [
+      "FBSnapshotTestCase/FBSnapshotTestCase.h",
+      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+      "FBSnapshotTestCase/FBSnapshotTestController.h"
+    ],
+    exclude = [
+      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -167,7 +200,10 @@ filegroup(
         "FBSnapshotTestCase/*.h",
         "FBSnapshotTestCase/Categories/UIImage+Compare.h",
         "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
+        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+        "FBSnapshotTestCase/FBSnapshotTestCase.h",
+        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+        "FBSnapshotTestCase/FBSnapshotTestController.h"
       ],
       exclude_directories = 1
     ),
@@ -252,19 +288,108 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/iOSSnapshotTestCase/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "SwiftSupport",
+filegroup(
+  name = "SwiftSupport_direct_hdrs",
   srcs = glob(
     [
-      "FBSnapshotTestCase/**/*.swift"
+      "pod_support/Headers/Public/**/*"
     ],
     exclude_directories = 1
   ),
-  deps = [
-    ":Core"
-  ],
-  data = [],
   visibility = [
     "//visibility:public"
   ]
+)
+filegroup(
+  name = "SwiftSupport_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SwiftSupport_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "SwiftSupport_union_hdrs",
+  srcs = [
+    "SwiftSupport_hdrs",
+    "iOSSnapshotTestCase_hdrs",
+    ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "SwiftSupport_hmap",
+  namespace = "FBSnapshotTestCase",
+  hdrs = [
+    "iOSSnapshotTestCase_package_hdrs",
+    ":SwiftSupport_union_hdrs"
+  ],
+  deps = [
+    ":Core"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "SwiftSupport_includes",
+  include = [
+    "Vendor/iOSSnapshotTestCase/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "SwiftSupport",
+  enable_modules = 0,
+  hdrs = [
+    ":SwiftSupport_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/iOSSnapshotTestCase-prefix.pch",
+  sdk_frameworks = [
+    "XCTest",
+    "UIKit",
+    "Foundation",
+    "QuartzCore"
+  ],
+  deps = [
+    ":Core",
+    ":SwiftSupport_includes"
+  ],
+  copts = select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
+  ] + [
+    "-fmodule-name=FBSnapshotTestCase"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "SwiftSupport_acknowledgement",
+  deps = [],
+  value = "//Vendor/iOSSnapshotTestCase/pod_support_buildable:acknowledgement_fragment"
 )

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -64,6 +64,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "iRate_public_hdrs",
+  srcs = glob(
+    [
+      "iRate/iRate.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "iRate_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "kingpin_public_hdrs",
+  srcs = glob(
+    [
+      "kingpin/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -53,10 +53,51 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "pop/**/*.h"
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
       ],
       exclude_directories = 1
     ),
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "pop_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ],
     exclude_directories = 1
   ),
   visibility = [
@@ -73,7 +114,22 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "pop/**/*.h"
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
       ],
       exclude_directories = 1
     ),
@@ -175,12 +231,55 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "pop/**/*.h"
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
       ],
       exclude_directories = 1
     ),
     exclude_directories = 1
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "pop_public_hdrs",
+  srcs = glob(
+    [
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":pop_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -195,7 +294,22 @@ filegroup(
       exclude_directories = 1
     ) + glob(
       [
-        "pop/**/*.h"
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
       ],
       exclude_directories = 1
     ),

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -63,6 +63,18 @@ filegroup(
   ]
 )
 filegroup(
+  name = "yoga_public_hdrs",
+  srcs = glob(
+    [
+      "yoga/**/*.h"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "yoga_hdrs",
   srcs = glob(
     glob(

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -130,6 +130,20 @@ filegroup(
   ]
 )
 filegroup(
+  name = "youtube-ios-player-helper_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/**/*.h",
+      "Classes/**/*.hpp",
+      "Classes/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
   name = "youtube-ios-player-helper_cxx_hdrs",
   srcs = select(
     {
@@ -358,6 +372,7 @@ objc_library(
       )
     }
   ),
+  module_map = ":youtube_ios_player_helper_extended_module_map_module_map_file",
   hdrs = [
     ":youtube-ios-player-helper_cxx_hdrs"
   ],
@@ -516,6 +531,22 @@ filegroup(
       )
     }
   ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "youtube-ios-player-helper_public_hdrs",
+  srcs = glob(
+    [
+      "Classes/**/*.h",
+      "Classes/**/*.hpp",
+      "Classes/**/*.hxx"
+    ],
+    exclude_directories = 1
+  ) + [
+    ":youtube-ios-player-helper_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -689,6 +720,7 @@ objc_library(
       )
     }
   ),
+  module_map = ":youtube_ios_player_helper_extended_module_map_module_map_file",
   hdrs = [
     ":youtube-ios-player-helper_hdrs"
   ],
@@ -724,6 +756,30 @@ acknowledged_target(
   name = "youtube-ios-player-helper_acknowledgement",
   deps = [],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
+)
+gen_module_map(
+  "youtube_ios_player_helper_extended_module_map_module_map_file",
+  "youtube_ios_player_helper_extended_module_map",
+  "youtube_ios_player_helper",
+  [
+    "youtube_ios_player_helper_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  "youtube_ios_player_helper_module_map_module_map_file",
+  "youtube_ios_player_helper_module_map",
+  "youtube_ios_player_helper",
+  [
+    "youtube_ios_player_helper_extended_module_map_module_map_file",
+    "youtube_ios_player_helper_public_hdrs"
+  ],
+  module_map_name = "youtube_ios_player_helper.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
 )
 apple_bundle_import(
   name = "youtube-ios-player-helper_Bundle_Assets",

--- a/Sources/PodToBUILD/ModuleMap.swift
+++ b/Sources/PodToBUILD/ModuleMap.swift
@@ -8,7 +8,7 @@ public struct ModuleMap: BazelTarget {
 
     public init(name: String, dirname: String, moduleName: String, headers:
                 [String], swiftHeader: String? = nil, moduleMapName: String? = nil) {
-        self.name = name
+        self.name = name + "_module_map_module_map_file"
         self.dirname = dirname
         self.moduleName = moduleName
         self.headers = headers
@@ -27,9 +27,6 @@ public struct ModuleMap: BazelTarget {
             .basic(moduleName.toSkylark()),
             .basic(headers.toSkylark())
         ]
-        if let swiftHeader = self.swiftHeader {
-            args.append(.named(name: "swift_header", value: swiftHeader.toSkylark()))
-        }
         if let moduleMapName = self.moduleMapName {
             args.append(.named(name: "module_map_name", value: moduleMapName.toSkylark()))
         }

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -332,8 +332,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         self.externalName = externalName
 
         sourceFiles = implFiles.zip(implExcludes).map {
-            t -> GlobNode in
-            GlobNode(include: .left(t.first ?? Set()), exclude: .left(t.second ?? Set()))
+            GlobNode(include: .left($0.first ?? Set()), exclude: .left($0.second ?? Set()))
         }
 
         let publicHeadersVal = fallbackSpec.attr(\.publicHeaders).unpackToMulti()
@@ -351,8 +350,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         }
         // lib/cocoapods/sandbox/file_accessor.rb
         self.publicHeaders = basePublicHeaders.zip(privateHeadersVal).map {
-            t -> GlobNode in
-            GlobNode(include: .left(t.first ?? Set()), exclude: .left(Set(t.second ?? [])))
+            GlobNode(include: .left($0.first ?? Set()), exclude: .left(Set($0.second ?? [])))
         }
 
         // It's possible to use preserve_paths for header includes

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -163,7 +163,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
     public let sdkDylibs: AttrSet<[String]>
     public let bundles: AttrSet<[String]>
     public let resources: AttrSet<GlobNode>
-    public let publicHeaders: AttrSet<Set<String>>
+    public let publicHeaders: AttrSet<GlobNode>
     public let nonArcSrcs: AttrSet<GlobNode>
 
     // only used later in transforms
@@ -193,7 +193,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         copts: AttrSet<[String]> = AttrSet.empty,
         bundles: AttrSet<[String]> = AttrSet.empty,
         resources: AttrSet<GlobNode> = AttrSet.empty,
-        publicHeaders: AttrSet<Set<String>> = AttrSet.empty,
+        publicHeaders: AttrSet<GlobNode> = AttrSet.empty,
         nonArcSrcs: AttrSet<GlobNode> = AttrSet.empty,
         requiresArc: AttrSet<Either<Bool, [String]>?> = AttrSet.empty,
         isTopLevelTarget: Bool = false
@@ -227,7 +227,8 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
     /// isSplitDep indicates if the library is a split language dependency
     init(parentSpecs: [PodSpec] = [], spec: PodSpec, extraDeps: [String] = [],
          isSplitDep: Bool = false,
-         sourceType: BazelSourceLibType = .objc) {
+         sourceType: BazelSourceLibType = .objc,
+         moduleMap: ModuleMap? = nil) {
         let fallbackSpec = FallbackSpec(specs: [spec] +  parentSpecs)
 
         isTopLevelTarget = parentSpecs.isEmpty && isSplitDep == false
@@ -257,8 +258,6 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
                     fatalError("null logic error")
                 }
             }
-        publicHeaders = fallbackSpec.attr(\.publicHeaders).map { Set($0) }
-
         let podName = GetBuildOptions().podName
         name = computeLibName(parentSpecs: parentSpecs, spec: spec, podName:
             podName, isSplitDep: isSplitDep, sourceType: sourceType)
@@ -337,45 +336,46 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
             GlobNode(include: .left(t.first ?? Set()), exclude: .left(t.second ?? Set()))
         }
 
-        let privateHeaders = fallbackSpec.attr(\.privateHeaders).unpackToMulti()
+        let publicHeadersVal = fallbackSpec.attr(\.publicHeaders).unpackToMulti()
+        let privateHeadersVal = fallbackSpec.attr(\.privateHeaders).unpackToMulti()
+
+        let sourceHeaders = extractFiles(fromPattern: allSourceFiles, includingFileTypes:
+                HeaderFileTypes)
+        let privateHeaders = extractFiles(fromPattern: privateHeadersVal, includingFileTypes:
+                HeaderFileTypes)
+        let publicHeaders = extractFiles(fromPattern: publicHeadersVal, includingFileTypes:
+                HeaderFileTypes)
+
+        let basePublicHeaders = sourceHeaders.zip(publicHeaders).map {
+            return Set($0.second ?? $0.first ?? [])
+        }
+        // lib/cocoapods/sandbox/file_accessor.rb
+        self.publicHeaders = basePublicHeaders.zip(privateHeadersVal).map {
+            t -> GlobNode in
+            GlobNode(include: .left(t.first ?? Set()), exclude: .left(Set(t.second ?? [])))
+        }
+
         // It's possible to use preserve_paths for header includes
         // also, preserve path may be used for a file, so we'd need to touch
         // the FS here to actually find out.
         let preservePaths = fallbackSpec.attr(\.preservePaths).unpackToMulti().map { $0.filter { !$0.contains("LICENSE") } }
-
         let allSpecHeadersList: AttrSet<[String]> =
-            extractFiles(fromPattern: allSourceFiles, includingFileTypes:
-                HeaderFileTypes) <>
-            extractFiles(fromPattern: privateHeaders, includingFileTypes:
-                HeaderFileTypes) <>
+            sourceHeaders <> privateHeaders <>
             extractFiles(fromPattern: preservePaths, includingFileTypes:
-                HeaderFileTypes)
+                HeaderFileTypes) <> publicHeaders
+
 
         let allSpecHeaders = allSpecHeadersList.map { Set($0) }
         let headerExcludes = extractFiles(fromPattern: allExcludes,
                                           includingFileTypes: HeaderFileTypes).map { Set($0) }
 
         headers = allSpecHeaders.zip(headerExcludes).map {
-            t -> GlobNode in
-            GlobNode(include: Set(t.first ?? []), exclude: Set(t.second
-                    ?? []))
+            GlobNode(include: Set($0.first ?? []), exclude: Set($0.second ?? []))
         }
 
         nonArcSrcs = AttrSet.empty
         sdkFrameworks = fallbackSpec.attr(\.frameworks)
-
-        let clangModuleName = headerName.basic?.replacingOccurrences(of: "-", with: "_")
-        let moduleMapDirectoryName = externalName + "_module_map"
-        if isTopLevelTarget, options.generateModuleMap {
-            moduleMap =  ModuleMap(
-                name: moduleName.basic ?? "",
-                dirname: moduleMapDirectoryName,
-                moduleName: clangModuleName ?? "",
-                headers: [externalName + "_hdrs"]
-                )
-        } else {
-            moduleMap = nil
-        }
+        self.moduleMap = moduleMap
 
         weakSdkFrameworks = fallbackSpec.attr(\.weakFrameworks)
         sdkDylibs = fallbackSpec.attr(\.libraries)
@@ -689,10 +689,26 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
             }.sorted(by: <).map { ($0 + "_hdrs").toSkylark() }
         }.toSkylark()
 
+        let depPublicHdrs = deps.map {
+            $0.filter { depLabelName -> Bool in
+                guard depLabelName.hasPrefix(":") else {
+                    return false
+                }
+                let offsetIdx = depLabelName.utf8
+                        .index(depLabelName.utf8.startIndex, offsetBy: 1)
+                let labelName = String(
+                        depLabelName[offsetIdx ..< depLabelName.utf8.endIndex])
+                let target = BuildFileContext.get()?.getBazelTarget(name:
+                        labelName)
+                return target is ObjcLibrary
+            }.sorted(by: <).map { ($0 + "_public_hdrs").toSkylark() }
+        }.toSkylark()
+
+
         let podSupportHeaders = AttrSet(basic: GlobNode(include: [
             PodSupportSystemPublicHeaderDir + "**/*"])).unpackToMulti()
-        let combinedHeaders: AttrSet<GlobNode> =
-        podSupportHeaders.zip(headers.unpackToMulti()).map {
+
+        let combinedHeaders: AttrSet<GlobNode> = (podSupportHeaders.zip(headers)).map {
             attrTuple -> GlobNode in
             if let first = attrTuple.first, let second = attrTuple.second {
                 return GlobNode(include:[.right(first), .right(second)] , exclude: [])
@@ -705,6 +721,15 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
             arguments: [
                 .named(name: "name", value: (name + "_direct_hdrs").toSkylark()),
                 .named(name: "srcs", value: combinedHeaders.toSkylark()),
+                .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
+                ]
+            ))
+
+        inlineSkylark.append(.functionCall(
+            name: "filegroup",
+            arguments: [
+                .named(name: "name", value: (name + "_public_hdrs").toSkylark()),
+                .named(name: "srcs", value: lib.publicHeaders.toSkylark() .+. depPublicHdrs.toSkylark()),
                 .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
                 ]
             ))
@@ -766,7 +791,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
                 // it may not hold true for all cocoapods ( e.g. give it all
                 // possibilities here )
                 .named(name: "deps", value: deps
-                       .map { $0.filter { !$0.hasSuffix("_swift") } }
+                       .map { Array(Set($0)).filter { !$0.hasSuffix("_swift") } }
                        .sorted(by: (<)).toSkylark()),
                 .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
             ]
@@ -802,24 +827,15 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
             ))
         }
 
-        let moduleHeaders: [String]
-        if options.generateModuleMap {
-            let moduleMapDirname = lib.moduleMap?.dirname ?? externalName + "_module_map"
-            moduleHeaders = [":" + moduleMapDirname + "_module_map_file"]
-            // TODO:
-            // - Consider moving this module map into deps 
-            // - Propagate as a module map
+        if let moduleMap = self.moduleMap {
             libArguments.append(.named(
-                name: "includes",
-                value: [moduleMapDirname].toSkylark()
-             ))
-        } else {
-            moduleHeaders = []
+                name: "module_map",
+                value: (":" + moduleMap.dirname + "_module_map_file").toSkylark()))
         }
 
         libArguments.append(.named(
             name: "hdrs",
-            value: ([":" + headerSrcsName + "_hdrs"] + moduleHeaders + (options.generateHeaderMap ? [":" + name + "_hmap"] : [])).toSkylark()
+            value: ([":" + headerSrcsName + "_hdrs"] + (options.generateHeaderMap ? [":" + name + "_hmap"] : [])).toSkylark()
         ))
 
         if AttrSet.empty != lib.prefixHeader {
@@ -852,7 +868,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
 
         var allDeps: SkylarkNode = SkylarkNode.empty
         if !lib.deps.isEmpty {
-            allDeps = lib.deps.sorted(by: (<)).toSkylark() 
+            allDeps = lib.deps.map { Array(Set($0)).sorted(by: (<)) } .toSkylark() 
         }
         if lib.includes.count > 0 {
             allDeps = allDeps .+. [":\(name)_includes"].toSkylark()

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -37,7 +37,7 @@ public struct SwiftLibrary: BazelTarget {
 
 
     init(parentSpecs: [PodSpec], spec: PodSpec, extraDeps: [String] = [],
-            isSplitDep: Bool = false) {
+            isSplitDep: Bool = false, moduleMap: ModuleMap? = nil) {
         let fallbackSpec = FallbackSpec(specs: parentSpecs + [spec])
         self.isTopLevelTarget = parentSpecs.isEmpty && isSplitDep == false
 


### PR DESCRIPTION
This PR fixes issues with module maps. First, it implements public
headers per the podspec. Module maps are normalized into a single
instance per spec. This is achieved through the
`objc_library`.module_map attribute, there is virtually no way around
using this with swift.

I've added a couple snapshot tests of the output and we'll have more
build tests for this with swift soon.