### PR TITLE
Filter resources from extra deps

### DIFF
--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -91,7 +91,6 @@ headermap(
   ],
   deps = [
     ":Basics_hmap",
-    ":Core_Bundle_FacebookSDKStrings_hmap",
     ":Core_hmap"
   ],
   visibility = [
@@ -303,7 +302,6 @@ objc_library(
   deps = [
     ":Basics",
     ":Core",
-    ":Core_Bundle_FacebookSDKStrings",
     ":FBSDKCoreKit_includes"
   ],
   copts = select(

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -402,6 +402,7 @@ public struct PodBuildFile: SkylarkConvertible {
 
         let allRootDeps = ((defaultSubspecTargets.isEmpty ? subspecTargets :
                     defaultSubspecTargets) + extraDeps)
+            .filter { !($0 is AppleResourceBundle || $0 is AppleBundleImport) }
         let sourceLibs = makeSourceLibs(parentSpecs: [], spec: podSpec, extraDeps:
                 allRootDeps)
 


### PR DESCRIPTION
At some point, Bazel started rejecting resources in `deps` which was
recently added. This caused an issue in 3.4.1