### PR TITLE
First pass at mixed module swift support

### DIFF
--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -103,9 +103,10 @@ def _module_map_impl(ctx):
     swift_header = ctx.attr.swift_header
     headers_list = _get_module_map_headers(deps)
 
-    # Up some dirs to the compilation root
-    # bazel-out/ios_x86_64-fastbuild/genfiles/external/__Pod__
-    relative_path = "../../../../../../"
+    # relative from the module_map dir to the compilation root
+    # e.g. bazel-out/ios_x86_64-fastbuild/genfiles/external/__Pod__
+    module_map = ctx.outputs.module_map
+    relative_path = "".join(["../" for i in range(len(module_map.dirname.split("/")))])
     system_tag = " [system] "
     content = "module " + module_name + (system_tag if ctx.attr.is_system else "" ) + " {\n" 
     content += "    export * \n"
@@ -126,7 +127,7 @@ module {module_name}.Swift {{
 
     ctx.actions.write(
         content=content,
-        output=ctx.outputs.module_map
+        output=module_map
     )
 
     # If the name is `module.modulemap` we propagate this as an include. If a
@@ -138,15 +139,15 @@ module {module_name}.Swift {{
     else:
         include = depset()
     objc_provider = apple_common.new_objc_provider(
-        module_map=depset([ctx.outputs.module_map]),
+        module_map=depset([module_map]),
         include=include
     )
 
     return struct(
-        files=depset([ctx.outputs.module_map]),
+        files=depset([module_map]),
         providers=[objc_provider],
         objc=objc_provider,
-        headers=depset([ctx.outputs.module_map]),
+        headers=depset([module_map]),
     )
 
 

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -51,8 +51,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +71,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -138,8 +136,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
-  ] + [
-    "-fmodule-name=Adjust"
   ],
   visibility = [
     "//visibility:public"
@@ -153,19 +149,11 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Adjust/*.h",
-        "Adjust/ADJAdditions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Adjust/*.h",
+      "Adjust/ADJAdditions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -177,8 +165,7 @@ filegroup(
     [
       "Adjust/*.h",
       "Adjust/ADJAdditions/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -187,19 +174,11 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Adjust/*.h",
-        "Adjust/ADJAdditions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Adjust/*.h",
+      "Adjust/ADJAdditions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -241,23 +220,11 @@ objc_library(
       "Adjust/*.m",
       "Adjust/ADJAdditions/*.m"
     ],
-    exclude = glob(
-      [
-        "plugin/Sociomantic/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "plugin/Sociomantic/*.m",
+      "plugin/Criteo/*.m",
+      "plugin/Trademob/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -292,8 +259,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
-  ] + [
-    "-fmodule-name=Adjust"
   ],
   visibility = [
     "//visibility:public"
@@ -307,18 +272,10 @@ acknowledged_target(
 filegroup(
   name = "Sociomantic_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Sociomantic/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Sociomantic/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -329,8 +286,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Sociomantic/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -341,18 +297,10 @@ filegroup(
 filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Sociomantic/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Sociomantic/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -395,8 +343,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Sociomantic/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Sociomantic_hdrs"
@@ -432,8 +379,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
-  ] + [
-    "-fmodule-name=Adjust"
   ],
   visibility = [
     "//visibility:public"
@@ -447,18 +392,10 @@ acknowledged_target(
 filegroup(
   name = "Criteo_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Criteo/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -469,8 +406,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Criteo/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -481,18 +417,10 @@ filegroup(
 filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Criteo/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -535,8 +463,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Criteo/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Criteo_hdrs"
@@ -572,8 +499,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
-  ] + [
-    "-fmodule-name=Adjust"
   ],
   visibility = [
     "//visibility:public"
@@ -587,18 +512,10 @@ acknowledged_target(
 filegroup(
   name = "Trademob_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Trademob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -609,8 +526,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Trademob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -621,18 +537,10 @@ filegroup(
 filegroup(
   name = "Trademob_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Trademob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -675,8 +583,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Trademob/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Trademob_hdrs"
@@ -712,8 +619,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Adjust/pod_support/Headers/Public/Adjust/"
-  ] + [
-    "-fmodule-name=Adjust"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -51,7 +51,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -71,7 +72,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_hdrs"
   ],
@@ -151,11 +153,19 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Adjust/*.h",
-      "Adjust/ADJAdditions/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Adjust/*.h",
+        "Adjust/ADJAdditions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -167,7 +177,8 @@ filegroup(
     [
       "Adjust/*.h",
       "Adjust/ADJAdditions/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -176,11 +187,19 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Adjust/*.h",
-      "Adjust/ADJAdditions/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Adjust/*.h",
+        "Adjust/ADJAdditions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -222,11 +241,23 @@ objc_library(
       "Adjust/*.m",
       "Adjust/ADJAdditions/*.m"
     ],
-    exclude = [
-      "plugin/Sociomantic/*.m",
-      "plugin/Criteo/*.m",
-      "plugin/Trademob/*.m"
-    ]
+    exclude = glob(
+      [
+        "plugin/Sociomantic/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Criteo/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Trademob/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -276,10 +307,18 @@ acknowledged_target(
 filegroup(
   name = "Sociomantic_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Sociomantic/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Sociomantic/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -290,7 +329,8 @@ filegroup(
   srcs = glob(
     [
       "plugin/Sociomantic/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -301,10 +341,18 @@ filegroup(
 filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Sociomantic/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Sociomantic/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -347,7 +395,8 @@ objc_library(
   srcs = glob(
     [
       "plugin/Sociomantic/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Sociomantic_hdrs"
@@ -398,10 +447,18 @@ acknowledged_target(
 filegroup(
   name = "Criteo_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Criteo/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Criteo/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -412,7 +469,8 @@ filegroup(
   srcs = glob(
     [
       "plugin/Criteo/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -423,10 +481,18 @@ filegroup(
 filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Criteo/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Criteo/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -469,7 +535,8 @@ objc_library(
   srcs = glob(
     [
       "plugin/Criteo/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Criteo_hdrs"
@@ -520,10 +587,18 @@ acknowledged_target(
 filegroup(
   name = "Trademob_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Trademob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Trademob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -534,7 +609,8 @@ filegroup(
   srcs = glob(
     [
       "plugin/Trademob/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -545,10 +621,18 @@ filegroup(
 filegroup(
   name = "Trademob_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "plugin/Trademob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "plugin/Trademob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -591,7 +675,8 @@ objc_library(
   srcs = glob(
     [
       "plugin/Trademob/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Trademob_hdrs"

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -50,7 +50,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -71,7 +72,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Basics_hdrs",
     ":Core_hdrs"
@@ -104,6 +106,171 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -164,11 +331,19 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -179,7 +354,8 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -188,11 +364,19 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -339,10 +523,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -449,10 +637,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -605,10 +797,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -715,10 +911,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -747,8 +947,10 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ]
-          )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -858,11 +1060,16 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-                ]
-              )
-            )
-          )
-        )
+                ],
+                exclude_directories = 1
+              ),
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         glob(
@@ -884,8 +1091,10 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ]
-          )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -992,11 +1201,16 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ]
-              )
-            )
-          )
-        )
+                ],
+                exclude_directories = 1
+              ),
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         glob(
@@ -1064,8 +1278,10 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ]
-          )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -1218,11 +1434,16 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-                ]
-              )
-            )
-          )
-        )
+                ],
+                exclude_directories = 1
+              ),
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         glob(
@@ -1244,8 +1465,10 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ]
-          )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -1352,11 +1575,16 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ]
-              )
-            )
-          )
-        )
+                ],
+                exclude_directories = 1
+              ),
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -1423,7 +1651,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -1436,9 +1665,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1453,13 +1685,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1471,13 +1708,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1521,13 +1763,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1539,8 +1786,10 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -1555,7 +1804,8 @@ filegroup(
       "FBSDKCoreKit/FBSDKCoreKit/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -1568,9 +1818,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1585,13 +1838,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1603,13 +1861,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1653,13 +1916,18 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1671,8 +1939,10 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -1819,9 +2089,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -1923,9 +2196,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -2073,9 +2349,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -2177,9 +2456,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -2203,7 +2485,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -2308,10 +2591,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         glob(
@@ -2328,7 +2615,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -2430,10 +2718,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         glob(
@@ -2496,7 +2788,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -2644,10 +2937,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         glob(
@@ -2664,7 +2961,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -2766,10 +3064,14 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -37,6 +37,7 @@ config_setting(
 filegroup(
   name = "FBSDKCoreKit_package_hdrs",
   srcs = [
+    "FBSDKCoreKit_cxx_direct_hdrs",
     "FBSDKCoreKit_direct_hdrs",
     "Basics_direct_hdrs",
     "Core_direct_hdrs"
@@ -46,12 +47,136 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FBSDKCoreKit_cxx_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_public_hdrs",
+  srcs = [
+    ":Basics_public_hdrs",
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_union_hdrs",
+  srcs = [
+    "FBSDKCoreKit_cxx_hdrs",
+    "FBSDKCoreKit_hdrs",
+    ":Basics_hdrs",
+    ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKCoreKit_cxx_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":FBSDKCoreKit_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Basics_hmap",
+    ":Core_hmap"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "FBSDKCoreKit_cxx_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "FBSDKCoreKit_cxx",
+  enable_modules = 0,
+  hdrs = [
+    ":FBSDKCoreKit_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accounts",
+        "CoreLocation",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  deps = [
+    ":Basics",
+    ":Core",
+    ":FBSDKCoreKit_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "FBSDKCoreKit_cxx_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
   name = "FBSDKCoreKit_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -61,7 +186,8 @@ filegroup(
   name = "FBSDKCoreKit_public_hdrs",
   srcs = [
     ":Basics_public_hdrs",
-    ":Core_public_hdrs"
+    ":Core_public_hdrs",
+    ":FBSDKCoreKit_cxx_public_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -72,11 +198,11 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_hdrs",
-    ":Core_hdrs"
+    ":Core_hdrs",
+    ":FBSDKCoreKit_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -91,7 +217,8 @@ headermap(
   ],
   deps = [
     ":Basics_hmap",
-    ":Core_hmap"
+    ":Core_hmap",
+    ":FBSDKCoreKit_cxx_hmap"
   ],
   visibility = [
     "//visibility:public"
@@ -106,171 +233,6 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -302,6 +264,7 @@ objc_library(
   deps = [
     ":Basics",
     ":Core",
+    ":FBSDKCoreKit_cxx",
     ":FBSDKCoreKit_includes"
   ],
   copts = select(
@@ -316,8 +279,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"
@@ -331,19 +292,11 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -354,8 +307,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -364,19 +316,11 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -523,14 +467,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -637,14 +577,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -797,14 +733,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -911,14 +843,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),
@@ -947,10 +875,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1060,16 +986,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -1091,10 +1012,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1201,16 +1120,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -1278,10 +1192,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1434,16 +1346,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -1465,10 +1372,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1575,16 +1480,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       )
     }
   ),
@@ -1634,8 +1534,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"
@@ -1651,8 +1549,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1665,12 +1562,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1685,18 +1579,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1708,18 +1597,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1763,18 +1647,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1786,10 +1665,8 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -1804,8 +1681,7 @@ filegroup(
       "FBSDKCoreKit/FBSDKCoreKit/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -1818,12 +1694,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1838,18 +1711,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1861,18 +1729,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1916,18 +1779,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1939,10 +1797,8 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2089,12 +1945,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -2196,12 +2049,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -2349,12 +2199,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -2456,12 +2303,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       )
     }
   ),
@@ -2485,8 +2329,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2591,14 +2434,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -2615,8 +2454,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2718,14 +2556,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -2788,8 +2622,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2937,14 +2770,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -2961,8 +2790,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -3064,14 +2892,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),
@@ -3119,8 +2943,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   data = [
     ":Core_Bundle_FacebookSDKStrings"

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":AppLinks_hdrs",
     ":Tasks_hdrs"
@@ -126,8 +124,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
-  ] + [
-    "-fmodule-name=Bolts"
   ],
   visibility = [
     "//visibility:public"
@@ -141,18 +137,10 @@ acknowledged_target(
 filegroup(
   name = "Tasks_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Bolts/Common/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Bolts/Common/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -163,8 +151,7 @@ filegroup(
   srcs = glob(
     [
       "Bolts/Common/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -173,18 +160,10 @@ filegroup(
 filegroup(
   name = "Tasks_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Bolts/Common/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Bolts/Common/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -227,31 +206,24 @@ objc_library(
         [
           "Bolts/Common/*.m"
         ],
-        exclude = glob(
-          [
-            "Bolts/iOS/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Bolts/iOS/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -274,8 +246,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
-  ] + [
-    "-fmodule-name=Bolts"
   ],
   visibility = [
     "//visibility:public"
@@ -291,37 +261,26 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Bolts/iOS/**/*.h",
-            "Bolts/iOS/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Bolts/iOS/**/*.h",
+          "Bolts/iOS/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -336,8 +295,7 @@ filegroup(
       "//conditions:default": glob(
         [
           "Bolts/iOS/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -352,37 +310,26 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Bolts/iOS/**/*.h",
-            "Bolts/iOS/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Bolts/iOS/**/*.h",
+          "Bolts/iOS/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -429,8 +376,7 @@ objc_library(
       "//conditions:default": glob(
         [
           "Bolts/iOS/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -454,8 +400,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Bolts/pod_support/Headers/Public/Bolts/"
-  ] + [
-    "-fmodule-name=Bolts"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -70,7 +71,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":AppLinks_hdrs",
     ":Tasks_hdrs"
@@ -139,10 +141,18 @@ acknowledged_target(
 filegroup(
   name = "Tasks_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Bolts/Common/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Bolts/Common/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -153,7 +163,8 @@ filegroup(
   srcs = glob(
     [
       "Bolts/Common/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -162,10 +173,18 @@ filegroup(
 filegroup(
   name = "Tasks_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Bolts/Common/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Bolts/Common/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -208,24 +227,31 @@ objc_library(
         [
           "Bolts/Common/*.m"
         ],
-        exclude = [
-          "Bolts/iOS/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Bolts/iOS/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "Bolts/Common/*.m"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Bolts/Common/*.m"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "Bolts/Common/*.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -265,26 +291,37 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Bolts/iOS/**/*.h",
-          "Bolts/iOS/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Bolts/iOS/**/*.h",
+            "Bolts/iOS/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -299,7 +336,8 @@ filegroup(
       "//conditions:default": glob(
         [
           "Bolts/iOS/*.h"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ) + [
@@ -314,26 +352,37 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Bolts/iOS/**/*.h",
-          "Bolts/iOS/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Bolts/iOS/**/*.h",
+            "Bolts/iOS/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -380,7 +429,8 @@ objc_library(
       "//conditions:default": glob(
         [
           "Bolts/iOS/**/*.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -60,7 +60,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -83,7 +84,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Card_hdrs",
     ":Core_hdrs",
@@ -160,11 +162,19 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeCore/**/*.h",
-      "BraintreeCore/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCore/**/*.h",
+        "BraintreeCore/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -175,7 +185,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCore/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -184,11 +195,19 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeCore/**/*.h",
-      "BraintreeCore/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCore/**/*.h",
+        "BraintreeCore/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -229,18 +248,58 @@ objc_library(
     [
       "BraintreeCore/**/*.m"
     ],
-    exclude = [
-      "BraintreeApplePay/**/*.m",
-      "BraintreeCard/**/*.m",
-      "BraintreeDataCollector/**/*.m",
-      "BraintreePayPal/*.m",
-      "BraintreeVenmo/**/*.m",
-      "BraintreeUI/**/*.m",
-      "BraintreeUnionPay/**/*.m",
-      "Braintree3DSecure/**/*.m",
-      "BraintreePayPal/PayPalOneTouch/**/*.m",
-      "BraintreePayPal/PayPalDataCollector/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "BraintreeApplePay/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCard/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeDataCollector/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeVenmo/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUI/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUnionPay/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Braintree3DSecure/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalDataCollector/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -284,11 +343,19 @@ acknowledged_target(
 filegroup(
   name = "Apple-Pay_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeApplePay/**/*.h",
-      "BraintreeApplePay/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeApplePay/**/*.h",
+        "BraintreeApplePay/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -299,7 +366,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeApplePay/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -310,11 +378,19 @@ filegroup(
 filegroup(
   name = "Apple-Pay_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeApplePay/**/*.h",
-      "BraintreeApplePay/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeApplePay/**/*.h",
+        "BraintreeApplePay/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -357,7 +433,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreeApplePay/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Apple-Pay_hdrs"
@@ -399,11 +476,19 @@ acknowledged_target(
 filegroup(
   name = "Card_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeCard/**/*.h",
-      "BraintreeCard/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCard/**/*.h",
+        "BraintreeCard/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -414,7 +499,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCard/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -425,11 +511,19 @@ filegroup(
 filegroup(
   name = "Card_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeCard/**/*.h",
-      "BraintreeCard/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeCard/**/*.h",
+        "BraintreeCard/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -473,11 +567,23 @@ objc_library(
     [
       "BraintreeCard/**/*.m"
     ],
-    exclude = [
-      "BraintreeUI/**/*.m",
-      "BraintreeUnionPay/**/*.m",
-      "Braintree3DSecure/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "BraintreeUI/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUnionPay/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Braintree3DSecure/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Card_hdrs"
@@ -516,11 +622,19 @@ acknowledged_target(
 filegroup(
   name = "DataCollector_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeDataCollector/**/*.h",
-      "BraintreeDataCollector/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeDataCollector/**/*.h",
+        "BraintreeDataCollector/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -531,7 +645,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeDataCollector/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -542,11 +657,19 @@ filegroup(
 filegroup(
   name = "DataCollector_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeDataCollector/**/*.h",
-      "BraintreeDataCollector/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeDataCollector/**/*.h",
+        "BraintreeDataCollector/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -589,7 +712,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreeDataCollector/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":DataCollector_hdrs"
@@ -640,11 +764,19 @@ acknowledged_target(
 filegroup(
   name = "PayPal_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/*.h",
-      "BraintreePayPal/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/*.h",
+        "BraintreePayPal/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -655,7 +787,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":PayPalOneTouch_public_hdrs"
@@ -667,11 +800,19 @@ filegroup(
 filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/*.h",
-      "BraintreePayPal/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/*.h",
+        "BraintreePayPal/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -716,7 +857,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreePayPal/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":PayPal_hdrs"
@@ -756,11 +898,19 @@ acknowledged_target(
 filegroup(
   name = "Venmo_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeVenmo/**/*.h",
-      "BraintreeVenmo/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeVenmo/**/*.h",
+        "BraintreeVenmo/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -771,7 +921,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeVenmo/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs"
@@ -783,11 +934,19 @@ filegroup(
 filegroup(
   name = "Venmo_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeVenmo/**/*.h",
-      "BraintreeVenmo/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeVenmo/**/*.h",
+        "BraintreeVenmo/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -832,7 +991,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreeVenmo/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Venmo_hdrs"
@@ -874,7 +1034,8 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Drop-In/Localization/*.lproj"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -887,7 +1048,8 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Localization/*.lproj"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -898,11 +1060,19 @@ acknowledged_target(
 filegroup(
   name = "UI_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeUI/**/*.h",
-      "BraintreeUI/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUI/**/*.h",
+        "BraintreeUI/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -913,7 +1083,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUI/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -925,11 +1096,19 @@ filegroup(
 filegroup(
   name = "UI_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeUI/**/*.h",
-      "BraintreeUI/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUI/**/*.h",
+        "BraintreeUI/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -974,7 +1153,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUI/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":UI_hdrs"
@@ -1021,11 +1201,19 @@ acknowledged_target(
 filegroup(
   name = "UnionPay_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeUnionPay/**/*.h",
-      "BraintreeUnionPay/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUnionPay/**/*.h",
+        "BraintreeUnionPay/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1036,7 +1224,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUnionPay/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1048,11 +1237,19 @@ filegroup(
 filegroup(
   name = "UnionPay_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreeUnionPay/**/*.h",
-      "BraintreeUnionPay/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreeUnionPay/**/*.h",
+        "BraintreeUnionPay/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1097,7 +1294,8 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUnionPay/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":UnionPay_hdrs"
@@ -1142,7 +1340,8 @@ apple_resource_bundle(
   resources = glob(
     [
       "Braintree3DSecure/Localization/*.lproj"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -1153,11 +1352,19 @@ acknowledged_target(
 filegroup(
   name = "3D-Secure_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Braintree3DSecure/**/*.h",
-      "Braintree3DSecure/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Braintree3DSecure/**/*.h",
+        "Braintree3DSecure/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1168,7 +1375,8 @@ filegroup(
   srcs = glob(
     [
       "Braintree3DSecure/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1180,11 +1388,19 @@ filegroup(
 filegroup(
   name = "3D-Secure_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Braintree3DSecure/**/*.h",
-      "Braintree3DSecure/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Braintree3DSecure/**/*.h",
+        "Braintree3DSecure/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1229,7 +1445,8 @@ objc_library(
   srcs = glob(
     [
       "Braintree3DSecure/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":3D-Secure_hdrs"
@@ -1275,11 +1492,19 @@ acknowledged_target(
 filegroup(
   name = "PayPalOneTouch_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalOneTouch/**/*.h",
-      "BraintreePayPal/PayPalOneTouch/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.h",
+        "BraintreePayPal/PayPalOneTouch/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1290,7 +1515,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalOneTouch/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs",
@@ -1303,11 +1529,19 @@ filegroup(
 filegroup(
   name = "PayPalOneTouch_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalOneTouch/**/*.h",
-      "BraintreePayPal/PayPalOneTouch/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.h",
+        "BraintreePayPal/PayPalOneTouch/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1355,9 +1589,13 @@ objc_library(
     [
       "BraintreePayPal/PayPalOneTouch/**/*.m"
     ],
-    exclude = [
-      "BraintreePayPal/*.m"
-    ]
+    exclude = glob(
+      [
+        "BraintreePayPal/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":PayPalOneTouch_hdrs"
@@ -1406,12 +1644,20 @@ acknowledged_target(
 filegroup(
   name = "PayPalDataCollector_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalDataCollector/**/*.h",
-      "BraintreePayPal/PayPalDataCollector/Public/*.h",
-      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalDataCollector/**/*.h",
+        "BraintreePayPal/PayPalDataCollector/Public/*.h",
+        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1423,7 +1669,8 @@ filegroup(
     [
       "BraintreePayPal/PayPalDataCollector/Public/*.h",
       "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":PayPalUtils_public_hdrs"
@@ -1435,12 +1682,20 @@ filegroup(
 filegroup(
   name = "PayPalDataCollector_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalDataCollector/**/*.h",
-      "BraintreePayPal/PayPalDataCollector/Public/*.h",
-      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalDataCollector/**/*.h",
+        "BraintreePayPal/PayPalDataCollector/Public/*.h",
+        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1486,10 +1741,18 @@ objc_library(
     [
       "BraintreePayPal/PayPalDataCollector/**/*.m"
     ],
-    exclude = [
-      "BraintreeVenmo/**/*.m",
-      "BraintreePayPal/PayPalOneTouch/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "BraintreeVenmo/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":PayPalDataCollector_hdrs"
@@ -1547,11 +1810,19 @@ acknowledged_target(
 filegroup(
   name = "PayPalUtils_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalUtils/**/*.h",
-      "BraintreePayPal/PayPalUtils/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalUtils/**/*.h",
+        "BraintreePayPal/PayPalUtils/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1562,7 +1833,8 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalUtils/Public/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1571,11 +1843,19 @@ filegroup(
 filegroup(
   name = "PayPalUtils_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "BraintreePayPal/PayPalUtils/**/*.h",
-      "BraintreePayPal/PayPalUtils/Public/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalUtils/**/*.h",
+        "BraintreePayPal/PayPalUtils/Public/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1616,11 +1896,23 @@ objc_library(
     [
       "BraintreePayPal/PayPalUtils/**/*.m"
     ],
-    exclude = [
-      "BraintreePayPal/PayPalOneTouch/**/*.m",
-      "BraintreePayPal/PayPalDataCollector/**/*.m",
-      "BraintreePayPal/*.m"
-    ]
+    exclude = glob(
+      [
+        "BraintreePayPal/PayPalOneTouch/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/PayPalDataCollector/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "BraintreePayPal/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":PayPalUtils_hdrs"

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -60,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,8 +83,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_hdrs",
     ":Core_hdrs",
@@ -147,8 +145,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -162,19 +158,11 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCore/**/*.h",
-        "BraintreeCore/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCore/**/*.h",
+      "BraintreeCore/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -185,8 +173,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCore/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -195,19 +182,11 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCore/**/*.h",
-        "BraintreeCore/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCore/**/*.h",
+      "BraintreeCore/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -248,58 +227,18 @@ objc_library(
     [
       "BraintreeCore/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeApplePay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeApplePay/**/*.m",
+      "BraintreeCard/**/*.m",
+      "BraintreeDataCollector/**/*.m",
+      "BraintreePayPal/*.m",
+      "BraintreeVenmo/**/*.m",
+      "BraintreeUI/**/*.m",
+      "BraintreeUnionPay/**/*.m",
+      "Braintree3DSecure/**/*.m",
+      "BraintreePayPal/PayPalOneTouch/**/*.m",
+      "BraintreePayPal/PayPalDataCollector/**/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -328,8 +267,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -343,19 +280,11 @@ acknowledged_target(
 filegroup(
   name = "Apple-Pay_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeApplePay/**/*.h",
-        "BraintreeApplePay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeApplePay/**/*.h",
+      "BraintreeApplePay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -366,8 +295,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeApplePay/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -378,19 +306,11 @@ filegroup(
 filegroup(
   name = "Apple-Pay_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeApplePay/**/*.h",
-        "BraintreeApplePay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeApplePay/**/*.h",
+      "BraintreeApplePay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -433,8 +353,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeApplePay/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Apple-Pay_hdrs"
@@ -461,8 +380,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -476,19 +393,11 @@ acknowledged_target(
 filegroup(
   name = "Card_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.h",
-        "BraintreeCard/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCard/**/*.h",
+      "BraintreeCard/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -499,8 +408,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCard/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -511,19 +419,11 @@ filegroup(
 filegroup(
   name = "Card_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.h",
-        "BraintreeCard/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCard/**/*.h",
+      "BraintreeCard/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -567,23 +467,11 @@ objc_library(
     [
       "BraintreeCard/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeUI/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeUI/**/*.m",
+      "BraintreeUnionPay/**/*.m",
+      "Braintree3DSecure/**/*.m"
+    ]
   ),
   hdrs = [
     ":Card_hdrs"
@@ -607,8 +495,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -622,19 +508,11 @@ acknowledged_target(
 filegroup(
   name = "DataCollector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.h",
-        "BraintreeDataCollector/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeDataCollector/**/*.h",
+      "BraintreeDataCollector/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -645,8 +523,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeDataCollector/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -657,19 +534,11 @@ filegroup(
 filegroup(
   name = "DataCollector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.h",
-        "BraintreeDataCollector/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeDataCollector/**/*.h",
+      "BraintreeDataCollector/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -712,8 +581,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeDataCollector/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":DataCollector_hdrs"
@@ -738,8 +606,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -764,19 +630,11 @@ acknowledged_target(
 filegroup(
   name = "PayPal_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.h",
-        "BraintreePayPal/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/*.h",
+      "BraintreePayPal/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -787,8 +645,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalOneTouch_public_hdrs"
@@ -800,19 +657,11 @@ filegroup(
 filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.h",
-        "BraintreePayPal/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/*.h",
+      "BraintreePayPal/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -857,8 +706,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreePayPal/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PayPal_hdrs"
@@ -883,8 +731,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -898,19 +744,11 @@ acknowledged_target(
 filegroup(
   name = "Venmo_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.h",
-        "BraintreeVenmo/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeVenmo/**/*.h",
+      "BraintreeVenmo/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -921,8 +759,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeVenmo/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs"
@@ -934,19 +771,11 @@ filegroup(
 filegroup(
   name = "Venmo_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.h",
-        "BraintreeVenmo/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeVenmo/**/*.h",
+      "BraintreeVenmo/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -991,8 +820,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeVenmo/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Venmo_hdrs"
@@ -1017,8 +845,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -1034,8 +860,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Drop-In/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1048,8 +873,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1060,19 +884,11 @@ acknowledged_target(
 filegroup(
   name = "UI_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.h",
-        "BraintreeUI/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUI/**/*.h",
+      "BraintreeUI/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1083,8 +899,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUI/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1096,19 +911,11 @@ filegroup(
 filegroup(
   name = "UI_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.h",
-        "BraintreeUI/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUI/**/*.h",
+      "BraintreeUI/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1153,8 +960,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUI/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":UI_hdrs"
@@ -1182,8 +988,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   data = [
     ":UI_Bundle_Braintree-Drop-In-Localization",
@@ -1201,19 +1005,11 @@ acknowledged_target(
 filegroup(
   name = "UnionPay_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.h",
-        "BraintreeUnionPay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUnionPay/**/*.h",
+      "BraintreeUnionPay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1224,8 +1020,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUnionPay/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1237,19 +1032,11 @@ filegroup(
 filegroup(
   name = "UnionPay_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.h",
-        "BraintreeUnionPay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUnionPay/**/*.h",
+      "BraintreeUnionPay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1294,8 +1081,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUnionPay/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":UnionPay_hdrs"
@@ -1323,8 +1109,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -1340,8 +1124,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "Braintree3DSecure/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1352,19 +1135,11 @@ acknowledged_target(
 filegroup(
   name = "3D-Secure_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.h",
-        "Braintree3DSecure/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Braintree3DSecure/**/*.h",
+      "Braintree3DSecure/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1375,8 +1150,7 @@ filegroup(
   srcs = glob(
     [
       "Braintree3DSecure/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1388,19 +1162,11 @@ filegroup(
 filegroup(
   name = "3D-Secure_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.h",
-        "Braintree3DSecure/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Braintree3DSecure/**/*.h",
+      "Braintree3DSecure/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1445,8 +1211,7 @@ objc_library(
   srcs = glob(
     [
       "Braintree3DSecure/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":3D-Secure_hdrs"
@@ -1474,8 +1239,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   data = [
     ":3D-Secure_Bundle_Braintree-3D-Secure-Localization"
@@ -1492,19 +1255,11 @@ acknowledged_target(
 filegroup(
   name = "PayPalOneTouch_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.h",
-        "BraintreePayPal/PayPalOneTouch/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalOneTouch/**/*.h",
+      "BraintreePayPal/PayPalOneTouch/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1515,8 +1270,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalOneTouch/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs",
@@ -1529,19 +1283,11 @@ filegroup(
 filegroup(
   name = "PayPalOneTouch_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.h",
-        "BraintreePayPal/PayPalOneTouch/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalOneTouch/**/*.h",
+      "BraintreePayPal/PayPalOneTouch/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1589,13 +1335,9 @@ objc_library(
     [
       "BraintreePayPal/PayPalOneTouch/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreePayPal/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalOneTouch_hdrs"
@@ -1629,8 +1371,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -1644,20 +1384,12 @@ acknowledged_target(
 filegroup(
   name = "PayPalDataCollector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.h",
-        "BraintreePayPal/PayPalDataCollector/Public/*.h",
-        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalDataCollector/**/*.h",
+      "BraintreePayPal/PayPalDataCollector/Public/*.h",
+      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1669,8 +1401,7 @@ filegroup(
     [
       "BraintreePayPal/PayPalDataCollector/Public/*.h",
       "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalUtils_public_hdrs"
@@ -1682,20 +1413,12 @@ filegroup(
 filegroup(
   name = "PayPalDataCollector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.h",
-        "BraintreePayPal/PayPalDataCollector/Public/*.h",
-        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalDataCollector/**/*.h",
+      "BraintreePayPal/PayPalDataCollector/Public/*.h",
+      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1741,18 +1464,10 @@ objc_library(
     [
       "BraintreePayPal/PayPalDataCollector/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeVenmo/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeVenmo/**/*.m",
+      "BraintreePayPal/PayPalOneTouch/**/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalDataCollector_hdrs"
@@ -1784,8 +1499,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"
@@ -1810,19 +1523,11 @@ acknowledged_target(
 filegroup(
   name = "PayPalUtils_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalUtils/**/*.h",
-        "BraintreePayPal/PayPalUtils/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalUtils/**/*.h",
+      "BraintreePayPal/PayPalUtils/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1833,8 +1538,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalUtils/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1843,19 +1547,11 @@ filegroup(
 filegroup(
   name = "PayPalUtils_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalUtils/**/*.h",
-        "BraintreePayPal/PayPalUtils/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalUtils/**/*.h",
+      "BraintreePayPal/PayPalUtils/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1896,23 +1592,11 @@ objc_library(
     [
       "BraintreePayPal/PayPalUtils/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreePayPal/PayPalOneTouch/**/*.m",
+      "BraintreePayPal/PayPalDataCollector/**/*.m",
+      "BraintreePayPal/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalUtils_hdrs"
@@ -1941,8 +1625,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Braintree/pod_support/Headers/Public/Braintree/"
-  ] + [
-    "-fmodule-name=Braintree"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -70,7 +71,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_hdrs",
     ":without-IDFA_hdrs"
@@ -139,12 +141,20 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -160,7 +170,8 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -169,12 +180,20 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -215,7 +234,8 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -256,12 +276,20 @@ acknowledged_target(
 filegroup(
   name = "without-IDFA_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -277,7 +305,8 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -286,12 +315,20 @@ filegroup(
 filegroup(
   name = "without-IDFA_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Branch-SDK/Branch-SDK/*.h",
-      "Branch-SDK/Branch-SDK/Requests/*.h",
-      "Branch-SDK/Fabric/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Branch-SDK/Branch-SDK/*.h",
+        "Branch-SDK/Branch-SDK/Requests/*.h",
+        "Branch-SDK/Fabric/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -332,7 +369,8 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":without-IDFA_hdrs"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs",
     ":without-IDFA_hdrs"
@@ -126,8 +124,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
-  ] + [
-    "-fmodule-name=Branch"
   ],
   visibility = [
     "//visibility:public"
@@ -141,20 +137,12 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -170,8 +158,7 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -180,20 +167,12 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -234,8 +213,7 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -261,8 +239,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
-  ] + [
-    "-fmodule-name=Branch"
   ],
   visibility = [
     "//visibility:public"
@@ -276,20 +252,12 @@ acknowledged_target(
 filegroup(
   name = "without-IDFA_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -305,8 +273,7 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -315,20 +282,12 @@ filegroup(
 filegroup(
   name = "without-IDFA_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -369,8 +328,7 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":without-IDFA_hdrs"
@@ -395,8 +353,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Branch/pod_support/Headers/Public/Branch/"
-  ] + [
-    "-fmodule-name=Branch"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -47,12 +47,20 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -65,7 +73,8 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -74,12 +83,20 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -122,24 +139,32 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.cpp",
       "calabash.framework/Versions/A/Headers/*.cxx"
     ],
-    exclude = [
-      "calabash.framework/Versions/A/Headers/*.S",
-      "calabash.framework/Versions/A/Headers/*.c",
-      "calabash.framework/Versions/A/Headers/*.m",
-      "calabash.framework/Versions/A/Headers/*.s"
-    ]
+    exclude = glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.S",
+        "calabash.framework/Versions/A/Headers/*.c",
+        "calabash.framework/Versions/A/Headers/*.m",
+        "calabash.framework/Versions/A/Headers/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
       [
         "calabash.framework/Versions/A/Headers/*.mm"
       ],
-      exclude = [
-        "calabash.framework/Versions/A/Headers/*.S",
-        "calabash.framework/Versions/A/Headers/*.c",
-        "calabash.framework/Versions/A/Headers/*.m",
-        "calabash.framework/Versions/A/Headers/*.s"
-      ]
+      exclude = glob(
+        [
+          "calabash.framework/Versions/A/Headers/*.S",
+          "calabash.framework/Versions/A/Headers/*.c",
+          "calabash.framework/Versions/A/Headers/*.m",
+          "calabash.framework/Versions/A/Headers/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -147,13 +172,18 @@ objc_library(
         "calabash.framework/Versions/A/Headers/*.cpp",
         "calabash.framework/Versions/A/Headers/*.cxx"
       ],
-      exclude = [
-        "calabash.framework/Versions/A/Headers/*.S",
-        "calabash.framework/Versions/A/Headers/*.c",
-        "calabash.framework/Versions/A/Headers/*.m",
-        "calabash.framework/Versions/A/Headers/*.s"
-      ]
-    )
+      exclude = glob(
+        [
+          "calabash.framework/Versions/A/Headers/*.S",
+          "calabash.framework/Versions/A/Headers/*.c",
+          "calabash.framework/Versions/A/Headers/*.m",
+          "calabash.framework/Versions/A/Headers/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
@@ -204,7 +234,8 @@ swift_library(
   srcs = glob(
     [
       "calabash.framework/Versions/A/Headers/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [],
   data = [],
@@ -215,12 +246,20 @@ swift_library(
 filegroup(
   name = "Calabash_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -233,7 +272,8 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Calabash_cxx_public_hdrs"
   ],
@@ -244,12 +284,20 @@ filegroup(
 filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "calabash.framework/Versions/A/Headers/*.h",
-      "calabash.framework/Versions/A/Headers/*.hpp",
-      "calabash.framework/Versions/A/Headers/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "calabash.framework/Versions/A/Headers/*.h",
+        "calabash.framework/Versions/A/Headers/*.hpp",
+        "calabash.framework/Versions/A/Headers/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":Calabash_cxx_hdrs"
   ],
@@ -286,7 +334,8 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.c",
       "calabash.framework/Versions/A/Headers/*.m",
       "calabash.framework/Versions/A/Headers/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -47,20 +46,12 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +64,7 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +73,12 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -139,32 +121,24 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.cpp",
       "calabash.framework/Versions/A/Headers/*.cxx"
     ],
-    exclude = glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.S",
-        "calabash.framework/Versions/A/Headers/*.c",
-        "calabash.framework/Versions/A/Headers/*.m",
-        "calabash.framework/Versions/A/Headers/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "calabash.framework/Versions/A/Headers/*.S",
+      "calabash.framework/Versions/A/Headers/*.c",
+      "calabash.framework/Versions/A/Headers/*.m",
+      "calabash.framework/Versions/A/Headers/*.s"
+    ]
   ),
   non_arc_srcs = glob(
     glob(
       [
         "calabash.framework/Versions/A/Headers/*.mm"
       ],
-      exclude = glob(
-        [
-          "calabash.framework/Versions/A/Headers/*.S",
-          "calabash.framework/Versions/A/Headers/*.c",
-          "calabash.framework/Versions/A/Headers/*.m",
-          "calabash.framework/Versions/A/Headers/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "calabash.framework/Versions/A/Headers/*.S",
+        "calabash.framework/Versions/A/Headers/*.c",
+        "calabash.framework/Versions/A/Headers/*.m",
+        "calabash.framework/Versions/A/Headers/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -172,20 +146,14 @@ objc_library(
         "calabash.framework/Versions/A/Headers/*.cpp",
         "calabash.framework/Versions/A/Headers/*.cxx"
       ],
-      exclude = glob(
-        [
-          "calabash.framework/Versions/A/Headers/*.S",
-          "calabash.framework/Versions/A/Headers/*.c",
-          "calabash.framework/Versions/A/Headers/*.m",
-          "calabash.framework/Versions/A/Headers/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      exclude = [
+        "calabash.framework/Versions/A/Headers/*.S",
+        "calabash.framework/Versions/A/Headers/*.c",
+        "calabash.framework/Versions/A/Headers/*.m",
+        "calabash.framework/Versions/A/Headers/*.s"
+      ]
+    )
   ),
-  module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
     ":Calabash_cxx_hdrs"
   ],
@@ -217,8 +185,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Calabash/pod_support/Headers/Public/Calabash/"
-  ] + [
-    "-fmodule-name=Calabash"
   ],
   visibility = [
     "//visibility:public"
@@ -229,37 +195,15 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "Calabash_swift",
-  srcs = glob(
-    [
-      "calabash.framework/Versions/A/Headers/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "Calabash_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -272,8 +216,7 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Calabash_cxx_public_hdrs"
   ],
@@ -284,20 +227,12 @@ filegroup(
 filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ) + [
     ":Calabash_cxx_hdrs"
   ],
@@ -334,10 +269,8 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.c",
       "calabash.framework/Versions/A/Headers/*.m",
       "calabash.framework/Versions/A/Headers/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
-  module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
     ":Calabash_hdrs"
   ],
@@ -351,7 +284,6 @@ objc_library(
   ),
   deps = [
     ":Calabash_cxx",
-    ":Calabash_swift",
     ":Calabash_includes"
   ],
   copts = [
@@ -370,8 +302,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Calabash/pod_support/Headers/Public/Calabash/"
-  ] + [
-    "-fmodule-name=Calabash"
   ],
   visibility = [
     "//visibility:public"
@@ -381,28 +311,4 @@ acknowledged_target(
   name = "Calabash_acknowledgement",
   deps = [],
   value = "//Vendor/Calabash/pod_support_buildable:acknowledgement_fragment"
-)
-gen_module_map(
-  "Calabash_extended_module_map_module_map_file",
-  "Calabash_extended_module_map",
-  "Calabash",
-  [
-    "Calabash_public_hdrs"
-  ],
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  "Calabash_module_map_module_map_file",
-  "Calabash_module_map",
-  "Calabash",
-  [
-    "Calabash_extended_module_map_module_map_file",
-    "Calabash_public_hdrs"
-  ],
-  module_map_name = "Calabash.modulemap",
-  visibility = [
-    "//visibility:public"
-  ]
 )

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "CardIO_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "CardIO/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "CardIO/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "CardIO/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "CardIO/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "CardIO/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -150,8 +133,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CardIO/pod_support/Headers/Public/CardIO/"
-  ] + [
-    "-fmodule-name=CardIO"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "CardIO_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "CardIO/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "CardIO/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "CardIO/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "CardIO/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "CardIO/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -52,8 +52,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +73,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_hdrs",
     ":Extensions_hdrs"
@@ -129,8 +127,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"
@@ -144,19 +140,11 @@ acknowledged_target(
 filegroup(
   name = "Default_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/CocoaLumberjack.h",
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/CocoaLumberjack.h",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -168,8 +156,7 @@ filegroup(
     [
       "Classes/CocoaLumberjack.h",
       "Classes/DD*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -178,19 +165,11 @@ filegroup(
 filegroup(
   name = "Default_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/CocoaLumberjack.h",
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/CocoaLumberjack.h",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -231,13 +210,9 @@ objc_library(
     [
       "Classes/DD*.m"
     ],
-    exclude = glob(
-      [
-        "Classes/Extensions/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Classes/Extensions/*.m"
+    ]
   ),
   hdrs = [
     ":Default_hdrs"
@@ -258,8 +233,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"
@@ -273,18 +246,10 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -295,8 +260,7 @@ filegroup(
   srcs = glob(
     [
       "Classes/DD*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -305,18 +269,10 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -356,8 +312,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/DD*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -378,8 +333,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"
@@ -393,18 +346,10 @@ acknowledged_target(
 filegroup(
   name = "Extensions_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/Extensions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/Extensions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -415,8 +360,7 @@ filegroup(
   srcs = glob(
     [
       "Classes/Extensions/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_public_hdrs"
   ],
@@ -427,18 +371,10 @@ filegroup(
 filegroup(
   name = "Extensions_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/Extensions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/Extensions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -481,8 +417,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/Extensions/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Extensions_hdrs"
@@ -504,8 +439,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"
@@ -523,34 +456,23 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/CLI/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/CLI/*.h"
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -566,8 +488,7 @@ filegroup(
       ":osxCase": glob(
         [
           "Classes/CLI/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + select(
@@ -589,34 +510,23 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/CLI/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/CLI/*.h"
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -675,8 +585,7 @@ objc_library(
       ":osxCase": glob(
         [
           "Classes/CLI/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -706,8 +615,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"
@@ -723,8 +630,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -744,8 +650,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -805,8 +710,6 @@ objc_library(
     }
   ) + [
     "-IVendor/CocoaLumberjack/pod_support/Headers/Public/CocoaLumberjack/"
-  ] + [
-    "-fmodule-name=CocoaLumberjack"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -52,7 +52,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -73,7 +74,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Default_hdrs",
     ":Extensions_hdrs"
@@ -142,11 +144,19 @@ acknowledged_target(
 filegroup(
   name = "Default_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/CocoaLumberjack.h",
-      "Classes/DD*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/CocoaLumberjack.h",
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -158,7 +168,8 @@ filegroup(
     [
       "Classes/CocoaLumberjack.h",
       "Classes/DD*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -167,11 +178,19 @@ filegroup(
 filegroup(
   name = "Default_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/CocoaLumberjack.h",
-      "Classes/DD*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/CocoaLumberjack.h",
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -212,9 +231,13 @@ objc_library(
     [
       "Classes/DD*.m"
     ],
-    exclude = [
-      "Classes/Extensions/*.m"
-    ]
+    exclude = glob(
+      [
+        "Classes/Extensions/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Default_hdrs"
@@ -250,10 +273,18 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/DD*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -264,7 +295,8 @@ filegroup(
   srcs = glob(
     [
       "Classes/DD*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -273,10 +305,18 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/DD*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/DD*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -316,7 +356,8 @@ objc_library(
   srcs = glob(
     [
       "Classes/DD*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -352,10 +393,18 @@ acknowledged_target(
 filegroup(
   name = "Extensions_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/Extensions/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/Extensions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -366,7 +415,8 @@ filegroup(
   srcs = glob(
     [
       "Classes/Extensions/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Default_public_hdrs"
   ],
@@ -377,10 +427,18 @@ filegroup(
 filegroup(
   name = "Extensions_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/Extensions/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/Extensions/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -423,7 +481,8 @@ objc_library(
   srcs = glob(
     [
       "Classes/Extensions/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Extensions_hdrs"
@@ -464,23 +523,34 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/CLI/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/CLI/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -496,7 +566,8 @@ filegroup(
       ":osxCase": glob(
         [
           "Classes/CLI/*.h"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ) + select(
@@ -518,23 +589,34 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/CLI/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/CLI/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -593,7 +675,8 @@ objc_library(
       ":osxCase": glob(
         [
           "Classes/CLI/*.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -640,7 +723,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -660,7 +744,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "ColorCube_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ColorCube/ColorCube/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ColorCube/ColorCube/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ColorCube/ColorCube/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ColorCube/ColorCube/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ColorCube_hdrs"
@@ -140,8 +122,6 @@ objc_library(
     }
   ) + [
     "-IVendor/ColorCube/pod_support/Headers/Public/ColorCube/"
-  ] + [
-    "-fmodule-name=ColorCube"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "ColorCube_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ColorCube/ColorCube/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ColorCube/ColorCube/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ColorCube/ColorCube/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ColorCube/ColorCube/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":ColorCube_hdrs"

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -144,7 +146,8 @@ apple_static_framework_import(
       "//conditions:default": glob(
         [
           "EarlGrey/EarlGrey.framework/**"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -127,8 +125,6 @@ objc_library(
     }
   ) + [
     "-IVendor/EarlGrey/pod_support/Headers/Public/EarlGrey/"
-  ] + [
-    "-fmodule-name=EarlGrey"
   ],
   visibility = [
     "//visibility:public"
@@ -146,8 +142,7 @@ apple_static_framework_import(
       "//conditions:default": glob(
         [
           "EarlGrey/EarlGrey.framework/**"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -47,23 +46,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +67,7 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -86,23 +76,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -162,36 +144,26 @@ objc_library(
           "FBAllocationTracker/**/*.cxx",
           "FBAllocationTracker/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "FBAllocationTracker/**/*.S",
-            "FBAllocationTracker/**/*.c",
-            "FBAllocationTracker/**/*.m",
-            "FBAllocationTracker/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        exclude = [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ]
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
       [
         "FBAllocationTracker/**/*.mm"
       ],
-      exclude = glob(
-        [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "FBAllocationTracker/**/*.S",
+        "FBAllocationTracker/**/*.c",
+        "FBAllocationTracker/**/*.m",
+        "FBAllocationTracker/**/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -216,24 +188,16 @@ objc_library(
             "FBAllocationTracker/**/*.cxx",
             "FBAllocationTracker/**/*.mm"
           ],
-          exclude = glob(
-            [
-              "FBAllocationTracker/**/*.S",
-              "FBAllocationTracker/**/*.c",
-              "FBAllocationTracker/**/*.m",
-              "FBAllocationTracker/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          exclude = [
+            "FBAllocationTracker/**/*.S",
+            "FBAllocationTracker/**/*.c",
+            "FBAllocationTracker/**/*.m",
+            "FBAllocationTracker/**/*.s"
+          ]
+        )
+      )
+    )
   ),
-  module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
     ":FBAllocationTracker_cxx_hdrs"
   ],
@@ -261,8 +225,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBAllocationTracker/pod_support/Headers/Public/FBAllocationTracker/"
-  ] + [
-    "-fmodule-name=FBAllocationTracker"
   ],
   visibility = [
     "//visibility:public"
@@ -273,40 +235,18 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/FBAllocationTracker/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "FBAllocationTracker_swift",
-  srcs = glob(
-    [
-      "FBAllocationTracker/**/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "FBAllocationTracker_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -319,8 +259,7 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":FBAllocationTracker_cxx_public_hdrs"
   ],
@@ -331,23 +270,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ) + [
     ":FBAllocationTracker_cxx_hdrs"
   ],
@@ -394,29 +325,21 @@ objc_library(
         "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
         "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
       ],
-      exclude = glob(
-        [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    glob(
-      [
+      exclude = [
         "FBAllocationTracker/**/*.S",
         "FBAllocationTracker/**/*.c",
         "FBAllocationTracker/**/*.m",
         "FBAllocationTracker/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
+      ]
+    )
+  ),
+  non_arc_srcs = glob(
+    [
+      "FBAllocationTracker/**/*.S",
+      "FBAllocationTracker/**/*.c",
+      "FBAllocationTracker/**/*.m",
+      "FBAllocationTracker/**/*.s"
+    ],
     exclude = glob(
       [
         "FBAllocationTracker/FBAllocationTrackerImpl.mm",
@@ -433,22 +356,15 @@ objc_library(
           "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
           "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
         ],
-        exclude = glob(
-          [
-            "FBAllocationTracker/**/*.S",
-            "FBAllocationTracker/**/*.c",
-            "FBAllocationTracker/**/*.m",
-            "FBAllocationTracker/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        exclude = [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ]
+      )
+    )
   ),
-  module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
     ":FBAllocationTracker_hdrs"
   ],
@@ -461,7 +377,6 @@ objc_library(
   ],
   deps = [
     ":FBAllocationTracker_cxx",
-    ":FBAllocationTracker_swift",
     ":FBAllocationTracker_includes"
   ],
   copts = select(
@@ -476,8 +391,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBAllocationTracker/pod_support/Headers/Public/FBAllocationTracker/"
-  ] + [
-    "-fmodule-name=FBAllocationTracker"
   ],
   visibility = [
     "//visibility:public"
@@ -487,28 +400,4 @@ acknowledged_target(
   name = "FBAllocationTracker_acknowledgement",
   deps = [],
   value = "//Vendor/FBAllocationTracker/pod_support_buildable:acknowledgement_fragment"
-)
-gen_module_map(
-  "FBAllocationTracker_extended_module_map_module_map_file",
-  "FBAllocationTracker_extended_module_map",
-  "FBAllocationTracker",
-  [
-    "FBAllocationTracker_public_hdrs"
-  ],
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  "FBAllocationTracker_module_map_module_map_file",
-  "FBAllocationTracker_module_map",
-  "FBAllocationTracker",
-  [
-    "FBAllocationTracker_extended_module_map_module_map_file",
-    "FBAllocationTracker_public_hdrs"
-  ],
-  module_map_name = "FBAllocationTracker.modulemap",
-  visibility = [
-    "//visibility:public"
-  ]
 )

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -47,15 +47,23 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBAllocationTracker/**/*.h",
-      "FBAllocationTracker/**/*.hpp",
-      "FBAllocationTracker/**/*.hxx",
-      "FBAllocationTracker/FBAllocationTracker.h",
-      "FBAllocationTracker/FBAllocationTrackerManager.h",
-      "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBAllocationTracker/**/*.h",
+        "FBAllocationTracker/**/*.hpp",
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,7 +76,8 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -77,15 +86,23 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBAllocationTracker/**/*.h",
-      "FBAllocationTracker/**/*.hpp",
-      "FBAllocationTracker/**/*.hxx",
-      "FBAllocationTracker/FBAllocationTracker.h",
-      "FBAllocationTracker/FBAllocationTrackerManager.h",
-      "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBAllocationTracker/**/*.h",
+        "FBAllocationTracker/**/*.hpp",
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -145,26 +162,36 @@ objc_library(
           "FBAllocationTracker/**/*.cxx",
           "FBAllocationTracker/**/*.mm"
         ],
-        exclude = [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ]
-      )
-    )
+        exclude = glob(
+          [
+            "FBAllocationTracker/**/*.S",
+            "FBAllocationTracker/**/*.c",
+            "FBAllocationTracker/**/*.m",
+            "FBAllocationTracker/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
       [
         "FBAllocationTracker/**/*.mm"
       ],
-      exclude = [
-        "FBAllocationTracker/**/*.S",
-        "FBAllocationTracker/**/*.c",
-        "FBAllocationTracker/**/*.m",
-        "FBAllocationTracker/**/*.s"
-      ]
+      exclude = glob(
+        [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -189,15 +216,22 @@ objc_library(
             "FBAllocationTracker/**/*.cxx",
             "FBAllocationTracker/**/*.mm"
           ],
-          exclude = [
-            "FBAllocationTracker/**/*.S",
-            "FBAllocationTracker/**/*.c",
-            "FBAllocationTracker/**/*.m",
-            "FBAllocationTracker/**/*.s"
-          ]
-        )
-      )
-    )
+          exclude = glob(
+            [
+              "FBAllocationTracker/**/*.S",
+              "FBAllocationTracker/**/*.c",
+              "FBAllocationTracker/**/*.m",
+              "FBAllocationTracker/**/*.s"
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
@@ -244,7 +278,8 @@ swift_library(
   srcs = glob(
     [
       "FBAllocationTracker/**/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [],
   data = [],
@@ -255,15 +290,23 @@ swift_library(
 filegroup(
   name = "FBAllocationTracker_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBAllocationTracker/**/*.h",
-      "FBAllocationTracker/**/*.hpp",
-      "FBAllocationTracker/**/*.hxx",
-      "FBAllocationTracker/FBAllocationTracker.h",
-      "FBAllocationTracker/FBAllocationTrackerManager.h",
-      "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBAllocationTracker/**/*.h",
+        "FBAllocationTracker/**/*.hpp",
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -276,7 +319,8 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":FBAllocationTracker_cxx_public_hdrs"
   ],
@@ -287,15 +331,23 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBAllocationTracker/**/*.h",
-      "FBAllocationTracker/**/*.hpp",
-      "FBAllocationTracker/**/*.hxx",
-      "FBAllocationTracker/FBAllocationTracker.h",
-      "FBAllocationTracker/FBAllocationTrackerManager.h",
-      "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBAllocationTracker/**/*.h",
+        "FBAllocationTracker/**/*.hpp",
+        "FBAllocationTracker/**/*.hxx",
+        "FBAllocationTracker/FBAllocationTracker.h",
+        "FBAllocationTracker/FBAllocationTrackerManager.h",
+        "FBAllocationTracker/FBAllocationTrackerSummary.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":FBAllocationTracker_cxx_hdrs"
   ],
@@ -342,21 +394,29 @@ objc_library(
         "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
         "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
       ],
-      exclude = [
+      exclude = glob(
+        [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    glob(
+      [
         "FBAllocationTracker/**/*.S",
         "FBAllocationTracker/**/*.c",
         "FBAllocationTracker/**/*.m",
         "FBAllocationTracker/**/*.s"
-      ]
-    )
-  ),
-  non_arc_srcs = glob(
-    [
-      "FBAllocationTracker/**/*.S",
-      "FBAllocationTracker/**/*.c",
-      "FBAllocationTracker/**/*.m",
-      "FBAllocationTracker/**/*.s"
-    ],
+      ],
+      exclude_directories = 1
+    ),
     exclude = glob(
       [
         "FBAllocationTracker/FBAllocationTrackerImpl.mm",
@@ -373,14 +433,20 @@ objc_library(
           "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
           "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
         ],
-        exclude = [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ]
-      )
-    )
+        exclude = glob(
+          [
+            "FBAllocationTracker/**/*.S",
+            "FBAllocationTracker/**/*.c",
+            "FBAllocationTracker/**/*.m",
+            "FBAllocationTracker/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -51,7 +51,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -72,7 +73,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Basics_hdrs",
     ":Core_hdrs"
@@ -105,6 +107,200 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+    ],
+    exclude = glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -172,13 +368,21 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -195,7 +399,8 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -204,13 +409,21 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -376,7 +589,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -399,10 +613,14 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ]
-        )
-      )
-    )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
@@ -432,7 +650,8 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ]
+        ],
+        exclude_directories = 1
       ) + glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -455,8 +674,10 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ]
-      )
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -587,7 +808,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ]
+            ],
+            exclude_directories = 1
           ) + glob(
             [
               "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -610,11 +832,16 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ]
-          )
-        )
-      )
-    )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Basics_hdrs"
@@ -682,7 +909,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -693,9 +921,12 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -714,8 +945,10 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -735,7 +968,8 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -746,9 +980,12 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -767,8 +1004,10 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -954,10 +1193,14 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ]
-        )
-      )
-    )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
@@ -1004,8 +1247,10 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ]
-      )
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -1153,11 +1398,16 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ]
-          )
-        )
-      )
-    )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [
@@ -1230,9 +1480,12 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1251,8 +1504,10 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1272,7 +1527,8 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Basics_public_hdrs",
     ":Core_cxx_public_hdrs"
@@ -1284,9 +1540,12 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1305,8 +1564,10 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1472,9 +1733,12 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ]
-      )
-    )
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
@@ -1499,7 +1763,8 @@ objc_library(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-      ]
+      ],
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -1625,10 +1890,14 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ]
-        )
-      )
-    )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -37,6 +37,7 @@ config_setting(
 filegroup(
   name = "FBSDKCoreKit_package_hdrs",
   srcs = [
+    "FBSDKCoreKit_cxx_direct_hdrs",
     "FBSDKCoreKit_direct_hdrs",
     "Basics_direct_hdrs",
     "Core_cxx_direct_hdrs",
@@ -47,12 +48,142 @@ filegroup(
   ]
 )
 filegroup(
+  name = "FBSDKCoreKit_cxx_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_public_hdrs",
+  srcs = [
+    ":Basics_public_hdrs",
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_union_hdrs",
+  srcs = [
+    "FBSDKCoreKit_cxx_hdrs",
+    "FBSDKCoreKit_hdrs",
+    ":Basics_hdrs",
+    ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKCoreKit_cxx_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":FBSDKCoreKit_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Basics_hmap",
+    ":Core_hmap"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "FBSDKCoreKit_cxx_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "FBSDKCoreKit_cxx",
+  enable_modules = 0,
+  hdrs = [
+    ":FBSDKCoreKit_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accelerate",
+        "Accounts",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "c++",
+    "stdc++"
+  ],
+  deps = [
+    ":Basics",
+    ":Core",
+    ":FBSDKCoreKit_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14",
+    "-DFBSDKCOCOAPODS=1",
+    "-DFBSDKCOCOAPODS=1"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "FBSDKCoreKit_cxx_acknowledgement",
+  deps = [],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
   name = "FBSDKCoreKit_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -62,7 +193,8 @@ filegroup(
   name = "FBSDKCoreKit_public_hdrs",
   srcs = [
     ":Basics_public_hdrs",
-    ":Core_public_hdrs"
+    ":Core_public_hdrs",
+    ":FBSDKCoreKit_cxx_public_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -73,11 +205,11 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_hdrs",
-    ":Core_hdrs"
+    ":Core_hdrs",
+    ":FBSDKCoreKit_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -92,7 +224,8 @@ headermap(
   ],
   deps = [
     ":Basics_hmap",
-    ":Core_hmap"
+    ":Core_hmap",
+    ":FBSDKCoreKit_cxx_hmap"
   ],
   visibility = [
     "//visibility:public"
@@ -107,200 +240,6 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -336,6 +275,7 @@ objc_library(
   deps = [
     ":Basics",
     ":Core",
+    ":FBSDKCoreKit_cxx",
     ":FBSDKCoreKit_includes"
   ],
   copts = [
@@ -353,8 +293,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"
@@ -368,21 +306,13 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -399,8 +329,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -409,21 +338,13 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -589,8 +510,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -613,14 +533,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -650,8 +566,7 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ) + glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -674,10 +589,8 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+        ]
+      )
     ),
     exclude = glob(
       [
@@ -808,8 +721,7 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
+            ]
           ) + glob(
             [
               "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -832,16 +744,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+            ]
+          )
+        )
+      )
+    )
   ),
   hdrs = [
     ":Basics_hdrs"
@@ -892,8 +799,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"
@@ -909,8 +814,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -921,12 +825,9 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -945,10 +846,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -968,8 +867,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -980,12 +878,9 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1004,10 +899,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1193,14 +1086,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -1247,10 +1136,8 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+        ]
+      )
     ),
     exclude = glob(
       [
@@ -1398,18 +1285,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+            ]
+          )
+        )
+      )
+    )
   ),
-  module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [
     ":Core_cxx_hdrs"
   ],
@@ -1462,8 +1343,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   data = [
     ":Core_Bundle_FacebookSDKStrings"
@@ -1480,12 +1359,9 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1504,10 +1380,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1527,8 +1401,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs",
     ":Core_cxx_public_hdrs"
@@ -1540,12 +1413,9 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1564,10 +1434,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1733,12 +1601,9 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        ]
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -1763,8 +1628,7 @@ objc_library(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-      ],
-      exclude_directories = 1
+      ]
     ),
     exclude = glob(
       [
@@ -1890,16 +1754,11 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
-  module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [
     ":Core_hdrs"
   ],
@@ -1952,8 +1811,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   data = [
     ":Core_Bundle_FacebookSDKStrings"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -37,6 +37,7 @@ config_setting(
 filegroup(
   name = "FBSDKCoreKit_package_hdrs",
   srcs = [
+    "FBSDKCoreKit_cxx_direct_hdrs",
     "FBSDKCoreKit_direct_hdrs"
   ],
   visibility = [
@@ -44,16 +45,13 @@ filegroup(
   ]
 )
 filegroup(
-  name = "FBSDKCoreKit_direct_hdrs",
+  name = "FBSDKCoreKit_cxx_direct_hdrs",
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -64,33 +62,20 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -123,25 +108,289 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_public_hdrs",
+  srcs = glob(
+    [
+      "FBSDKCoreKit/FBSDKCoreKit/*.h"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
           ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
+          ]
+        )
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
+      ),
+      ":tvosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+          ]
+        )
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
+      )
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "FBSDKCoreKit_cxx_union_hdrs",
+  srcs = [
+    "FBSDKCoreKit_cxx_hdrs",
+    "FBSDKCoreKit_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "FBSDKCoreKit_cxx_hmap",
+  namespace = "FBSDKCoreKit",
+  hdrs = [
+    "FBSDKCoreKit_package_hdrs",
+    ":FBSDKCoreKit_cxx_union_hdrs"
+  ],
+  deps = select(
+    {
+      "//conditions:default": [
+        "//Vendor/Bolts:Bolts"
+      ]
+    }
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "FBSDKCoreKit_cxx_includes",
+  include = [
+    "Vendor/FBSDKCoreKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "FBSDKCoreKit_cxx",
+  enable_modules = 0,
+  hdrs = [
+    ":FBSDKCoreKit_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/FBSDKCoreKit-prefix.pch",
+  weak_sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "Accounts",
+        "CoreLocation",
+        "Social",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ],
+      ":tvosCase": [
+        "CoreLocation",
+        "Security",
+        "QuartzCore",
+        "CoreGraphics",
+        "UIKit",
+        "Foundation",
+        "AudioToolbox"
+      ]
+    }
+  ),
+  deps = select(
+    {
+      "//conditions:default": [
+        "//Vendor/Bolts:Bolts"
+      ]
+    }
+  ) + [
+    ":FBSDKCoreKit_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
+  ],
+  data = [
+    ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "FBSDKCoreKit_cxx_acknowledgement",
+  deps = [
+    "//Vendor/Bolts:Bolts_acknowledgement"
+  ],
+  value = "//Vendor/FBSDKCoreKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
+  name = "FBSDKCoreKit_direct_hdrs",
+  srcs = select(
+    {
+      "//conditions:default": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
+          ]
+        )
+      ),
+      ":osxCase": glob(
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
+      ),
+      ":tvosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKMutableCopying.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.h",
+            "FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/**/*.hxx",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKContainerViewController.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKMonotonicTime.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKProfile+Internal.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKCloseIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKColor.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKMaleSilhouetteIcon.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
+            "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
+          ]
+        )
+      ),
+      ":watchosCase": glob(
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       )
     }
   ),
@@ -154,9 +403,10 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/*.h"
-    ],
-    exclude_directories = 1
-  ),
+    ]
+  ) + [
+    ":FBSDKCoreKit_cxx_public_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -166,12 +416,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -182,33 +429,20 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -241,28 +475,20 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       )
     }
-  ),
+  ) + [
+    ":FBSDKCoreKit_cxx_hdrs"
+  ],
   visibility = [
     "//visibility:public"
   ]
@@ -274,7 +500,9 @@ headermap(
     "FBSDKCoreKit_package_hdrs",
     ":FBSDKCoreKit_hdrs"
   ],
-  deps = select(
+  deps = [
+    ":FBSDKCoreKit_cxx_hmap"
+  ] + select(
     {
       "//conditions:default": [
         "//Vendor/Bolts:Bolts"
@@ -349,12 +577,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -394,15 +619,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = glob(
-            [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ]
+        )
       ),
       ":tvosCase": glob(
         [
@@ -492,12 +712,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -537,15 +754,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = glob(
-            [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ]
+        )
       )
     }
   ),
@@ -567,8 +779,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -623,22 +834,15 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -677,17 +881,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = glob(
-              [
-                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -740,8 +938,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -831,22 +1028,15 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -885,17 +1075,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = glob(
-              [
-                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ]
+          )
+        )
       )
     }
   ),
@@ -927,7 +1111,9 @@ objc_library(
       ]
     }
   ),
-  deps = select(
+  deps = [
+    ":FBSDKCoreKit_cxx"
+  ] + select(
     {
       "//conditions:default": [
         "//Vendor/Bolts:Bolts"
@@ -948,8 +1134,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKCoreKit/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   data = [
     ":FBSDKCoreKit_Bundle_FacebookSDKStrings"
@@ -970,8 +1154,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -48,9 +48,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -61,20 +64,33 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -107,15 +123,25 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -128,7 +154,8 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -139,9 +166,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -152,20 +182,33 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -198,15 +241,25 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-          "FBSDKCoreKit/FBSDKCoreKit/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+            "FBSDKCoreKit/FBSDKCoreKit/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -296,9 +349,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -338,10 +394,15 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ]
-        )
+          exclude = glob(
+            [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -431,9 +492,12 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -473,10 +537,15 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ]
-        )
+          exclude = glob(
+            [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -498,7 +567,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -553,15 +623,22 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-        ],
+        glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -600,11 +677,17 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ]
-          )
-        )
+            exclude = glob(
+              [
+                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         glob(
@@ -657,7 +740,8 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -747,15 +831,22 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-        ],
+        glob(
+          [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -794,11 +885,17 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ]
-          )
-        )
+            exclude = glob(
+              [
+                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -873,7 +970,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Login_hdrs"
   ],
@@ -143,8 +141,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKLoginKit/pod_support/Headers/Public/FBSDKLoginKit/"
-  ] + [
-    "-fmodule-name=FBSDKLoginKit"
   ],
   visibility = [
     "//visibility:public"
@@ -158,12 +154,9 @@ acknowledged_target(
 filegroup(
   name = "Login_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -172,10 +165,8 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -186,8 +177,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -196,12 +186,9 @@ filegroup(
 filegroup(
   name = "Login_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -210,10 +197,8 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -265,10 +250,8 @@ objc_library(
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.m",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.mm",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
-  module_map = ":FBSDKLoginKit_extended_module_map_module_map_file",
   hdrs = [
     ":Login_hdrs"
   ],
@@ -311,8 +294,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKLoginKit/pod_support/Headers/Public/FBSDKLoginKit/"
-  ] + [
-    "-fmodule-name=FBSDKLoginKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,7 +69,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Login_hdrs"
   ],
@@ -156,9 +158,12 @@ acknowledged_target(
 filegroup(
   name = "Login_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -167,8 +172,10 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -179,7 +186,8 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -188,9 +196,12 @@ filegroup(
 filegroup(
   name = "Login_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -199,8 +210,10 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -252,7 +265,8 @@ objc_library(
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.m",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.mm",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   module_map = ":FBSDKLoginKit_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -45,19 +45,11 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-        "FBSDKLoginKit/FBSDKLoginKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+      "FBSDKLoginKit/FBSDKLoginKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,19 +69,11 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-        "FBSDKLoginKit/FBSDKLoginKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+      "FBSDKLoginKit/FBSDKLoginKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -122,8 +105,7 @@ objc_library(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FBSDKLoginKit_hdrs"
@@ -158,8 +140,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKLoginKit/pod_support/Headers/Public/FBSDKLoginKit/"
-  ] + [
-    "-fmodule-name=FBSDKLoginKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -45,11 +45,19 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-      "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+        "FBSDKLoginKit/FBSDKLoginKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -60,7 +68,8 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,11 +78,19 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-      "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+        "FBSDKLoginKit/FBSDKLoginKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -105,7 +122,8 @@ objc_library(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FBSDKLoginKit_hdrs"

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -45,11 +45,19 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -60,7 +68,8 @@ filegroup(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,11 +78,19 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -103,7 +120,8 @@ objc_library(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -45,19 +45,11 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,19 +69,11 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -120,8 +103,7 @@ objc_library(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"
@@ -142,8 +124,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKMessengerShareKit/pod_support/Headers/Public/FBSDKMessengerShareKit/"
-  ] + [
-    "-fmodule-name=FBSDKMessengerShareKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -47,12 +47,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -60,59 +57,47 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -127,8 +112,7 @@ filegroup(
       "//conditions:default": glob(
         [
           "FBSDKShareKit/FBSDKShareKit/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -149,8 +133,7 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -163,12 +146,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -176,59 +156,47 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -268,8 +236,7 @@ objc_library(
         exclude = [
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.m",
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -291,8 +258,7 @@ objc_library(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -342,8 +308,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FBSDKShareKit/pod_support/Headers/Public/FBSDKShareKit/"
-  ] + [
-    "-fmodule-name=FBSDKShareKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -47,9 +47,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -57,47 +60,59 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -112,7 +127,8 @@ filegroup(
       "//conditions:default": glob(
         [
           "FBSDKShareKit/FBSDKShareKit/*.h"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -133,7 +149,8 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -146,9 +163,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -156,47 +176,59 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -236,7 +268,8 @@ objc_library(
         exclude = [
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.m",
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.m"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -258,7 +291,8 @@ objc_library(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FLAnimatedImage/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FLAnimatedImage/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FLAnimatedImage/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FLAnimatedImage/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
@@ -146,8 +128,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FLAnimatedImage/pod_support/Headers/Public/FLAnimatedImage/"
-  ] + [
-    "-fmodule-name=FLAnimatedImage"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FLAnimatedImage/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FLAnimatedImage/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FLAnimatedImage/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FLAnimatedImage/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -45,12 +45,20 @@ filegroup(
 filegroup(
   name = "FLEX_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/**/*.h",
-      "Classes/**/FLEXManager.h",
-      "Classes/FLEX.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/**/*.h",
+        "Classes/**/FLEXManager.h",
+        "Classes/FLEX.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -62,7 +70,8 @@ filegroup(
     [
       "Classes/**/FLEXManager.h",
       "Classes/FLEX.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -71,12 +80,20 @@ filegroup(
 filegroup(
   name = "FLEX_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Classes/**/*.h",
-      "Classes/**/FLEXManager.h",
-      "Classes/FLEX.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Classes/**/*.h",
+        "Classes/**/FLEXManager.h",
+        "Classes/FLEX.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -106,7 +123,8 @@ objc_library(
   srcs = glob(
     [
       "Classes/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FLEX_hdrs"

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "FLEX_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/**/*.h",
-        "Classes/**/FLEXManager.h",
-        "Classes/FLEX.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/**/*.h",
+      "Classes/**/FLEXManager.h",
+      "Classes/FLEX.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -70,8 +62,7 @@ filegroup(
     [
       "Classes/**/FLEXManager.h",
       "Classes/FLEX.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -80,20 +71,12 @@ filegroup(
 filegroup(
   name = "FLEX_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/**/*.h",
-        "Classes/**/FLEXManager.h",
-        "Classes/FLEX.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/**/*.h",
+      "Classes/**/FLEXManager.h",
+      "Classes/FLEX.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -123,8 +106,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLEX_hdrs"
@@ -154,8 +136,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FLEX/pod_support/Headers/Public/FLEX/"
-  ] + [
-    "-fmodule-name=FLEX"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -53,8 +53,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +73,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":standard_hdrs"
   ],
@@ -126,8 +124,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -141,18 +137,10 @@ acknowledged_target(
 filegroup(
   name = "standard_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -163,8 +151,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -173,18 +160,10 @@ filegroup(
 filegroup(
   name = "standard_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -226,14 +205,9 @@ objc_library(
       "src/fmdb/FM*.m"
     ],
     exclude = [
-      "src/fmdb.m"
-    ] + glob(
-      [
-        "src/extra/fts3/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "src/fmdb.m",
+      "src/extra/fts3/*.m"
+    ]
   ),
   hdrs = [
     ":standard_hdrs"
@@ -257,8 +231,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -272,18 +244,10 @@ acknowledged_target(
 filegroup(
   name = "FTS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -294,8 +258,7 @@ filegroup(
   srcs = glob(
     [
       "src/extra/fts3/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":standard_public_hdrs"
   ],
@@ -306,18 +269,10 @@ filegroup(
 filegroup(
   name = "FTS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -360,8 +315,7 @@ objc_library(
   srcs = glob(
     [
       "src/extra/fts3/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FTS_hdrs"
@@ -383,8 +337,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -400,8 +352,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -419,8 +370,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -478,8 +428,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -493,18 +441,10 @@ acknowledged_target(
 filegroup(
   name = "standalone_default_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -515,8 +455,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -525,18 +464,10 @@ filegroup(
 filegroup(
   name = "standalone_default_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -581,8 +512,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":standalone_default_hdrs"
@@ -606,8 +536,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -623,19 +551,11 @@ acknowledged_target(
 filegroup(
   name = "standalone_FTS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h",
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -647,8 +567,7 @@ filegroup(
     [
       "src/extra/fts3/*.h",
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -657,19 +576,11 @@ filegroup(
 filegroup(
   name = "standalone_FTS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h",
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -715,8 +626,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":standalone_FTS_hdrs"
@@ -740,8 +650,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"
@@ -757,18 +665,10 @@ acknowledged_target(
 filegroup(
   name = "SQLCipher_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -779,8 +679,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -789,18 +688,10 @@ filegroup(
 filegroup(
   name = "SQLCipher_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -845,8 +736,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SQLCipher_hdrs"
@@ -871,8 +761,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FMDB/pod_support/Headers/Public/FMDB/"
-  ] + [
-    "-fmodule-name=FMDB"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -53,7 +53,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -73,7 +74,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":standard_hdrs"
   ],
@@ -139,10 +141,18 @@ acknowledged_target(
 filegroup(
   name = "standard_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -153,7 +163,8 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -162,10 +173,18 @@ filegroup(
 filegroup(
   name = "standard_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -207,9 +226,14 @@ objc_library(
       "src/fmdb/FM*.m"
     ],
     exclude = [
-      "src/fmdb.m",
-      "src/extra/fts3/*.m"
-    ]
+      "src/fmdb.m"
+    ] + glob(
+      [
+        "src/extra/fts3/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":standard_hdrs"
@@ -248,10 +272,18 @@ acknowledged_target(
 filegroup(
   name = "FTS_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/extra/fts3/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -262,7 +294,8 @@ filegroup(
   srcs = glob(
     [
       "src/extra/fts3/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":standard_public_hdrs"
   ],
@@ -273,10 +306,18 @@ filegroup(
 filegroup(
   name = "FTS_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/extra/fts3/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -319,7 +360,8 @@ objc_library(
   srcs = glob(
     [
       "src/extra/fts3/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FTS_hdrs"
@@ -358,7 +400,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -376,7 +419,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -449,10 +493,18 @@ acknowledged_target(
 filegroup(
   name = "standalone_default_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -463,7 +515,8 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -472,10 +525,18 @@ filegroup(
 filegroup(
   name = "standalone_default_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -520,7 +581,8 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":standalone_default_hdrs"
@@ -561,11 +623,19 @@ acknowledged_target(
 filegroup(
   name = "standalone_FTS_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/extra/fts3/*.h",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h",
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -577,7 +647,8 @@ filegroup(
     [
       "src/extra/fts3/*.h",
       "src/fmdb/FM*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -586,11 +657,19 @@ filegroup(
 filegroup(
   name = "standalone_FTS_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/extra/fts3/*.h",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/extra/fts3/*.h",
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -636,7 +715,8 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":standalone_FTS_hdrs"
@@ -677,10 +757,18 @@ acknowledged_target(
 filegroup(
   name = "SQLCipher_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -691,7 +779,8 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -700,10 +789,18 @@ filegroup(
 filegroup(
   name = "SQLCipher_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "src/fmdb/FM*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "src/fmdb/FM*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -748,7 +845,8 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":SQLCipher_hdrs"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -43,54 +42,13 @@ filegroup(
     "//visibility:public"
   ]
 )
-swift_library(
-  name = "FolioReaderKit_swift",
-  srcs = glob(
-    [
-      "Source/**/*.swift",
-      "Source/*.swift",
-      "Vendor/**/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [
-    "//Vendor/AEXML:AEXML",
-    "//Vendor/FontBlaster:FontBlaster",
-    "//Vendor/JSQWebViewController:JSQWebViewController",
-    "//Vendor/MenuItemKit:MenuItemKit",
-    "//Vendor/RealmSwift:RealmSwift",
-    "//Vendor/SSZipArchive:SSZipArchive",
-    "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition"
-  ],
-  data = glob(
-    [
-      "Source/**/*.css",
-      "Source/**/*.js",
-      "Source/Resources/*.xcassets",
-      "Source/Resources/Fonts/**/*.otf",
-      "Source/Resources/Fonts/**/*.ttf"
-    ],
-    exclude_directories = 1
-  ),
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "FolioReaderKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -101,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -111,18 +68,10 @@ filegroup(
 filegroup(
   name = "FolioReaderKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -172,7 +121,6 @@ objc_library(
     "//Vendor/RealmSwift:RealmSwift",
     "//Vendor/SSZipArchive:SSZipArchive",
     "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition",
-    ":FolioReaderKit_swift",
     ":FolioReaderKit_includes"
   ],
   copts = select(
@@ -187,8 +135,6 @@ objc_library(
     }
   ) + [
     "-IVendor/FolioReaderKit/pod_support/Headers/Public/FolioReaderKit/"
-  ] + [
-    "-fmodule-name=FolioReaderKit"
   ],
   data = glob(
     [
@@ -197,8 +143,7 @@ objc_library(
       "Source/Resources/*.xcassets",
       "Source/Resources/Fonts/**/*.otf",
       "Source/Resources/Fonts/**/*.ttf"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -50,7 +50,8 @@ swift_library(
       "Source/**/*.swift",
       "Source/*.swift",
       "Vendor/**/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [
     "//Vendor/AEXML:AEXML",
@@ -68,7 +69,8 @@ swift_library(
       "Source/Resources/*.xcassets",
       "Source/Resources/Fonts/**/*.otf",
       "Source/Resources/Fonts/**/*.ttf"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -77,10 +79,18 @@ swift_library(
 filegroup(
   name = "FolioReaderKit_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -91,7 +101,8 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -100,10 +111,18 @@ filegroup(
 filegroup(
   name = "FolioReaderKit_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -178,7 +197,8 @@ objc_library(
       "Source/Resources/*.xcassets",
       "Source/Resources/Fonts/**/*.otf",
       "Source/Resources/Fonts/**/*.ttf"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -45,12 +45,20 @@ filegroup(
 filegroup(
   name = "Folly_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "folly/*.h",
-      "folly/detail/*.h",
-      "folly/portability/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "folly/*.h",
+        "folly/detail/*.h",
+        "folly/portability/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,12 +74,20 @@ filegroup(
 filegroup(
   name = "Folly_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "folly/*.h",
-      "folly/detail/*.h",
-      "folly/portability/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "folly/*.h",
+        "folly/detail/*.h",
+        "folly/portability/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -115,7 +131,8 @@ objc_library(
       "folly/dynamic.cpp",
       "folly/json.cpp",
       "folly/portability/BitsFunctexcept.cpp"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Folly_hdrs"

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "Folly_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "folly/*.h",
-        "folly/detail/*.h",
-        "folly/portability/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "folly/*.h",
+      "folly/detail/*.h",
+      "folly/portability/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,20 +66,12 @@ filegroup(
 filegroup(
   name = "Folly_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "folly/*.h",
-        "folly/detail/*.h",
-        "folly/portability/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "folly/*.h",
+      "folly/detail/*.h",
+      "folly/portability/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -131,8 +115,7 @@ objc_library(
       "folly/dynamic.cpp",
       "folly/json.cpp",
       "folly/portability/BitsFunctexcept.cpp"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Folly_hdrs"
@@ -161,9 +144,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-  ) + [
-    "-fmodule-name=folly"
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -47,12 +47,20 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Changelog/**/*.h",
-      "Changelog/**/*.hpp",
-      "Changelog/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Changelog/**/*.h",
+        "Changelog/**/*.hpp",
+        "Changelog/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,12 +76,20 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Changelog/**/*.h",
-      "Changelog/**/*.hpp",
-      "Changelog/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Changelog/**/*.h",
+        "Changelog/**/*.hpp",
+        "Changelog/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -144,7 +160,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleAppIndexingResources.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -157,7 +174,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleAppIndexing.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -47,20 +47,12 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Changelog/**/*.h",
-        "Changelog/**/*.hpp",
-        "Changelog/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Changelog/**/*.h",
+      "Changelog/**/*.hpp",
+      "Changelog/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,20 +68,12 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Changelog/**/*.h",
-        "Changelog/**/*.hpp",
-        "Changelog/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Changelog/**/*.h",
+      "Changelog/**/*.hpp",
+      "Changelog/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -140,8 +124,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleAppIndexing/pod_support/Headers/Public/GoogleAppIndexing/"
-  ] + [
-    "-fmodule-name=GoogleAppIndexing"
   ],
   data = [
     ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources"
@@ -160,8 +142,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleAppIndexingResources.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -174,8 +155,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleAppIndexing.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -135,7 +137,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAppUtilities.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +116,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleAppUtilities/pod_support/Headers/Public/GoogleAppUtilities/"
-  ] + [
-    "-fmodule-name=GoogleAppUtilities"
   ],
   visibility = [
     "//visibility:public"
@@ -137,8 +133,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAppUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -128,7 +130,8 @@ objc_library(
   data = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/Resources/GTMOAuth2ViewTouch.xib"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -147,7 +150,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -124,14 +122,11 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleAuthUtilities/pod_support/Headers/Public/GoogleAuthUtilities/"
-  ] + [
-    "-fmodule-name=GoogleAuthUtilities"
   ],
   data = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/Resources/GTMOAuth2ViewTouch.xib"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -150,8 +145,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -138,7 +140,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleNetworkingUtilities.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -121,8 +119,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleNetworkingUtilities/pod_support/Headers/Public/GoogleNetworkingUtilities/"
-  ] + [
-    "-fmodule-name=GoogleNetworkingUtilities"
   ],
   visibility = [
     "//visibility:public"
@@ -140,8 +136,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleNetworkingUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -67,7 +68,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -153,7 +155,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleSignIn.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(
@@ -166,7 +169,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleSignIn.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +67,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -130,8 +128,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleSignIn/pod_support/Headers/Public/GoogleSignIn/"
-  ] + [
-    "-fmodule-name=GoogleSignIn"
   ],
   data = [
     ":GoogleSignIn_Bundle_GoogleSignIn"
@@ -155,8 +151,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleSignIn.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -169,8 +164,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleSignIn.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -115,8 +113,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleSymbolUtilities/pod_support/Headers/Public/GoogleSymbolUtilities/"
-  ] + [
-    "-fmodule-name=GoogleSymbolUtilities"
   ],
   visibility = [
     "//visibility:public"
@@ -132,8 +128,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleSymbolUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -130,7 +132,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleSymbolUtilities.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -125,8 +123,6 @@ objc_library(
     }
   ) + [
     "-IVendor/GoogleUtilities/pod_support/Headers/Public/GoogleUtilities/"
-  ] + [
-    "-fmodule-name=GoogleUtilities"
   ],
   visibility = [
     "//visibility:public"
@@ -144,8 +140,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -142,7 +144,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleUtilities.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "IBActionSheet_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":IBActionSheet_hdrs"

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "IBActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":IBActionSheet_hdrs"
@@ -143,8 +125,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IBActionSheet/pod_support/Headers/Public/IBActionSheet/"
-  ] + [
-    "-fmodule-name=IBActionSheet"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -51,7 +51,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -71,7 +72,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Default_hdrs"
   ],
@@ -153,11 +155,19 @@ acknowledged_target(
 filegroup(
   name = "Diffing_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Common/**/*.h",
-      "Source/Common/Internal/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -171,7 +181,8 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -180,11 +191,19 @@ filegroup(
 filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Common/**/*.h",
-      "Source/Common/Internal/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -227,39 +246,79 @@ objc_library(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = [
-          "Source/Common/**/*.m",
-          "Source/**/*.mm",
-          "Source/**/*.m",
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/Common/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = [
-          "Source/Common/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/Common/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = [
-          "Source/Common/**/*.m",
-          "Source/**/*.mm",
-          "Source/**/*.m",
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/Common/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = [
-          "Source/Common/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/Common/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -317,11 +376,19 @@ acknowledged_target(
 filegroup(
   name = "Diffing_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Common/**/*.h",
-      "Source/Common/Internal/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -335,7 +402,8 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Diffing_cxx_public_hdrs"
   ],
@@ -346,11 +414,19 @@ filegroup(
 filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Common/**/*.h",
-      "Source/Common/Internal/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Common/**/*.h",
+        "Source/Common/Internal/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -396,31 +472,57 @@ objc_library(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = [
-          "Source/**/*.mm",
-          "Source/**/*.m",
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/**/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.m"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = [
-          "Source/**/*.mm",
-          "Source/**/*.m",
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/**/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -477,30 +579,48 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -519,7 +639,8 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -528,7 +649,8 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ) + [
@@ -543,30 +665,48 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -614,17 +754,25 @@ objc_library(
         [
           "Source/**/*.mm"
         ],
-        exclude = [
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.mm"
         ],
-        exclude = [
-          "Source/**/*.m"
-        ]
+        exclude = glob(
+          [
+            "Source/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -685,30 +833,48 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -727,7 +893,8 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -736,7 +903,8 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ) + [
@@ -752,30 +920,48 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Source/**/*.h",
-          "Source/Common/Internal/*.h",
-          "Source/Internal/*.h"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Source/**/*.h",
+            "Source/Common/Internal/*.h",
+            "Source/Internal/*.h"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -824,12 +1010,14 @@ objc_library(
       "//conditions:default": glob(
         [
           "Source/**/*.m"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.m"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -36,6 +36,7 @@ config_setting(
 filegroup(
   name = "IGListKit_package_hdrs",
   srcs = [
+    "IGListKit_cxx_direct_hdrs",
     "IGListKit_direct_hdrs",
     "Diffing_cxx_direct_hdrs",
     "Diffing_direct_hdrs",
@@ -47,12 +48,126 @@ filegroup(
   ]
 )
 filegroup(
+  name = "IGListKit_cxx_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "IGListKit_cxx_public_hdrs",
+  srcs = [
+    ":Default_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "IGListKit_cxx_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "IGListKit_cxx_union_hdrs",
+  srcs = [
+    "IGListKit_cxx_hdrs",
+    "IGListKit_hdrs",
+    ":Default_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "IGListKit_cxx_hmap",
+  namespace = "IGListKit",
+  hdrs = [
+    "IGListKit_package_hdrs",
+    ":IGListKit_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Default_hmap"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "IGListKit_cxx_includes",
+  include = [
+    "Vendor/IGListKit/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "IGListKit_cxx",
+  enable_modules = 0,
+  hdrs = [
+    ":IGListKit_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/IGListKit-prefix.pch",
+  sdk_frameworks = select(
+    {
+      "//conditions:default": [
+        "UIKit"
+      ],
+      ":osxCase": [
+        "Cocoa"
+      ],
+      ":tvosCase": [
+        "UIKit"
+      ]
+    }
+  ),
+  sdk_dylibs = [
+    "c++"
+  ],
+  deps = [
+    ":Default",
+    ":IGListKit_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14",
+    "-std=c++11",
+    "-stdlib=libc++"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "IGListKit_cxx_acknowledgement",
+  deps = [],
+  value = "//Vendor/IGListKit/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
   name = "IGListKit_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -61,7 +176,8 @@ filegroup(
 filegroup(
   name = "IGListKit_public_hdrs",
   srcs = [
-    ":Default_public_hdrs"
+    ":Default_public_hdrs",
+    ":IGListKit_cxx_public_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -72,10 +188,10 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
-    ":Default_hdrs"
+    ":Default_hdrs",
+    ":IGListKit_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -89,7 +205,8 @@ headermap(
     ":IGListKit_hdrs"
   ],
   deps = [
-    ":Default_hmap"
+    ":Default_hmap",
+    ":IGListKit_cxx_hmap"
   ],
   visibility = [
     "//visibility:public"
@@ -126,6 +243,7 @@ objc_library(
   ],
   deps = [
     ":Default",
+    ":IGListKit_cxx",
     ":IGListKit_includes"
   ],
   copts = select(
@@ -140,8 +258,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
-  ] + [
-    "-fmodule-name=IGListKit"
   ],
   visibility = [
     "//visibility:public"
@@ -155,19 +271,11 @@ acknowledged_target(
 filegroup(
   name = "Diffing_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -181,8 +289,7 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -191,19 +298,11 @@ filegroup(
 filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -246,79 +345,39 @@ objc_library(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m",
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m",
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m"
+        ]
       )
     }
   ),
@@ -361,8 +420,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
-  ] + [
-    "-fmodule-name=IGListKit"
   ],
   visibility = [
     "//visibility:public"
@@ -376,19 +433,11 @@ acknowledged_target(
 filegroup(
   name = "Diffing_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -402,8 +451,7 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Diffing_cxx_public_hdrs"
   ],
@@ -414,19 +462,11 @@ filegroup(
 filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -472,57 +512,31 @@ objc_library(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -562,8 +576,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
-  ] + [
-    "-fmodule-name=IGListKit"
   ],
   visibility = [
     "//visibility:public"
@@ -579,48 +591,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -639,8 +633,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -649,8 +642,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -665,48 +657,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -754,25 +728,17 @@ objc_library(
         [
           "Source/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.m"
+        ]
       )
     }
   ),
@@ -816,8 +782,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
-  ] + [
-    "-fmodule-name=IGListKit"
   ],
   visibility = [
     "//visibility:public"
@@ -833,48 +797,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -893,8 +839,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -903,8 +848,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -920,48 +864,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -1010,14 +936,12 @@ objc_library(
       "//conditions:default": glob(
         [
           "Source/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -1058,8 +982,6 @@ objc_library(
     }
   ) + [
     "-IVendor/IGListKit/pod_support/Headers/Public/IGListKit/"
-  ] + [
-    "-fmodule-name=IGListKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "KVOController_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBKVOController/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBKVOController/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "FBKVOController/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBKVOController/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBKVOController/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "FBKVOController/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":KVOController_hdrs"
@@ -140,8 +122,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KVOController/pod_support/Headers/Public/KVOController/"
-  ] + [
-    "-fmodule-name=KVOController"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "KVOController_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBKVOController/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBKVOController/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "FBKVOController/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBKVOController/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBKVOController/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "FBKVOController/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":KVOController_hdrs"

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -52,8 +52,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +75,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":KakaoLink_hdrs",
     ":KakaoNavi_hdrs",
@@ -141,8 +139,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
-  ] + [
-    "-fmodule-name=KakaoOpenSDK"
   ],
   visibility = [
     "//visibility:public"
@@ -158,8 +154,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -177,8 +172,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -239,8 +233,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
-  ] + [
-    "-fmodule-name=KakaoOpenSDK"
   ],
   visibility = [
     "//visibility:public"
@@ -256,8 +248,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoOpenSDK.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -273,8 +264,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -292,8 +282,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -353,8 +342,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
-  ] + [
-    "-fmodule-name=KakaoOpenSDK"
   ],
   visibility = [
     "//visibility:public"
@@ -370,8 +357,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoNavi.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -387,8 +373,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -406,8 +391,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -467,8 +451,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
-  ] + [
-    "-fmodule-name=KakaoOpenSDK"
   ],
   visibility = [
     "//visibility:public"
@@ -484,8 +466,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoLink.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -501,8 +482,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -520,8 +500,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -581,8 +560,6 @@ objc_library(
     }
   ) + [
     "-IVendor/KakaoOpenSDK/pod_support/Headers/Public/KakaoOpenSDK/"
-  ] + [
-    "-fmodule-name=KakaoOpenSDK"
   ],
   visibility = [
     "//visibility:public"
@@ -598,8 +575,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoS2.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -52,7 +52,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -75,7 +76,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":KakaoLink_hdrs",
     ":KakaoNavi_hdrs",
@@ -156,7 +158,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -174,7 +177,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -252,7 +256,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoOpenSDK.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -268,7 +273,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -286,7 +292,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -363,7 +370,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoNavi.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -379,7 +387,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -397,7 +406,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -474,7 +484,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoLink.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -490,7 +501,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -508,7 +520,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -585,7 +598,8 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoS2.framework/**"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "Masonry_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Masonry/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Masonry/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "Masonry/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Masonry/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Masonry/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "Masonry/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Masonry_hdrs"

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Masonry_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Masonry/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Masonry/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "Masonry/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Masonry/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Masonry/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "Masonry/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Masonry_hdrs"
@@ -156,8 +138,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Masonry/pod_support/Headers/Public/Masonry/"
-  ] + [
-    "-fmodule-name=Masonry"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -47,9 +47,12 @@ filegroup(
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "Sources/**/*.h"
       ],
@@ -57,8 +60,10 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,7 +74,8 @@ filegroup(
   srcs = glob(
     [
       "Sources/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Default_public_hdrs",
     ":Subspec_public_hdrs"
@@ -81,9 +87,12 @@ filegroup(
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "Sources/**/*.h"
       ],
@@ -91,8 +100,10 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":Default_hdrs",
     ":Subspec_hdrs"
@@ -138,7 +149,8 @@ objc_library(
       "Classes/Exclude/**/*.m",
       "Classes/Exclude/**/*.mm",
       "Classes/Exclude/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":ObjcParentWithSwiftSubspecs_hdrs"
@@ -178,7 +190,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -196,7 +209,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -269,7 +283,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -287,7 +302,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -1,3 +1,4 @@
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -44,15 +45,45 @@ filegroup(
     "//visibility:public"
   ]
 )
+swift_library(
+  name = "ObjcParentWithSwiftSubspecs_swift",
+  module_name = "ObjcParentWithSwiftSubspecs",
+  srcs = glob(
+    [
+      "Sources/**/*.swift",
+      "**/*.swift"
+    ]
+  ),
+  deps = [],
+  data = [],
+  copts = [
+    "-Xcc",
+    "-I.",
+    "-Xcc",
+    "-D__SWIFTC__",
+    "-Xfrontend",
+    "-no-clang-module-breadcrumbs",
+    "-Xcc",
+    "-fmodule-map-file=$(execpath ObjcParentWithSwiftSubspecs_module_map)",
+    "-import-underlying-module"
+  ],
+  swiftc_inputs = [
+    "ObjcParentWithSwiftSubspecs_module_map"
+  ],
+  generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
+  features = [
+    "swift.no_generated_module_map"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Sources/**/*.h"
       ],
@@ -60,10 +91,8 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +103,7 @@ filegroup(
   srcs = glob(
     [
       "Sources/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_public_hdrs",
     ":Subspec_public_hdrs"
@@ -87,12 +115,9 @@ filegroup(
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Sources/**/*.h"
       ],
@@ -100,10 +125,8 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ) + [
     ":Default_hdrs",
     ":Subspec_hdrs"
@@ -149,17 +172,19 @@ objc_library(
       "Classes/Exclude/**/*.m",
       "Classes/Exclude/**/*.mm",
       "Classes/Exclude/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
+  module_map = ":ObjcParentWithSwiftSubspecs_extended_module_map",
   hdrs = [
     ":ObjcParentWithSwiftSubspecs_hdrs"
   ],
   pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
   deps = [
     ":Default",
+    ":ObjcParentWithSwiftSubspecs_swift",
     ":Subspec",
-    ":ObjcParentWithSwiftSubspecs_includes"
+    ":ObjcParentWithSwiftSubspecs_includes",
+    ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = select(
     {
@@ -173,8 +198,6 @@ objc_library(
     }
   ) + [
     "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
-  ] + [
-    "-fmodule-name=ObjcParentWithSwiftSubspecs"
   ],
   visibility = [
     "//visibility:public"
@@ -185,13 +208,35 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/ObjcParentWithSwiftSubspecs/pod_support_buildable:acknowledgement_fragment"
 )
+gen_module_map(
+  name = "ObjcParentWithSwiftSubspecs_extended_module_map",
+  module_name = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_public_hdrs"
+  ],
+  swift_header = "../ObjcParentWithSwiftSubspecs-Swift.h",
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_module_map(
+  name = "ObjcParentWithSwiftSubspecs_module_map",
+  module_name = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_extended_module_map",
+    "ObjcParentWithSwiftSubspecs_public_hdrs"
+  ],
+  module_map_name = "ObjcParentWithSwiftSubspecs.modulemap",
+  visibility = [
+    "//visibility:public"
+  ]
+)
 filegroup(
   name = "Default_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -209,8 +254,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -247,12 +291,15 @@ gen_includes(
 objc_library(
   name = "Default",
   enable_modules = 0,
+  module_map = ":ObjcParentWithSwiftSubspecs_extended_module_map",
   hdrs = [
     ":Default_hdrs"
   ],
   pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
   deps = [
-    ":Default_includes"
+    ":ObjcParentWithSwiftSubspecs_swift",
+    ":Default_includes",
+    ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = select(
     {
@@ -266,8 +313,6 @@ objc_library(
     }
   ) + [
     "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
-  ] + [
-    "-fmodule-name=ObjcParentWithSwiftSubspecs"
   ],
   visibility = [
     "//visibility:public"
@@ -283,8 +328,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -302,8 +346,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -340,12 +383,15 @@ gen_includes(
 objc_library(
   name = "Subspec",
   enable_modules = 0,
+  module_map = ":ObjcParentWithSwiftSubspecs_extended_module_map",
   hdrs = [
     ":Subspec_hdrs"
   ],
   pch = "pod_support/Headers/Private/ObjcParentWithSwiftSubspecs-prefix.pch",
   deps = [
-    ":Subspec_includes"
+    ":ObjcParentWithSwiftSubspecs_swift",
+    ":Subspec_includes",
+    ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = select(
     {
@@ -359,8 +405,6 @@ objc_library(
     }
   ) + [
     "-IVendor/ObjcParentWithSwiftSubspecs/pod_support/Headers/Public/ObjcParentWithSwiftSubspecs/"
-  ] + [
-    "-fmodule-name=ObjcParentWithSwiftSubspecs"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -46,9 +46,12 @@ filegroup(
 filegroup(
   name = "OnePasswordExtension_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "*.h"
       ],
@@ -56,8 +59,10 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,7 +73,8 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -77,9 +83,12 @@ filegroup(
 filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "*.h"
       ],
@@ -87,8 +96,10 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -135,7 +146,8 @@ objc_library(
       "Demos/**/*.m",
       "Demos/**/*.mm",
       "Demos/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":1PasswordExtension_hdrs"
@@ -185,7 +197,8 @@ apple_resource_bundle(
     [
       "1Password.xcassets",
       "1Password.xcassets/*.imageset/*.png"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -46,12 +46,9 @@ filegroup(
 filegroup(
   name = "OnePasswordExtension_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "*.h"
       ],
@@ -59,10 +56,8 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,12 +77,9 @@ filegroup(
 filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "*.h"
       ],
@@ -96,10 +87,8 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -146,8 +135,7 @@ objc_library(
       "Demos/**/*.m",
       "Demos/**/*.mm",
       "Demos/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":1PasswordExtension_hdrs"
@@ -176,8 +164,6 @@ objc_library(
     }
   ) + [
     "-IVendor/OnePasswordExtension/pod_support/Headers/Public/OnePasswordExtension/"
-  ] + [
-    "-fmodule-name=OnePasswordExtension"
   ],
   data = [
     ":OnePasswordExtension_Bundle_OnePasswordExtensionResources"
@@ -197,8 +183,7 @@ apple_resource_bundle(
     [
       "1Password.xcassets",
       "1Password.xcassets/*.imageset/*.png"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -70,7 +71,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Arc-exception-safe_hdrs",
     ":Core_hdrs"
@@ -152,10 +154,18 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -166,7 +176,8 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -175,10 +186,18 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -221,9 +240,13 @@ objc_library(
     [
       "Source/*.m"
     ],
-    exclude = [
-      "Source/PINDiskCache.m"
-    ]
+    exclude = glob(
+      [
+        "Source/PINDiskCache.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -277,7 +300,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -297,7 +321,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -340,7 +365,8 @@ objc_library(
   srcs = glob(
     [
       "Source/PINDiskCache.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Arc-exception-safe_hdrs"

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Arc-exception-safe_hdrs",
     ":Core_hdrs"
@@ -139,8 +137,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
-  ] + [
-    "-fmodule-name=PINCache"
   ],
   visibility = [
     "//visibility:public"
@@ -154,18 +150,10 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -176,8 +164,7 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -186,18 +173,10 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -240,13 +219,9 @@ objc_library(
     [
       "Source/*.m"
     ],
-    exclude = glob(
-      [
-        "Source/PINDiskCache.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Source/PINDiskCache.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -281,8 +256,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
-  ] + [
-    "-fmodule-name=PINCache"
   ],
   visibility = [
     "//visibility:public"
@@ -300,8 +273,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -321,8 +293,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -365,8 +336,7 @@ objc_library(
   srcs = glob(
     [
       "Source/PINDiskCache.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Arc-exception-safe_hdrs"
@@ -403,8 +373,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINCache/pod_support/Headers/Public/PINCache/"
-  ] + [
-    "-fmodule-name=PINCache"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -46,18 +46,10 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,18 +69,10 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -130,13 +113,9 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "Source/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Source/**/*.m"
+    ]
   ),
   hdrs = [
     ":PINOperation_cxx_hdrs"
@@ -162,8 +141,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINOperation/pod_support/Headers/Public/PINOperation/"
-  ] + [
-    "-fmodule-name=PINOperation"
   ],
   visibility = [
     "//visibility:public"
@@ -177,18 +154,10 @@ acknowledged_target(
 filegroup(
   name = "PINOperation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -199,8 +168,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":PINOperation_cxx_public_hdrs"
   ],
@@ -211,18 +179,10 @@ filegroup(
 filegroup(
   name = "PINOperation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ) + [
     ":PINOperation_cxx_hdrs"
   ],
@@ -256,8 +216,7 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PINOperation_hdrs"
@@ -282,8 +241,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINOperation/pod_support/Headers/Public/PINOperation/"
-  ] + [
-    "-fmodule-name=PINOperation"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -46,10 +46,18 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -60,7 +68,8 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,10 +78,18 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -113,9 +130,13 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = [
-      "Source/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "Source/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":PINOperation_cxx_hdrs"
@@ -156,10 +177,18 @@ acknowledged_target(
 filegroup(
   name = "PINOperation_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -170,7 +199,8 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":PINOperation_cxx_public_hdrs"
   ],
@@ -181,10 +211,18 @@ filegroup(
 filegroup(
   name = "PINOperation_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":PINOperation_cxx_hdrs"
   ],
@@ -218,7 +256,8 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":PINOperation_hdrs"

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -54,7 +54,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -75,7 +76,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":FLAnimatedImage_hdrs",
     ":PINCache_hdrs"
@@ -144,17 +146,22 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -165,7 +172,8 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -174,17 +182,22 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -229,10 +242,19 @@ objc_library(
     ],
     exclude = [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
-      "Source/Classes/PINCache/*.m",
-      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
       "Source/Classes/PINCache/*.m"
-    ]
+    ] + glob(
+      [
+        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/PINCache/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -277,7 +299,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -297,7 +320,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -377,7 +401,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -397,7 +422,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -478,7 +504,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -498,7 +525,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -573,10 +601,18 @@ acknowledged_target(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -587,7 +623,8 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -598,10 +635,18 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -645,7 +690,8 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
@@ -687,7 +733,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -707,7 +754,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -788,10 +836,18 @@ acknowledged_target(
 filegroup(
   name = "PINCache_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Classes/PINCache/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/PINCache/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -802,7 +858,8 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -813,10 +870,18 @@ filegroup(
 filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/Classes/PINCache/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/Classes/PINCache/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -860,7 +925,8 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":PINCache_hdrs"

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -54,8 +54,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +75,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":FLAnimatedImage_hdrs",
     ":PINCache_hdrs"
@@ -131,8 +129,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -146,22 +142,17 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -172,8 +163,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -182,22 +172,17 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -242,19 +227,10 @@ objc_library(
     ],
     exclude = [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
+      "Source/Classes/PINCache/*.m",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
       "Source/Classes/PINCache/*.m"
-    ] + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -280,8 +256,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -299,8 +273,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -320,8 +293,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -384,8 +356,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -401,8 +371,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -422,8 +391,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -487,8 +455,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -504,8 +470,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -525,8 +490,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -586,8 +550,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -601,18 +563,10 @@ acknowledged_target(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -623,8 +577,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -635,18 +588,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -690,8 +635,7 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
@@ -714,8 +658,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -733,8 +675,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -754,8 +695,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -819,8 +759,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"
@@ -836,18 +774,10 @@ acknowledged_target(
 filegroup(
   name = "PINCache_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/PINCache/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -858,8 +788,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -870,18 +799,10 @@ filegroup(
 filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/PINCache/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -925,8 +846,7 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PINCache_hdrs"
@@ -949,8 +869,6 @@ objc_library(
     }
   ) + [
     "-IVendor/PINRemoteImage/pod_support/Headers/Public/PINRemoteImage/"
-  ] + [
-    "-fmodule-name=PINRemoteImage"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "PaymentKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PaymentKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PaymentKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "PaymentKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PaymentKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PaymentKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "PaymentKit/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PaymentKit_hdrs"
@@ -140,15 +122,12 @@ objc_library(
     }
   ) + [
     "-IVendor/PaymentKit/pod_support/Headers/Public/PaymentKit/"
-  ] + [
-    "-fmodule-name=PaymentKit"
   ],
   data = glob(
     [
       "PaymentKit/Resources/*.png",
       "PaymentKit/Resources/Cards/*.png"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "PaymentKit_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "PaymentKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PaymentKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "PaymentKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "PaymentKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PaymentKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "PaymentKit/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":PaymentKit_hdrs"
@@ -129,7 +147,8 @@ objc_library(
     [
       "PaymentKit/Resources/*.png",
       "PaymentKit/Resources/Cards/*.png"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "RadarKit_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "RadarKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "RadarKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "RadarKit/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "RadarKit/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "RadarKit/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "RadarKit/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RadarKit_hdrs"

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "RadarKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "RadarKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "RadarKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "RadarKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "RadarKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "RadarKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "RadarKit/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RadarKit_hdrs"
@@ -144,8 +126,6 @@ objc_library(
     }
   ) + [
     "-IVendor/RadarKit/pod_support/Headers/Public/RadarKit/"
-  ] + [
-    "-fmodule-name=RadarKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -91,7 +91,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -111,7 +112,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_hdrs"
   ],
@@ -179,9 +181,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -210,13 +215,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -242,13 +252,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -295,13 +310,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -327,8 +347,10 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -341,7 +363,8 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -352,9 +375,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -383,13 +409,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -415,13 +446,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -468,13 +504,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -500,8 +541,10 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -686,30 +729,43 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ]
-        ) + [
-          "React/Cxx*/*.mm"
-        ] + [
-          "React/Cxx*/*.m"
-        ] + [
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm"
-        ] + [
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
-        ] + glob(
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -723,7 +779,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -739,46 +796,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -905,30 +1018,43 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ]
-        ) + [
-          "React/Cxx*/*.mm"
-        ] + [
-          "React/Cxx*/*.m"
-        ] + [
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm"
-        ] + [
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
-        ] + glob(
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -942,7 +1068,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -958,46 +1085,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -1236,30 +1419,43 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ]
-        ) + [
-          "React/Cxx*/*.mm"
-        ] + [
-          "React/Cxx*/*.m"
-        ] + [
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm"
-        ] + [
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
-        ] + glob(
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1273,7 +1469,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1289,46 +1486,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -1455,30 +1708,43 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ]
-        ) + [
-          "React/Cxx*/*.mm"
-        ] + [
-          "React/Cxx*/*.m"
-        ] + [
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm"
-        ] + [
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
-        ] + glob(
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1492,7 +1758,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1508,46 +1775,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -1598,9 +1921,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1629,13 +1955,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1661,13 +1992,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1714,13 +2050,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1746,8 +2087,10 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -1760,7 +2103,8 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -1773,9 +2117,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1804,13 +2151,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1836,13 +2188,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1889,13 +2246,18 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/**/*.h"
           ],
@@ -1921,8 +2283,10 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -2038,26 +2402,42 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s",
-          "React/Cxx*/*.mm",
-          "React/Cxx*/*.m",
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm",
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
+          "ReactCommon/yoga/*.s"
         ] + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2071,7 +2451,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2087,46 +2468,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -2190,26 +2627,42 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s",
-          "React/Cxx*/*.mm",
-          "React/Cxx*/*.m",
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm",
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
+          "ReactCommon/yoga/*.s"
         ] + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2223,7 +2676,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2239,46 +2693,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -2398,26 +2908,42 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s",
-          "React/Cxx*/*.mm",
-          "React/Cxx*/*.m",
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm",
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
+          "ReactCommon/yoga/*.s"
         ] + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2431,7 +2957,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2447,46 +2974,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -2550,26 +3133,42 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s",
-          "React/Cxx*/*.mm",
-          "React/Cxx*/*.m",
-          "React/DevSupport/*.cc",
-          "React/DevSupport/*.cpp",
-          "React/DevSupport/*.cxx",
-          "React/DevSupport/*.mm",
-          "React/Inspector/*.cc",
-          "React/Inspector/*.cpp",
-          "React/Inspector/*.cxx",
-          "React/Inspector/*.mm",
-          "React/DevSupport/*.S",
-          "React/DevSupport/*.c",
-          "React/DevSupport/*.m",
-          "React/DevSupport/*.s",
-          "React/Inspector/*.S",
-          "React/Inspector/*.c",
-          "React/Inspector/*.m",
-          "React/Inspector/*.s"
+          "ReactCommon/yoga/*.s"
         ] + glob(
+          [
+            "React/Cxx*/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/Cxx*/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.cc",
+            "React/DevSupport/*.cpp",
+            "React/DevSupport/*.cxx",
+            "React/DevSupport/*.mm",
+            "React/Inspector/*.cc",
+            "React/Inspector/*.cpp",
+            "React/Inspector/*.cxx",
+            "React/Inspector/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/DevSupport/*.S",
+            "React/DevSupport/*.c",
+            "React/DevSupport/*.m",
+            "React/DevSupport/*.s",
+            "React/Inspector/*.S",
+            "React/Inspector/*.c",
+            "React/Inspector/*.m",
+            "React/Inspector/*.s"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2583,7 +3182,8 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
+          ],
+          exclude_directories = 1
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2599,46 +3199,102 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ]
-        ) + [
-          "React/**/RCTTV*.m"
-        ] + [
-          "Libraries/ART/**/*.m"
-        ] + [
-          "Libraries/ActionSheetIOS/*.m"
-        ] + [
-          "Libraries/NativeAnimation/*.m",
-          "Libraries/NativeAnimation/Drivers/*.m",
-          "Libraries/NativeAnimation/Nodes/*.m"
-        ] + [
-          "Libraries/Blob/*.mm"
-        ] + [
-          "Libraries/Blob/*.m"
-        ] + [
-          "Libraries/CameraRoll/*.m"
-        ] + [
-          "Libraries/Geolocation/*.m"
-        ] + [
-          "Libraries/Image/*.m"
-        ] + [
-          "Libraries/Network/*.mm"
-        ] + [
-          "Libraries/Network/*.m"
-        ] + [
-          "Libraries/PushNotificationIOS/*.m"
-        ] + [
-          "Libraries/Settings/*.m"
-        ] + [
-          "Libraries/Text/**/*.m"
-        ] + [
-          "Libraries/Vibration/*.m"
-        ] + [
-          "Libraries/WebSocket/*.m"
-        ] + [
-          "Libraries/LinkingIOS/*.m"
-        ] + [
-          "Libraries/RCTTest/**/*.m"
-        ]
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "React/**/RCTTV*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ART/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/ActionSheetIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/NativeAnimation/*.m",
+            "Libraries/NativeAnimation/Drivers/*.m",
+            "Libraries/NativeAnimation/Nodes/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Blob/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/CameraRoll/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Geolocation/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Image/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.mm"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Network/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/PushNotificationIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Settings/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Text/**/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/Vibration/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/WebSocket/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/LinkingIOS/*.m"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Libraries/RCTTest/**/*.m"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -2686,10 +3342,18 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/Cxx*/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2708,10 +3372,18 @@ filegroup(
 filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/Cxx*/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2758,9 +3430,13 @@ objc_library(
     [
       "React/Cxx*/*.mm"
     ],
-    exclude = [
-      "React/Cxx*/*.m"
-    ]
+    exclude = glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":CxxBridge_cxx_hdrs"
@@ -2805,10 +3481,18 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/Cxx*/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2828,10 +3512,18 @@ filegroup(
 filegroup(
   name = "CxxBridge_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/Cxx*/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2879,7 +3571,8 @@ objc_library(
   srcs = glob(
     [
       "React/Cxx*/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":CxxBridge_hdrs"
@@ -2923,15 +3616,23 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -2947,7 +3648,8 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTWebSocket_public_hdrs"
@@ -2959,15 +3661,23 @@ filegroup(
 filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3020,16 +3730,20 @@ objc_library(
       "React/Inspector/*.cxx",
       "React/Inspector/*.mm"
     ],
-    exclude = [
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s"
-    ]
+    exclude = glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
@@ -3071,15 +3785,23 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3095,7 +3817,8 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":DevSupport_cxx_public_hdrs",
@@ -3108,15 +3831,23 @@ filegroup(
 filegroup(
   name = "DevSupport_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/DevSupport/*.h",
-      "React/DevSupport/*.hpp",
-      "React/DevSupport/*.hxx",
-      "React/Inspector/*.h",
-      "React/Inspector/*.hpp",
-      "React/Inspector/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.h",
+        "React/DevSupport/*.hpp",
+        "React/DevSupport/*.hxx",
+        "React/Inspector/*.h",
+        "React/Inspector/*.hpp",
+        "React/Inspector/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3170,7 +3901,8 @@ objc_library(
       "React/Inspector/*.c",
       "React/Inspector/*.m",
       "React/Inspector/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
@@ -3210,9 +3942,12 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3220,8 +3955,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3232,7 +3969,8 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":fabric_public_hdrs"
@@ -3244,9 +3982,12 @@ filegroup(
 filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3254,8 +3995,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3328,8 +4071,10 @@ objc_library(
         "**/tests/*.m",
         "**/tests/*.mm",
         "**/tests/*.s"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTFabric_cxx_hdrs"
@@ -3376,9 +4121,12 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3386,8 +4134,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3398,7 +4148,8 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTFabric_cxx_public_hdrs",
@@ -3411,9 +4162,12 @@ filegroup(
 filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3421,8 +4175,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3483,7 +4239,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTFabric_hdrs"
@@ -3530,10 +4287,18 @@ acknowledged_target(
 filegroup(
   name = "tvOS_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/**/RCTTV*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/**/RCTTV*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3544,7 +4309,8 @@ filegroup(
   srcs = glob(
     [
       "React/**/RCTTV*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -3555,10 +4321,18 @@ filegroup(
 filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "React/**/RCTTV*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/**/RCTTV*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3601,7 +4375,8 @@ objc_library(
   srcs = glob(
     [
       "React/**/RCTTV*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":tvOS_hdrs"
@@ -3638,10 +4413,18 @@ acknowledged_target(
 filegroup(
   name = "jschelpers_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/jschelpers/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jschelpers/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3659,10 +4442,18 @@ filegroup(
 filegroup(
   name = "jschelpers_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/jschelpers/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jschelpers/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3721,14 +4512,25 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ]
-    ) + [
-      "React/Cxx*/*.mm"
-    ] + [
-      "React/Cxx*/*.m"
-    ] + [
-      "React/Cxx*/*.m"
-    ]
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":jschelpers_hdrs"
@@ -3774,10 +4576,18 @@ acknowledged_target(
 filegroup(
   name = "jsinspector_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/jsinspector/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jsinspector/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3793,10 +4603,18 @@ filegroup(
 filegroup(
   name = "jsinspector_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/jsinspector/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/jsinspector/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3851,14 +4669,25 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ]
-    ) + [
-      "React/Cxx*/*.mm"
-    ] + [
-      "React/Cxx*/*.m"
-    ] + [
-      "React/Cxx*/*.m"
-    ]
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":jsinspector_hdrs"
@@ -3896,10 +4725,18 @@ acknowledged_target(
 filegroup(
   name = "PrivateDatabase_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/privatedata/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/privatedata/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3915,10 +4752,18 @@ filegroup(
 filegroup(
   name = "PrivateDatabase_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "ReactCommon/privatedata/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "ReactCommon/privatedata/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -3960,9 +4805,12 @@ objc_library(
     [
       "ReactCommon/privatedata/*.cpp"
     ],
-    exclude = [
-      "ReactCommon/jschelpers/*.cpp"
-    ] + glob(
+    exclude = glob(
+      [
+        "ReactCommon/jschelpers/*.cpp"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/cxxreact/*.cpp"
       ],
@@ -3975,14 +4823,25 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ]
-    ) + [
-      "React/Cxx*/*.mm"
-    ] + [
-      "React/Cxx*/*.m"
-    ] + [
-      "React/Cxx*/*.m"
-    ]
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":PrivateDatabase_hdrs"
@@ -4020,9 +4879,12 @@ acknowledged_target(
 filegroup(
   name = "cxxreact_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4030,8 +4892,10 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4050,9 +4914,12 @@ filegroup(
 filegroup(
   name = "cxxreact_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4060,8 +4927,10 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4121,11 +4990,24 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.cxx",
       "ReactCommon/cxxreact/SampleCxxModule.m",
       "ReactCommon/cxxreact/SampleCxxModule.mm",
-      "ReactCommon/cxxreact/SampleCxxModule.s",
-      "React/Cxx*/*.mm",
-      "React/Cxx*/*.m",
-      "React/Cxx*/*.m"
-    ]
+      "ReactCommon/cxxreact/SampleCxxModule.s"
+    ] + glob(
+      [
+        "React/Cxx*/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/Cxx*/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":cxxreact_hdrs"
@@ -4173,7 +5055,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4191,7 +5074,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4262,9 +5146,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_activityindicator_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -4272,8 +5159,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4284,7 +5173,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/activityindicator/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4293,9 +5183,12 @@ filegroup(
 filegroup(
   name = "fabric_activityindicator_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -4303,8 +5196,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4358,7 +5253,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_activityindicator_hdrs"
@@ -4400,9 +5296,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_attributedstring_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -4410,8 +5309,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4422,7 +5323,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/attributedstring/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4431,9 +5333,12 @@ filegroup(
 filegroup(
   name = "fabric_attributedstring_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -4441,8 +5346,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4496,7 +5403,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_attributedstring_hdrs"
@@ -4538,9 +5446,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -4548,8 +5459,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4560,7 +5473,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/core/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4569,9 +5483,12 @@ filegroup(
 filegroup(
   name = "fabric_core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -4579,8 +5496,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4634,7 +5553,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_core_hdrs"
@@ -4676,9 +5596,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_debug_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -4686,8 +5609,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4698,7 +5623,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/debug/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4707,9 +5633,12 @@ filegroup(
 filegroup(
   name = "fabric_debug_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -4717,8 +5646,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4772,7 +5703,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_debug_hdrs"
@@ -4814,9 +5746,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_graphics_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -4824,8 +5759,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4836,7 +5773,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/graphics/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4845,9 +5783,12 @@ filegroup(
 filegroup(
   name = "fabric_graphics_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -4855,8 +5796,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4910,7 +5853,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_graphics_hdrs"
@@ -4952,9 +5896,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_scrollview_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -4962,8 +5909,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4974,7 +5923,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/scrollview/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -4983,9 +5933,12 @@ filegroup(
 filegroup(
   name = "fabric_scrollview_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -4993,8 +5946,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5048,7 +6003,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_scrollview_hdrs"
@@ -5090,9 +6046,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_text_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -5100,8 +6059,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5112,7 +6073,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/text/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5121,9 +6083,12 @@ filegroup(
 filegroup(
   name = "fabric_text_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -5131,8 +6096,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5186,7 +6153,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_text_hdrs"
@@ -5228,9 +6196,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_textlayoutmanager_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -5238,8 +6209,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5250,7 +6223,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/textlayoutmanager/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5259,9 +6233,12 @@ filegroup(
 filegroup(
   name = "fabric_textlayoutmanager_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -5269,8 +6246,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5325,7 +6304,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_textlayoutmanager_hdrs"
@@ -5367,9 +6347,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_uimanager_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -5377,8 +6360,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5389,7 +6374,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/uimanager/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5398,9 +6384,12 @@ filegroup(
 filegroup(
   name = "fabric_uimanager_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -5408,8 +6397,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5463,7 +6454,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_uimanager_hdrs"
@@ -5505,9 +6497,12 @@ acknowledged_target(
 filegroup(
   name = "fabric_view_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -5515,8 +6510,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5527,7 +6524,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/view/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5536,9 +6534,12 @@ filegroup(
 filegroup(
   name = "fabric_view_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -5546,8 +6547,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5602,7 +6605,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":fabric_view_hdrs"
@@ -5646,9 +6650,12 @@ acknowledged_target(
 filegroup(
   name = "RCTFabricSample_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -5656,8 +6663,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5668,7 +6677,8 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/sample/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5677,9 +6687,12 @@ filegroup(
 filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -5687,8 +6700,10 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5742,7 +6757,8 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTFabricSample_hdrs"
@@ -5784,10 +6800,18 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ART/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5798,7 +6822,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -5809,10 +6834,18 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ART/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5855,7 +6888,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":ART_hdrs"
@@ -5892,10 +6926,18 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ActionSheetIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5906,7 +6948,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -5917,10 +6960,18 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ActionSheetIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -5963,7 +7014,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -6000,12 +7052,20 @@ acknowledged_target(
 filegroup(
   name = "RCTAnimation_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/NativeAnimation/*.h",
-      "Libraries/NativeAnimation/Drivers/*.h",
-      "Libraries/NativeAnimation/Nodes/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/NativeAnimation/*.h",
+        "Libraries/NativeAnimation/Drivers/*.h",
+        "Libraries/NativeAnimation/Nodes/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6018,7 +7078,8 @@ filegroup(
       "Libraries/NativeAnimation/*.h",
       "Libraries/NativeAnimation/Drivers/*.h",
       "Libraries/NativeAnimation/Nodes/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6029,12 +7090,20 @@ filegroup(
 filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/NativeAnimation/*.h",
-      "Libraries/NativeAnimation/Drivers/*.h",
-      "Libraries/NativeAnimation/Nodes/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/NativeAnimation/*.h",
+        "Libraries/NativeAnimation/Drivers/*.h",
+        "Libraries/NativeAnimation/Nodes/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6079,7 +7148,8 @@ objc_library(
       "Libraries/NativeAnimation/*.m",
       "Libraries/NativeAnimation/Drivers/*.m",
       "Libraries/NativeAnimation/Nodes/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTAnimation_hdrs"
@@ -6116,10 +7186,18 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Blob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6130,7 +7208,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6141,10 +7220,18 @@ filegroup(
 filegroup(
   name = "RCTBlob_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Blob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6188,34 +7275,54 @@ objc_library(
     [
       "Libraries/Blob/*.mm"
     ],
-    exclude = [
-      "Libraries/Blob/*.m",
-      "Libraries/WebSocket/*.m",
-      "React/DevSupport/*.cc",
-      "React/DevSupport/*.cpp",
-      "React/DevSupport/*.cxx",
-      "React/DevSupport/*.mm",
-      "React/Inspector/*.cc",
-      "React/Inspector/*.cpp",
-      "React/Inspector/*.cxx",
-      "React/Inspector/*.mm",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s"
-    ]
+    exclude = glob(
+      [
+        "Libraries/Blob/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.cc",
+        "React/DevSupport/*.cpp",
+        "React/DevSupport/*.cxx",
+        "React/DevSupport/*.mm",
+        "React/Inspector/*.cc",
+        "React/Inspector/*.cpp",
+        "React/Inspector/*.cxx",
+        "React/Inspector/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTBlob_cxx_hdrs"
@@ -6255,10 +7362,18 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Blob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6269,7 +7384,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_cxx_public_hdrs"
@@ -6281,10 +7397,18 @@ filegroup(
 filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Blob/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Blob/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6330,33 +7454,49 @@ objc_library(
     [
       "Libraries/Blob/*.m"
     ],
-    exclude = [
-      "Libraries/WebSocket/*.m",
-      "React/DevSupport/*.cc",
-      "React/DevSupport/*.cpp",
-      "React/DevSupport/*.cxx",
-      "React/DevSupport/*.mm",
-      "React/Inspector/*.cc",
-      "React/Inspector/*.cpp",
-      "React/Inspector/*.cxx",
-      "React/Inspector/*.mm",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s"
-    ]
+    exclude = glob(
+      [
+        "Libraries/WebSocket/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.cc",
+        "React/DevSupport/*.cpp",
+        "React/DevSupport/*.cxx",
+        "React/DevSupport/*.mm",
+        "React/Inspector/*.cc",
+        "React/Inspector/*.cpp",
+        "React/Inspector/*.cxx",
+        "React/Inspector/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTBlob_hdrs"
@@ -6394,10 +7534,18 @@ acknowledged_target(
 filegroup(
   name = "RCTCameraRoll_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/CameraRoll/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/CameraRoll/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6408,7 +7556,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTImage_public_hdrs"
@@ -6420,10 +7569,18 @@ filegroup(
 filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/CameraRoll/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/CameraRoll/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6468,7 +7625,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTCameraRoll_hdrs"
@@ -6506,10 +7664,18 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Geolocation/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6520,7 +7686,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6531,10 +7698,18 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Geolocation/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6577,7 +7752,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -6614,10 +7790,18 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Image/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6628,7 +7812,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_public_hdrs"
@@ -6640,10 +7825,18 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Image/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6689,9 +7882,13 @@ objc_library(
     [
       "Libraries/Image/*.m"
     ],
-    exclude = [
-      "Libraries/CameraRoll/*.m"
-    ]
+    exclude = glob(
+      [
+        "Libraries/CameraRoll/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -6729,10 +7926,18 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6743,7 +7948,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6754,10 +7960,18 @@ filegroup(
 filegroup(
   name = "RCTNetwork_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6801,11 +8015,23 @@ objc_library(
     [
       "Libraries/Network/*.mm"
     ],
-    exclude = [
-      "Libraries/Network/*.m",
-      "Libraries/Image/*.m",
-      "Libraries/CameraRoll/*.m"
-    ]
+    exclude = glob(
+      [
+        "Libraries/Network/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/CameraRoll/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTNetwork_cxx_hdrs"
@@ -6845,10 +8071,18 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6859,7 +8093,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_cxx_public_hdrs"
@@ -6871,10 +8106,18 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6920,10 +8163,18 @@ objc_library(
     [
       "Libraries/Network/*.m"
     ],
-    exclude = [
-      "Libraries/Image/*.m",
-      "Libraries/CameraRoll/*.m"
-    ]
+    exclude = glob(
+      [
+        "Libraries/Image/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/CameraRoll/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -6961,10 +8212,18 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/PushNotificationIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -6975,7 +8234,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6986,10 +8246,18 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/PushNotificationIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7032,7 +8300,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -7069,10 +8338,18 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Settings/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7083,7 +8360,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7094,10 +8372,18 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Settings/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7140,7 +8426,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -7177,10 +8464,18 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Text/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7191,7 +8486,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7202,10 +8498,18 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Text/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7248,7 +8552,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -7285,10 +8590,18 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Vibration/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7299,7 +8612,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7310,10 +8624,18 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Vibration/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7356,7 +8678,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -7393,10 +8716,18 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/WebSocket/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7407,7 +8738,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_public_hdrs",
@@ -7420,10 +8752,18 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/WebSocket/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7471,32 +8811,44 @@ objc_library(
     [
       "Libraries/WebSocket/*.m"
     ],
-    exclude = [
-      "React/DevSupport/*.cc",
-      "React/DevSupport/*.cpp",
-      "React/DevSupport/*.cxx",
-      "React/DevSupport/*.mm",
-      "React/Inspector/*.cc",
-      "React/Inspector/*.cpp",
-      "React/Inspector/*.cxx",
-      "React/Inspector/*.mm",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s"
-    ]
+    exclude = glob(
+      [
+        "React/DevSupport/*.cc",
+        "React/DevSupport/*.cpp",
+        "React/DevSupport/*.cxx",
+        "React/DevSupport/*.mm",
+        "React/Inspector/*.cc",
+        "React/Inspector/*.cpp",
+        "React/Inspector/*.cxx",
+        "React/Inspector/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -7535,10 +8887,18 @@ acknowledged_target(
 filegroup(
   name = "fishhook_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/fishhook/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/fishhook/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7549,7 +8909,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/fishhook/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7558,10 +8919,18 @@ filegroup(
 filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/fishhook/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/fishhook/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7602,33 +8971,49 @@ objc_library(
     [
       "Libraries/fishhook/*.c"
     ],
-    exclude = [
-      "Libraries/WebSocket/*.m",
-      "React/DevSupport/*.cc",
-      "React/DevSupport/*.cpp",
-      "React/DevSupport/*.cxx",
-      "React/DevSupport/*.mm",
-      "React/Inspector/*.cc",
-      "React/Inspector/*.cpp",
-      "React/Inspector/*.cxx",
-      "React/Inspector/*.mm",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s",
-      "React/DevSupport/*.S",
-      "React/DevSupport/*.c",
-      "React/DevSupport/*.m",
-      "React/DevSupport/*.s",
-      "React/Inspector/*.S",
-      "React/Inspector/*.c",
-      "React/Inspector/*.m",
-      "React/Inspector/*.s"
-    ]
+    exclude = glob(
+      [
+        "Libraries/WebSocket/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.cc",
+        "React/DevSupport/*.cpp",
+        "React/DevSupport/*.cxx",
+        "React/DevSupport/*.mm",
+        "React/Inspector/*.cc",
+        "React/Inspector/*.cpp",
+        "React/Inspector/*.cxx",
+        "React/Inspector/*.mm"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "React/DevSupport/*.S",
+        "React/DevSupport/*.c",
+        "React/DevSupport/*.m",
+        "React/DevSupport/*.s",
+        "React/Inspector/*.S",
+        "React/Inspector/*.c",
+        "React/Inspector/*.m",
+        "React/Inspector/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":fishhook_hdrs"
@@ -7664,10 +9049,18 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/LinkingIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7678,7 +9071,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7689,10 +9083,18 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/LinkingIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7735,7 +9137,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"
@@ -7772,10 +9175,18 @@ acknowledged_target(
 filegroup(
   name = "RCTTest_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/RCTTest/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/RCTTest/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7786,7 +9197,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7797,10 +9209,18 @@ filegroup(
 filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/RCTTest/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/RCTTest/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7843,7 +9263,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTTest_hdrs"
@@ -7885,7 +9306,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -7906,7 +9328,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -36,6 +36,7 @@ config_setting(
 filegroup(
   name = "React_package_hdrs",
   srcs = [
+    "React_cxx_direct_hdrs",
     "React_direct_hdrs",
     "Core_cxx_direct_hdrs",
     "Core_direct_hdrs",
@@ -87,12 +88,109 @@ filegroup(
   ]
 )
 filegroup(
+  name = "React_cxx_direct_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_cxx_public_hdrs",
+  srcs = [
+    ":Core_public_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_cxx_hdrs",
+  srcs = glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ]
+  ),
+  visibility = [
+    "//visibility:public"
+  ]
+)
+filegroup(
+  name = "React_cxx_union_hdrs",
+  srcs = [
+    "React_cxx_hdrs",
+    "React_hdrs",
+    ":Core_hdrs"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+headermap(
+  name = "React_cxx_hmap",
+  namespace = "React",
+  hdrs = [
+    "React_package_hdrs",
+    ":React_cxx_union_hdrs"
+  ],
+  deps = [
+    ":Core_hmap"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+gen_includes(
+  name = "React_cxx_includes",
+  include = [
+    "Vendor/React/pod_support/Headers/Public/"
+  ]
+)
+objc_library(
+  name = "React_cxx",
+  enable_modules = 0,
+  hdrs = [
+    ":React_cxx_hdrs"
+  ],
+  pch = "pod_support/Headers/Private/React-prefix.pch",
+  deps = [
+    ":Core",
+    ":React_cxx_includes"
+  ],
+  copts = [
+    "-std=c++14",
+    "-std=c++14"
+  ] + select(
+    {
+      "//conditions:default": [
+        "-DPOD_CONFIGURATION_RELEASE=0"
+      ],
+      ":release": [
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
+      ]
+    }
+  ) + [
+    "-IVendor/React/pod_support/Headers/Public/React/"
+  ],
+  visibility = [
+    "//visibility:public"
+  ]
+)
+acknowledged_target(
+  name = "React_cxx_acknowledgement",
+  deps = [],
+  value = "//Vendor/React/pod_support_buildable:acknowledgement_fragment"
+)
+filegroup(
   name = "React_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +199,8 @@ filegroup(
 filegroup(
   name = "React_public_hdrs",
   srcs = [
-    ":Core_public_hdrs"
+    ":Core_public_hdrs",
+    ":React_cxx_public_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -112,10 +211,10 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
-    ":Core_hdrs"
+    ":Core_hdrs",
+    ":React_cxx_hdrs"
   ],
   visibility = [
     "//visibility:public"
@@ -129,7 +228,8 @@ headermap(
     ":React_hdrs"
   ],
   deps = [
-    ":Core_hmap"
+    ":Core_hmap",
+    ":React_cxx_hmap"
   ],
   visibility = [
     "//visibility:public"
@@ -150,6 +250,7 @@ objc_library(
   pch = "pod_support/Headers/Private/React-prefix.pch",
   deps = [
     ":Core",
+    ":React_cxx",
     ":React_includes"
   ],
   copts = select(
@@ -164,8 +265,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -181,12 +280,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -215,18 +311,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -252,18 +343,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -310,18 +396,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -347,10 +428,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -363,8 +442,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -375,12 +453,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -409,18 +484,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -446,18 +516,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -504,18 +569,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -541,10 +601,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -729,43 +787,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -779,8 +824,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -796,102 +840,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
@@ -1018,43 +1006,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1068,8 +1043,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1085,102 +1059,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -1419,43 +1337,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1469,8 +1374,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1486,102 +1390,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -1708,43 +1556,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1758,8 +1593,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1775,102 +1609,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       )
     }
   ),
@@ -1902,8 +1680,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1921,12 +1697,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -1955,18 +1728,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -1992,18 +1760,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2050,18 +1813,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2087,10 +1845,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2103,8 +1859,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -2117,12 +1872,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2151,18 +1903,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2188,18 +1935,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2246,18 +1988,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2283,10 +2020,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2402,42 +2137,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2451,8 +2170,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2468,102 +2186,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
@@ -2627,42 +2289,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2676,8 +2322,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2693,102 +2338,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -2908,42 +2497,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2957,8 +2530,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2974,102 +2546,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -3133,42 +2649,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -3182,8 +2682,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -3199,102 +2698,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       )
     }
   ),
@@ -3325,8 +2768,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -3342,18 +2783,10 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3372,18 +2805,10 @@ filegroup(
 filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3430,13 +2855,9 @@ objc_library(
     [
       "React/Cxx*/*.mm"
     ],
-    exclude = glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":CxxBridge_cxx_hdrs"
@@ -3464,8 +2885,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -3481,18 +2900,10 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3512,18 +2923,10 @@ filegroup(
 filegroup(
   name = "CxxBridge_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3571,8 +2974,7 @@ objc_library(
   srcs = glob(
     [
       "React/Cxx*/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":CxxBridge_hdrs"
@@ -3599,8 +3001,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -3616,23 +3016,15 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3648,8 +3040,7 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTWebSocket_public_hdrs"
@@ -3661,23 +3052,15 @@ filegroup(
 filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3730,22 +3113,17 @@ objc_library(
       "React/Inspector/*.cxx",
       "React/Inspector/*.mm"
     ],
-    exclude = glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
-  module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
     ":DevSupport_cxx_hdrs"
   ],
@@ -3770,8 +3148,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -3785,23 +3161,15 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3817,8 +3185,7 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":DevSupport_cxx_public_hdrs",
@@ -3831,23 +3198,15 @@ filegroup(
 filegroup(
   name = "DevSupport_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3901,10 +3260,8 @@ objc_library(
       "React/Inspector/*.c",
       "React/Inspector/*.m",
       "React/Inspector/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
-  module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
     ":DevSupport_hdrs"
   ],
@@ -3927,8 +3284,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -3942,12 +3297,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3955,10 +3307,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -3969,8 +3319,7 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":fabric_public_hdrs"
@@ -3982,12 +3331,9 @@ filegroup(
 filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3995,10 +3341,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4071,10 +3415,8 @@ objc_library(
         "**/tests/*.m",
         "**/tests/*.mm",
         "**/tests/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   hdrs = [
     ":RCTFabric_cxx_hdrs"
@@ -4104,8 +3446,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4121,12 +3461,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -4134,10 +3471,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4148,8 +3483,7 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTFabric_cxx_public_hdrs",
@@ -4162,12 +3496,9 @@ filegroup(
 filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -4175,10 +3506,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4239,8 +3568,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTFabric_hdrs"
@@ -4270,8 +3598,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4287,18 +3613,10 @@ acknowledged_target(
 filegroup(
   name = "tvOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/**/RCTTV*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/**/RCTTV*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4309,8 +3627,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/RCTTV*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -4321,18 +3638,10 @@ filegroup(
 filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/**/RCTTV*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/**/RCTTV*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4375,8 +3684,7 @@ objc_library(
   srcs = glob(
     [
       "React/**/RCTTV*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":tvOS_hdrs"
@@ -4398,8 +3706,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4413,18 +3719,10 @@ acknowledged_target(
 filegroup(
   name = "jschelpers_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jschelpers/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jschelpers/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4442,18 +3740,10 @@ filegroup(
 filegroup(
   name = "jschelpers_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jschelpers/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jschelpers/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4512,25 +3802,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":jschelpers_hdrs"
@@ -4559,8 +3838,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4576,18 +3853,10 @@ acknowledged_target(
 filegroup(
   name = "jsinspector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jsinspector/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jsinspector/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4603,18 +3872,10 @@ filegroup(
 filegroup(
   name = "jsinspector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jsinspector/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jsinspector/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4669,25 +3930,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":jsinspector_hdrs"
@@ -4710,8 +3960,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4725,18 +3973,10 @@ acknowledged_target(
 filegroup(
   name = "PrivateDatabase_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/privatedata/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/privatedata/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4752,18 +3992,10 @@ filegroup(
 filegroup(
   name = "PrivateDatabase_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/privatedata/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/privatedata/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4805,12 +4037,9 @@ objc_library(
     [
       "ReactCommon/privatedata/*.cpp"
     ],
-    exclude = glob(
-      [
-        "ReactCommon/jschelpers/*.cpp"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    exclude = [
+      "ReactCommon/jschelpers/*.cpp"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.cpp"
       ],
@@ -4823,25 +4052,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":PrivateDatabase_hdrs"
@@ -4864,8 +4082,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -4879,12 +4095,9 @@ acknowledged_target(
 filegroup(
   name = "cxxreact_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4892,10 +4105,8 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4914,12 +4125,9 @@ filegroup(
 filegroup(
   name = "cxxreact_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4927,10 +4135,8 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4990,24 +4196,11 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.cxx",
       "ReactCommon/cxxreact/SampleCxxModule.m",
       "ReactCommon/cxxreact/SampleCxxModule.mm",
-      "ReactCommon/cxxreact/SampleCxxModule.s"
-    ] + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "ReactCommon/cxxreact/SampleCxxModule.s",
+      "React/Cxx*/*.mm",
+      "React/Cxx*/*.m",
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":cxxreact_hdrs"
@@ -5035,8 +4228,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -5055,8 +4246,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5074,8 +4264,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5119,7 +4308,10 @@ objc_library(
   deps = [
     ":fabric_includes"
   ],
-  copts = select(
+  copts = [
+    "-std=c++14",
+    "-std=c++14"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -5131,8 +4323,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -5146,12 +4336,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_activityindicator_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -5159,10 +4346,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5173,8 +4358,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/activityindicator/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5183,12 +4367,9 @@ filegroup(
 filegroup(
   name = "fabric_activityindicator_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -5196,10 +4377,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5253,8 +4432,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_activityindicator_hdrs"
@@ -5279,8 +4457,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/activityindicator/"
-  ] + [
-    "-fmodule-name=fabric/activityindicator"
   ],
   visibility = [
     "//visibility:public"
@@ -5296,12 +4472,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_attributedstring_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -5309,10 +4482,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5323,8 +4494,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/attributedstring/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5333,12 +4503,9 @@ filegroup(
 filegroup(
   name = "fabric_attributedstring_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -5346,10 +4513,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5403,8 +4568,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_attributedstring_hdrs"
@@ -5429,8 +4593,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/attributedstring/"
-  ] + [
-    "-fmodule-name=fabric/attributedstring"
   ],
   visibility = [
     "//visibility:public"
@@ -5446,12 +4608,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -5459,10 +4618,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5473,8 +4630,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/core/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5483,12 +4639,9 @@ filegroup(
 filegroup(
   name = "fabric_core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -5496,10 +4649,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5553,8 +4704,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_core_hdrs"
@@ -5579,8 +4729,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/core/"
-  ] + [
-    "-fmodule-name=fabric/core"
   ],
   visibility = [
     "//visibility:public"
@@ -5596,12 +4744,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_debug_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -5609,10 +4754,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5623,8 +4766,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/debug/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5633,12 +4775,9 @@ filegroup(
 filegroup(
   name = "fabric_debug_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -5646,10 +4785,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5703,8 +4840,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_debug_hdrs"
@@ -5729,8 +4865,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/debug/"
-  ] + [
-    "-fmodule-name=fabric/debug"
   ],
   visibility = [
     "//visibility:public"
@@ -5746,12 +4880,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_graphics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -5759,10 +4890,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5773,8 +4902,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/graphics/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5783,12 +4911,9 @@ filegroup(
 filegroup(
   name = "fabric_graphics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -5796,10 +4921,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5853,8 +4976,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_graphics_hdrs"
@@ -5879,8 +5001,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/graphics/"
-  ] + [
-    "-fmodule-name=fabric/graphics"
   ],
   visibility = [
     "//visibility:public"
@@ -5896,12 +5016,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_scrollview_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -5909,10 +5026,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5923,8 +5038,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/scrollview/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5933,12 +5047,9 @@ filegroup(
 filegroup(
   name = "fabric_scrollview_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -5946,10 +5057,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6003,8 +5112,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_scrollview_hdrs"
@@ -6029,8 +5137,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/scrollview/"
-  ] + [
-    "-fmodule-name=fabric/scrollview"
   ],
   visibility = [
     "//visibility:public"
@@ -6046,12 +5152,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_text_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -6059,10 +5162,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6073,8 +5174,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/text/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6083,12 +5183,9 @@ filegroup(
 filegroup(
   name = "fabric_text_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -6096,10 +5193,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6153,8 +5248,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_text_hdrs"
@@ -6179,8 +5273,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/text/"
-  ] + [
-    "-fmodule-name=fabric/text"
   ],
   visibility = [
     "//visibility:public"
@@ -6196,12 +5288,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_textlayoutmanager_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -6209,10 +5298,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6223,8 +5310,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/textlayoutmanager/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6233,12 +5319,9 @@ filegroup(
 filegroup(
   name = "fabric_textlayoutmanager_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -6246,10 +5329,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6304,8 +5385,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_textlayoutmanager_hdrs"
@@ -6330,8 +5410,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/textlayoutmanager/"
-  ] + [
-    "-fmodule-name=fabric/textlayoutmanager"
   ],
   visibility = [
     "//visibility:public"
@@ -6347,12 +5425,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_uimanager_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -6360,10 +5435,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6374,8 +5447,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/uimanager/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6384,12 +5456,9 @@ filegroup(
 filegroup(
   name = "fabric_uimanager_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -6397,10 +5466,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6454,8 +5521,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_uimanager_hdrs"
@@ -6480,8 +5546,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/uimanager/"
-  ] + [
-    "-fmodule-name=fabric/uimanager"
   ],
   visibility = [
     "//visibility:public"
@@ -6497,12 +5561,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_view_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -6510,10 +5571,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6524,8 +5583,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/view/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6534,12 +5592,9 @@ filegroup(
 filegroup(
   name = "fabric_view_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -6547,10 +5602,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6605,8 +5658,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_view_hdrs"
@@ -6632,8 +5684,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/view/"
-  ] + [
-    "-fmodule-name=fabric/view"
   ],
   visibility = [
     "//visibility:public"
@@ -6650,12 +5700,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabricSample_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -6663,10 +5710,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6677,8 +5722,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/sample/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6687,12 +5731,9 @@ filegroup(
 filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -6700,10 +5741,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6757,8 +5796,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTFabricSample_hdrs"
@@ -6783,8 +5821,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fabric/sample/"
-  ] + [
-    "-fmodule-name=fabric/sample"
   ],
   visibility = [
     "//visibility:public"
@@ -6800,18 +5836,10 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6822,8 +5850,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6834,18 +5861,10 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6888,8 +5907,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ART_hdrs"
@@ -6911,8 +5929,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -6926,18 +5942,10 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6948,8 +5956,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6960,18 +5967,10 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7014,8 +6013,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -7037,8 +6035,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7052,20 +6048,12 @@ acknowledged_target(
 filegroup(
   name = "RCTAnimation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/NativeAnimation/*.h",
-        "Libraries/NativeAnimation/Drivers/*.h",
-        "Libraries/NativeAnimation/Nodes/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7078,8 +6066,7 @@ filegroup(
       "Libraries/NativeAnimation/*.h",
       "Libraries/NativeAnimation/Drivers/*.h",
       "Libraries/NativeAnimation/Nodes/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7090,20 +6077,12 @@ filegroup(
 filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/NativeAnimation/*.h",
-        "Libraries/NativeAnimation/Drivers/*.h",
-        "Libraries/NativeAnimation/Nodes/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7148,8 +6127,7 @@ objc_library(
       "Libraries/NativeAnimation/*.m",
       "Libraries/NativeAnimation/Drivers/*.m",
       "Libraries/NativeAnimation/Nodes/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTAnimation_hdrs"
@@ -7171,8 +6149,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/RCTAnimation/"
-  ] + [
-    "-fmodule-name=RCTAnimation"
   ],
   visibility = [
     "//visibility:public"
@@ -7186,18 +6162,10 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7208,8 +6176,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7220,18 +6187,10 @@ filegroup(
 filegroup(
   name = "RCTBlob_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7275,54 +6234,34 @@ objc_library(
     [
       "Libraries/Blob/*.mm"
     ],
-    exclude = glob(
-      [
-        "Libraries/Blob/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Blob/*.m",
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTBlob_cxx_hdrs"
@@ -7347,8 +6286,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7362,18 +6299,10 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7384,8 +6313,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_cxx_public_hdrs"
@@ -7397,18 +6325,10 @@ filegroup(
 filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7454,49 +6374,33 @@ objc_library(
     [
       "Libraries/Blob/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTBlob_hdrs"
@@ -7519,8 +6423,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7534,18 +6436,10 @@ acknowledged_target(
 filegroup(
   name = "RCTCameraRoll_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/CameraRoll/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7556,8 +6450,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTImage_public_hdrs"
@@ -7569,18 +6462,10 @@ filegroup(
 filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/CameraRoll/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7625,8 +6510,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTCameraRoll_hdrs"
@@ -7649,8 +6533,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7664,18 +6546,10 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7686,8 +6560,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7698,18 +6571,10 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7752,8 +6617,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -7775,8 +6639,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7790,18 +6652,10 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7812,8 +6666,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_public_hdrs"
@@ -7825,18 +6678,10 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7882,13 +6727,9 @@ objc_library(
     [
       "Libraries/Image/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -7911,8 +6752,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -7926,18 +6765,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7948,8 +6779,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7960,18 +6790,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8015,23 +6837,11 @@ objc_library(
     [
       "Libraries/Network/*.mm"
     ],
-    exclude = glob(
-      [
-        "Libraries/Network/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Network/*.m",
+      "Libraries/Image/*.m",
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTNetwork_cxx_hdrs"
@@ -8056,8 +6866,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8071,18 +6879,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8093,8 +6893,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_cxx_public_hdrs"
@@ -8106,18 +6905,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8163,18 +6954,10 @@ objc_library(
     [
       "Libraries/Network/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Image/*.m",
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -8197,8 +6980,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8212,18 +6993,10 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8234,8 +7007,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8246,18 +7018,10 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8300,8 +7064,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -8323,8 +7086,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8338,18 +7099,10 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8360,8 +7113,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8372,18 +7124,10 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8426,8 +7170,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -8449,8 +7192,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8464,18 +7205,10 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8486,8 +7219,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8498,18 +7230,10 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8552,8 +7276,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -8575,8 +7298,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8590,18 +7311,10 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8612,8 +7325,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8624,18 +7336,10 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8678,8 +7382,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -8701,8 +7404,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8716,18 +7417,10 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8738,8 +7431,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_public_hdrs",
@@ -8752,18 +7444,10 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8811,44 +7495,32 @@ objc_library(
     [
       "Libraries/WebSocket/*.m"
     ],
-    exclude = glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -8872,8 +7544,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -8887,18 +7557,10 @@ acknowledged_target(
 filegroup(
   name = "fishhook_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/fishhook/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/fishhook/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8909,8 +7571,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/fishhook/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8919,18 +7580,10 @@ filegroup(
 filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/fishhook/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/fishhook/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8971,49 +7624,33 @@ objc_library(
     [
       "Libraries/fishhook/*.c"
     ],
-    exclude = glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":fishhook_hdrs"
@@ -9034,8 +7671,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/fishhook/"
-  ] + [
-    "-fmodule-name=fishhook"
   ],
   visibility = [
     "//visibility:public"
@@ -9049,18 +7684,10 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9071,8 +7698,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -9083,18 +7709,10 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9137,8 +7755,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"
@@ -9160,8 +7777,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -9175,18 +7790,10 @@ acknowledged_target(
 filegroup(
   name = "RCTTest_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/RCTTest/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/RCTTest/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9197,8 +7804,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -9209,18 +7815,10 @@ filegroup(
 filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/RCTTest/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/RCTTest/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9263,8 +7861,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTTest_hdrs"
@@ -9289,8 +7886,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -9306,8 +7901,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9328,8 +7922,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9392,8 +7985,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -58,32 +58,24 @@ filegroup(
 filegroup(
   name = "React_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -101,32 +93,24 @@ filegroup(
 filegroup(
   name = "React_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -177,8 +161,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -192,12 +174,9 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -223,10 +202,8 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -237,8 +214,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -247,12 +223,9 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -278,10 +251,8 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -339,69 +310,20 @@ objc_library(
       "IntegrationTests/*.cxx",
       "IntegrationTests/*.m",
       "IntegrationTests/*.mm",
-      "IntegrationTests/*.s"
-    ] + glob(
-      [
-        "Libraries/ART/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "IntegrationTests/*.s",
+      "Libraries/ART/**/*.m",
+      "Libraries/ActionSheetIOS/*.m",
+      "Libraries/AdSupport/*.m",
+      "Libraries/Geolocation/*.m",
+      "Libraries/Image/*.m",
+      "Libraries/Network/*.m",
+      "Libraries/PushNotificationIOS/*.m",
+      "Libraries/Settings/*.m",
+      "Libraries/Text/*.m",
+      "Libraries/Vibration/*.m",
+      "Libraries/WebSocket/*.m",
+      "Libraries/LinkingIOS/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -425,8 +347,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -440,18 +360,10 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -462,8 +374,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -474,18 +385,10 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -528,8 +431,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ART_hdrs"
@@ -551,8 +453,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -566,18 +466,10 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -588,8 +480,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -600,18 +491,10 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -654,8 +537,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -677,8 +559,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -692,18 +572,10 @@ acknowledged_target(
 filegroup(
   name = "RCTAdSupport_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/AdSupport/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -714,8 +586,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/AdSupport/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -726,18 +597,10 @@ filegroup(
 filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/AdSupport/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -780,8 +643,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/AdSupport/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTAdSupport_hdrs"
@@ -803,8 +665,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -818,18 +678,10 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -840,8 +692,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -852,18 +703,10 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -906,8 +749,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -929,8 +771,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -944,18 +784,10 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -966,8 +798,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -978,18 +809,10 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1032,8 +855,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Image/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -1055,8 +877,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1070,18 +890,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1092,8 +904,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1104,18 +915,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1158,8 +961,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Network/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -1181,8 +983,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1196,18 +996,10 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1218,8 +1010,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1230,18 +1021,10 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1284,8 +1067,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -1307,8 +1089,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1322,18 +1102,10 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1344,8 +1116,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1356,18 +1127,10 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1410,8 +1173,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -1433,8 +1195,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1448,18 +1208,10 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1470,8 +1222,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1482,18 +1233,10 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1536,8 +1279,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -1559,8 +1301,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1574,18 +1314,10 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1596,8 +1328,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1608,18 +1339,10 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1662,8 +1385,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -1685,8 +1407,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1700,18 +1420,10 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1722,8 +1434,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1734,18 +1445,10 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1788,8 +1491,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/WebSocket/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -1811,8 +1513,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"
@@ -1826,18 +1526,10 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1848,8 +1540,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1860,18 +1551,10 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1914,8 +1597,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"
@@ -1937,8 +1619,6 @@ objc_library(
     }
   ) + [
     "-IVendor/React/pod_support/Headers/Public/React/"
-  ] + [
-    "-fmodule-name=React"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -58,24 +58,32 @@ filegroup(
 filegroup(
   name = "React_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "PATENTS/**/*.h",
-      "PATENTS/**/*.hpp",
-      "PATENTS/**/*.hxx",
-      "lint/**/*.h",
-      "lint/**/*.hpp",
-      "lint/**/*.hxx",
-      "node_modules/**/*.h",
-      "node_modules/**/*.hpp",
-      "node_modules/**/*.hxx",
-      "packager/**/*.h",
-      "packager/**/*.hpp",
-      "packager/**/*.hxx",
-      "react-native-cli/**/*.h",
-      "react-native-cli/**/*.hpp",
-      "react-native-cli/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PATENTS/**/*.h",
+        "PATENTS/**/*.hpp",
+        "PATENTS/**/*.hxx",
+        "lint/**/*.h",
+        "lint/**/*.hpp",
+        "lint/**/*.hxx",
+        "node_modules/**/*.h",
+        "node_modules/**/*.hpp",
+        "node_modules/**/*.hxx",
+        "packager/**/*.h",
+        "packager/**/*.hpp",
+        "packager/**/*.hxx",
+        "react-native-cli/**/*.h",
+        "react-native-cli/**/*.hpp",
+        "react-native-cli/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -93,24 +101,32 @@ filegroup(
 filegroup(
   name = "React_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "PATENTS/**/*.h",
-      "PATENTS/**/*.hpp",
-      "PATENTS/**/*.hxx",
-      "lint/**/*.h",
-      "lint/**/*.hpp",
-      "lint/**/*.hxx",
-      "node_modules/**/*.h",
-      "node_modules/**/*.hpp",
-      "node_modules/**/*.hxx",
-      "packager/**/*.h",
-      "packager/**/*.hpp",
-      "packager/**/*.hxx",
-      "react-native-cli/**/*.h",
-      "react-native-cli/**/*.hpp",
-      "react-native-cli/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "PATENTS/**/*.h",
+        "PATENTS/**/*.hpp",
+        "PATENTS/**/*.hxx",
+        "lint/**/*.h",
+        "lint/**/*.hpp",
+        "lint/**/*.hxx",
+        "node_modules/**/*.h",
+        "node_modules/**/*.hpp",
+        "node_modules/**/*.hxx",
+        "packager/**/*.h",
+        "packager/**/*.hpp",
+        "packager/**/*.hxx",
+        "react-native-cli/**/*.h",
+        "react-native-cli/**/*.hpp",
+        "react-native-cli/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":Core_hdrs"
   ],
@@ -176,9 +192,12 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -204,8 +223,10 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -216,7 +237,8 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -225,9 +247,12 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -253,8 +278,10 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -312,20 +339,69 @@ objc_library(
       "IntegrationTests/*.cxx",
       "IntegrationTests/*.m",
       "IntegrationTests/*.mm",
-      "IntegrationTests/*.s",
-      "Libraries/ART/**/*.m",
-      "Libraries/ActionSheetIOS/*.m",
-      "Libraries/AdSupport/*.m",
-      "Libraries/Geolocation/*.m",
-      "Libraries/Image/*.m",
-      "Libraries/Network/*.m",
-      "Libraries/PushNotificationIOS/*.m",
-      "Libraries/Settings/*.m",
-      "Libraries/Text/*.m",
-      "Libraries/Vibration/*.m",
-      "Libraries/WebSocket/*.m",
-      "Libraries/LinkingIOS/*.m"
-    ]
+      "IntegrationTests/*.s"
+    ] + glob(
+      [
+        "Libraries/ART/**/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/AdSupport/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.m"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -364,10 +440,18 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ART/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -378,7 +462,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -389,10 +474,18 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ART/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ART/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -435,7 +528,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":ART_hdrs"
@@ -472,10 +566,18 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ActionSheetIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -486,7 +588,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -497,10 +600,18 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/ActionSheetIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/ActionSheetIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -543,7 +654,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -580,10 +692,18 @@ acknowledged_target(
 filegroup(
   name = "RCTAdSupport_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/AdSupport/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/AdSupport/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -594,7 +714,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/AdSupport/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -605,10 +726,18 @@ filegroup(
 filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/AdSupport/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/AdSupport/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -651,7 +780,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/AdSupport/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTAdSupport_hdrs"
@@ -688,10 +818,18 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Geolocation/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -702,7 +840,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -713,10 +852,18 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Geolocation/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Geolocation/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -759,7 +906,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -796,10 +944,18 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Image/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -810,7 +966,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -821,10 +978,18 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Image/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Image/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -867,7 +1032,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Image/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -904,10 +1070,18 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -918,7 +1092,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -929,10 +1104,18 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Network/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Network/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -975,7 +1158,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Network/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -1012,10 +1196,18 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/PushNotificationIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1026,7 +1218,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1037,10 +1230,18 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/PushNotificationIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/PushNotificationIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1083,7 +1284,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -1120,10 +1322,18 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Settings/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1134,7 +1344,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1145,10 +1356,18 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Settings/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Settings/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1191,7 +1410,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -1228,10 +1448,18 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Text/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1242,7 +1470,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1253,10 +1482,18 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Text/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Text/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1299,7 +1536,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -1336,10 +1574,18 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Vibration/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1350,7 +1596,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1361,10 +1608,18 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/Vibration/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/Vibration/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1407,7 +1662,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -1444,10 +1700,18 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/WebSocket/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1458,7 +1722,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1469,10 +1734,18 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/WebSocket/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/WebSocket/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1515,7 +1788,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/WebSocket/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -1552,10 +1826,18 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/LinkingIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1566,7 +1848,8 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1577,10 +1860,18 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Libraries/LinkingIOS/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Libraries/LinkingIOS/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -1623,7 +1914,8 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -47,20 +46,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +64,7 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +73,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -139,32 +121,24 @@ objc_library(
       "security/**/*.cpp",
       "security/**/*.cxx"
     ],
-    exclude = glob(
-      [
-        "security/**/*.S",
-        "security/**/*.c",
-        "security/**/*.m",
-        "security/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "security/**/*.S",
+      "security/**/*.c",
+      "security/**/*.m",
+      "security/**/*.s"
+    ]
   ),
   non_arc_srcs = glob(
     glob(
       [
         "security/**/*.mm"
       ],
-      exclude = glob(
-        [
-          "security/**/*.S",
-          "security/**/*.c",
-          "security/**/*.m",
-          "security/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "security/**/*.S",
+        "security/**/*.c",
+        "security/**/*.m",
+        "security/**/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -172,20 +146,14 @@ objc_library(
         "security/**/*.cpp",
         "security/**/*.cxx"
       ],
-      exclude = glob(
-        [
-          "security/**/*.S",
-          "security/**/*.c",
-          "security/**/*.m",
-          "security/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      exclude = [
+        "security/**/*.S",
+        "security/**/*.c",
+        "security/**/*.m",
+        "security/**/*.s"
+      ]
+    )
   ),
-  module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
@@ -210,8 +178,6 @@ objc_library(
     }
   ) + [
     "-IVendor/SFHFKeychainUtils/pod_support/Headers/Public/SFHFKeychainUtils/"
-  ] + [
-    "-fmodule-name=SFHFKeychainUtils"
   ],
   visibility = [
     "//visibility:public"
@@ -222,37 +188,15 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "SFHFKeychainUtils_swift",
-  srcs = glob(
-    [
-      "security/**/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "SFHFKeychainUtils_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -265,8 +209,7 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":SFHFKeychainUtils_cxx_public_hdrs"
   ],
@@ -277,20 +220,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ) + [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
@@ -327,10 +262,8 @@ objc_library(
       "security/**/*.c",
       "security/**/*.m",
       "security/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
-  module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
     ":SFHFKeychainUtils_hdrs"
   ],
@@ -340,7 +273,6 @@ objc_library(
   ],
   deps = [
     ":SFHFKeychainUtils_cxx",
-    ":SFHFKeychainUtils_swift",
     ":SFHFKeychainUtils_includes"
   ],
   copts = select(
@@ -355,8 +287,6 @@ objc_library(
     }
   ) + [
     "-IVendor/SFHFKeychainUtils/pod_support/Headers/Public/SFHFKeychainUtils/"
-  ] + [
-    "-fmodule-name=SFHFKeychainUtils"
   ],
   visibility = [
     "//visibility:public"
@@ -366,28 +296,4 @@ acknowledged_target(
   name = "SFHFKeychainUtils_acknowledgement",
   deps = [],
   value = "//Vendor/SFHFKeychainUtils/pod_support_buildable:acknowledgement_fragment"
-)
-gen_module_map(
-  "SFHFKeychainUtils_extended_module_map_module_map_file",
-  "SFHFKeychainUtils_extended_module_map",
-  "SFHFKeychainUtils",
-  [
-    "SFHFKeychainUtils_public_hdrs"
-  ],
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  "SFHFKeychainUtils_module_map_module_map_file",
-  "SFHFKeychainUtils_module_map",
-  "SFHFKeychainUtils",
-  [
-    "SFHFKeychainUtils_extended_module_map_module_map_file",
-    "SFHFKeychainUtils_public_hdrs"
-  ],
-  module_map_name = "SFHFKeychainUtils.modulemap",
-  visibility = [
-    "//visibility:public"
-  ]
 )

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -47,12 +47,20 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -65,7 +73,8 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -74,12 +83,20 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -122,24 +139,32 @@ objc_library(
       "security/**/*.cpp",
       "security/**/*.cxx"
     ],
-    exclude = [
-      "security/**/*.S",
-      "security/**/*.c",
-      "security/**/*.m",
-      "security/**/*.s"
-    ]
+    exclude = glob(
+      [
+        "security/**/*.S",
+        "security/**/*.c",
+        "security/**/*.m",
+        "security/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   non_arc_srcs = glob(
     glob(
       [
         "security/**/*.mm"
       ],
-      exclude = [
-        "security/**/*.S",
-        "security/**/*.c",
-        "security/**/*.m",
-        "security/**/*.s"
-      ]
+      exclude = glob(
+        [
+          "security/**/*.S",
+          "security/**/*.c",
+          "security/**/*.m",
+          "security/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
     ),
     exclude = glob(
       [
@@ -147,13 +172,18 @@ objc_library(
         "security/**/*.cpp",
         "security/**/*.cxx"
       ],
-      exclude = [
-        "security/**/*.S",
-        "security/**/*.c",
-        "security/**/*.m",
-        "security/**/*.s"
-      ]
-    )
+      exclude = glob(
+        [
+          "security/**/*.S",
+          "security/**/*.c",
+          "security/**/*.m",
+          "security/**/*.s"
+        ],
+        exclude_directories = 1
+      ),
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
@@ -197,7 +227,8 @@ swift_library(
   srcs = glob(
     [
       "security/**/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [],
   data = [],
@@ -208,12 +239,20 @@ swift_library(
 filegroup(
   name = "SFHFKeychainUtils_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -226,7 +265,8 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":SFHFKeychainUtils_cxx_public_hdrs"
   ],
@@ -237,12 +277,20 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "security/**/*.h",
-      "security/**/*.hpp",
-      "security/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "security/**/*.h",
+        "security/**/*.hpp",
+        "security/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
@@ -279,7 +327,8 @@ objc_library(
       "security/**/*.c",
       "security/**/*.m",
       "security/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SPUserResizableView/SPUserResizableView.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SPUserResizableView/SPUserResizableView.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SPUserResizableView/SPUserResizableView.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SPUserResizableView/SPUserResizableView.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"
@@ -140,8 +122,6 @@ objc_library(
     }
   ) + [
     "-IVendor/SPUserResizableView+Pion/pod_support/Headers/Public/SPUserResizableView+Pion/"
-  ] + [
-    "-fmodule-name=SPUserResizableView+Pion"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "SPUserResizableView/SPUserResizableView.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SPUserResizableView/SPUserResizableView.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "SPUserResizableView/SPUserResizableView.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SPUserResizableView/SPUserResizableView.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -43,30 +42,12 @@ filegroup(
     "//visibility:public"
   ]
 )
-swift_library(
-  name = "SevenSwitch_swift",
-  srcs = glob(
-    [
-      "SevenSwitch.swift"
-    ],
-    exclude = [
-      "Classes/Exclude/**/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "SevenSwitch_direct_hdrs",
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,8 +65,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -121,7 +101,6 @@ objc_library(
     "QuartzCore"
   ],
   deps = [
-    ":SevenSwitch_swift",
     ":SevenSwitch_includes"
   ],
   copts = select(
@@ -136,8 +115,6 @@ objc_library(
     }
   ) + [
     "-IVendor/SevenSwitch/pod_support/Headers/Public/SevenSwitch/"
-  ] + [
-    "-fmodule-name=SevenSwitch"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -51,7 +51,8 @@ swift_library(
     ],
     exclude = [
       "Classes/Exclude/**/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [],
   data = [],
@@ -64,7 +65,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -82,7 +84,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Source/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Source/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":SlackTextViewController_hdrs"

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SlackTextViewController_hdrs"
@@ -140,8 +122,6 @@ objc_library(
     }
   ) + [
     "-IVendor/SlackTextViewController/pod_support/Headers/Public/SlackTextViewController/"
-  ] + [
-    "-fmodule-name=SlackTextViewController"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Smartling_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -140,8 +123,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Smartling/pod_support/Headers/Public/Smartling/"
-  ] + [
-    "-fmodule-name=Smartling"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "Smartling_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -46,11 +46,19 @@ filegroup(
 filegroup(
   name = "Stripe_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Stripe/*.h",
-      "Stripe/PublicHeaders/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Stripe/*.h",
+        "Stripe/PublicHeaders/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -61,7 +69,8 @@ filegroup(
   srcs = glob(
     [
       "Stripe/PublicHeaders/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -70,11 +79,19 @@ filegroup(
 filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Stripe/*.h",
-      "Stripe/PublicHeaders/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Stripe/*.h",
+        "Stripe/PublicHeaders/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -104,7 +121,8 @@ objc_library(
   srcs = glob(
     [
       "Stripe/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Stripe_hdrs"
@@ -156,7 +174,8 @@ apple_resource_bundle(
   resources = glob(
     [
       "Stripe/Resources/**/*"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -46,19 +46,11 @@ filegroup(
 filegroup(
   name = "Stripe_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Stripe/*.h",
-        "Stripe/PublicHeaders/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Stripe/*.h",
+      "Stripe/PublicHeaders/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +61,7 @@ filegroup(
   srcs = glob(
     [
       "Stripe/PublicHeaders/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -79,19 +70,11 @@ filegroup(
 filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Stripe/*.h",
-        "Stripe/PublicHeaders/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Stripe/*.h",
+      "Stripe/PublicHeaders/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -121,8 +104,7 @@ objc_library(
   srcs = glob(
     [
       "Stripe/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Stripe_hdrs"
@@ -150,8 +132,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Stripe/pod_support/Headers/Public/Stripe/"
-  ] + [
-    "-fmodule-name=Stripe"
   ],
   data = select(
     {
@@ -174,8 +154,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "Stripe/Resources/**/*"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -108,30 +106,6 @@ alias(
 objc_library(
   name = "TestArcPatternsWithExcludes",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "POD_REQUIRES_ARC/*.m"
-    ],
-    exclude = glob(
-      [
-        "POD_REQUIRES_ARC/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "POD_REQUIRES_ARC/*.m"
-    ],
-    exclude = glob(
-      [
-        "POD_REQUIRES_ARC/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -152,8 +126,6 @@ objc_library(
     }
   ) + [
     "-IVendor/TestArcPatternsWithExcludes/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"
@@ -169,74 +141,54 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -249,8 +201,7 @@ filegroup(
   srcs = glob(
     [
       "**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -261,74 +212,54 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -384,12 +315,9 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_IOS/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -405,12 +333,9 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -427,12 +352,9 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_TV/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -448,12 +370,9 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       )
     }
   ),
@@ -467,8 +386,7 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_IOS/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -485,14 +403,10 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_IOS/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -501,8 +415,7 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -518,14 +431,10 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -535,8 +444,7 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_TV/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -553,14 +461,10 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_TV/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -569,8 +473,7 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -586,14 +489,10 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),
@@ -616,8 +515,6 @@ objc_library(
     }
   ) + [
     "-IVendor/TestArcPatternsWithExcludes/pod_support/Headers/Public/FBSDKCoreKit/"
-  ] + [
-    "-fmodule-name=FBSDKCoreKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -48,7 +48,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,7 +69,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_hdrs"
   ],
@@ -106,6 +108,30 @@ alias(
 objc_library(
   name = "TestArcPatternsWithExcludes",
   enable_modules = 0,
+  srcs = glob(
+    [
+      "POD_REQUIRES_ARC/*.m"
+    ],
+    exclude = glob(
+      [
+        "POD_REQUIRES_ARC/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
+  non_arc_srcs = glob(
+    [
+      "POD_REQUIRES_ARC/*.m"
+    ],
+    exclude = glob(
+      [
+        "POD_REQUIRES_ARC/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
+  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -143,54 +169,74 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -203,7 +249,8 @@ filegroup(
   srcs = glob(
     [
       "**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -214,54 +261,74 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -317,9 +384,12 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_IOS/**/*.m"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -335,9 +405,12 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -354,9 +427,12 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_TV/**/*.m"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -372,9 +448,12 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ]
-          )
-        )
+            ],
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -388,7 +467,8 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_IOS/**/*.m"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -405,10 +485,14 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_IOS/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         glob(
@@ -417,7 +501,8 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -433,10 +518,14 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         glob(
@@ -446,7 +535,8 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_TV/**/*.m"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -463,10 +553,14 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_TV/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         glob(
@@ -475,7 +569,8 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ]
+          ],
+          exclude_directories = 1
         ),
         exclude = glob(
           [
@@ -491,10 +586,14 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ]
-            )
-          )
-        )
+              ],
+              exclude_directories = 1
+            ),
+            exclude_directories = 1
+          ),
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -55,7 +55,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -78,7 +79,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":AssetsLibrary_hdrs",
     ":MapKit_hdrs",
@@ -156,19 +158,27 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/*.h",
-      "Source/Base/*.h",
-      "Source/Debug/**/*.h",
-      "Source/Details/**/*.h",
-      "Source/Layout/**/*.h",
-      "Source/TextKit/*.h",
-      "Source/TextKit/ASTextKitComponents.h",
-      "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -185,7 +195,8 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -194,19 +205,27 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/*.h",
-      "Source/Base/*.h",
-      "Source/Debug/**/*.h",
-      "Source/Details/**/*.h",
-      "Source/Layout/**/*.h",
-      "Source/TextKit/*.h",
-      "Source/TextKit/ASTextKitComponents.h",
-      "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -247,10 +266,14 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = [
-      "Base/*.m",
-      "Source/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "Base/*.m",
+        "Source/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_cxx_hdrs"
@@ -294,19 +317,27 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/*.h",
-      "Source/Base/*.h",
-      "Source/Debug/**/*.h",
-      "Source/Details/**/*.h",
-      "Source/Layout/**/*.h",
-      "Source/TextKit/*.h",
-      "Source/TextKit/ASTextKitComponents.h",
-      "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -323,7 +354,8 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -334,19 +366,27 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "Base/*.h",
-      "Source/**/*.h",
-      "Source/*.h",
-      "Source/Base/*.h",
-      "Source/Debug/**/*.h",
-      "Source/Details/**/*.h",
-      "Source/Layout/**/*.h",
-      "Source/TextKit/*.h",
-      "Source/TextKit/ASTextKitComponents.h",
-      "Source/TextKit/ASTextNodeTypes.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "Base/*.h",
+        "Source/**/*.h",
+        "Source/*.h",
+        "Source/Base/*.h",
+        "Source/Debug/**/*.h",
+        "Source/Details/**/*.h",
+        "Source/Layout/**/*.h",
+        "Source/TextKit/*.h",
+        "Source/TextKit/ASTextKitComponents.h",
+        "Source/TextKit/ASTextNodeTypes.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -390,7 +430,8 @@ objc_library(
     [
       "Base/*.m",
       "Source/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -434,7 +475,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -454,7 +496,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -541,7 +584,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -561,7 +605,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -645,7 +690,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -665,7 +711,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -751,7 +798,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -771,7 +819,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -856,7 +905,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -876,7 +926,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -961,7 +1012,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -981,7 +1033,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -55,8 +55,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -79,8 +78,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":AssetsLibrary_hdrs",
     ":MapKit_hdrs",
@@ -143,8 +141,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -158,27 +154,19 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -195,8 +183,7 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -205,27 +192,19 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -266,14 +245,10 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "Base/*.m",
-        "Source/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Base/*.m",
+      "Source/**/*.m"
+    ]
   ),
   hdrs = [
     ":Core_cxx_hdrs"
@@ -302,8 +277,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -317,27 +290,19 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -354,8 +319,7 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -366,27 +330,19 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -430,8 +386,7 @@ objc_library(
     [
       "Base/*.m",
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -458,8 +413,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -475,8 +428,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -496,8 +448,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -564,8 +515,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -584,8 +533,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -605,8 +553,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -671,8 +618,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -690,8 +635,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -711,8 +655,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -779,8 +722,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -798,8 +739,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -819,8 +759,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -888,8 +827,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -905,8 +842,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -926,8 +862,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -995,8 +930,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"
@@ -1012,8 +945,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1033,8 +965,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1102,8 +1033,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Texture/pod_support/Headers/Public/AsyncDisplayKit/"
-  ] + [
-    "-fmodule-name=AsyncDisplayKit"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -47,12 +47,20 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -65,7 +73,8 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -74,12 +83,20 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -123,12 +140,16 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.cxx",
       "UICollectionViewLeftAlignedLayout/**/*.mm"
     ],
-    exclude = [
-      "UICollectionViewLeftAlignedLayout/**/*.S",
-      "UICollectionViewLeftAlignedLayout/**/*.c",
-      "UICollectionViewLeftAlignedLayout/**/*.m",
-      "UICollectionViewLeftAlignedLayout/**/*.s"
-    ]
+    exclude = glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.S",
+        "UICollectionViewLeftAlignedLayout/**/*.c",
+        "UICollectionViewLeftAlignedLayout/**/*.m",
+        "UICollectionViewLeftAlignedLayout/**/*.s"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
@@ -169,7 +190,8 @@ swift_library(
   srcs = glob(
     [
       "UICollectionViewLeftAlignedLayout/**/*.swift"
-    ]
+    ],
+    exclude_directories = 1
   ),
   deps = [],
   data = [],
@@ -180,12 +202,20 @@ swift_library(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -198,7 +228,8 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_public_hdrs"
   ],
@@ -209,12 +240,20 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "UICollectionViewLeftAlignedLayout/**/*.h",
-      "UICollectionViewLeftAlignedLayout/**/*.hpp",
-      "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "UICollectionViewLeftAlignedLayout/**/*.h",
+        "UICollectionViewLeftAlignedLayout/**/*.hpp",
+        "UICollectionViewLeftAlignedLayout/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
@@ -251,7 +290,8 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.c",
       "UICollectionViewLeftAlignedLayout/**/*.m",
       "UICollectionViewLeftAlignedLayout/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
   "acknowledged_target",
@@ -47,20 +46,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +64,7 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +73,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -140,18 +122,13 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.cxx",
       "UICollectionViewLeftAlignedLayout/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.S",
-        "UICollectionViewLeftAlignedLayout/**/*.c",
-        "UICollectionViewLeftAlignedLayout/**/*.m",
-        "UICollectionViewLeftAlignedLayout/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "UICollectionViewLeftAlignedLayout/**/*.S",
+      "UICollectionViewLeftAlignedLayout/**/*.c",
+      "UICollectionViewLeftAlignedLayout/**/*.m",
+      "UICollectionViewLeftAlignedLayout/**/*.s"
+    ]
   ),
-  module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
@@ -173,8 +150,6 @@ objc_library(
     }
   ) + [
     "-IVendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/UICollectionViewLeftAlignedLayout/"
-  ] + [
-    "-fmodule-name=UICollectionViewLeftAlignedLayout"
   ],
   visibility = [
     "//visibility:public"
@@ -185,37 +160,15 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "UICollectionViewLeftAlignedLayout_swift",
-  srcs = glob(
-    [
-      "UICollectionViewLeftAlignedLayout/**/*.swift"
-    ],
-    exclude_directories = 1
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -228,8 +181,7 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_public_hdrs"
   ],
@@ -240,20 +192,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
@@ -290,17 +234,14 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.c",
       "UICollectionViewLeftAlignedLayout/**/*.m",
       "UICollectionViewLeftAlignedLayout/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
-  module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
     ":UICollectionViewLeftAlignedLayout_hdrs"
   ],
   pch = "pod_support/Headers/Private/UICollectionViewLeftAlignedLayout-prefix.pch",
   deps = [
     ":UICollectionViewLeftAlignedLayout_cxx",
-    ":UICollectionViewLeftAlignedLayout_swift",
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = select(
@@ -315,8 +256,6 @@ objc_library(
     }
   ) + [
     "-IVendor/UICollectionViewLeftAlignedLayout/pod_support/Headers/Public/UICollectionViewLeftAlignedLayout/"
-  ] + [
-    "-fmodule-name=UICollectionViewLeftAlignedLayout"
   ],
   visibility = [
     "//visibility:public"
@@ -326,28 +265,4 @@ acknowledged_target(
   name = "UICollectionViewLeftAlignedLayout_acknowledgement",
   deps = [],
   value = "//Vendor/UICollectionViewLeftAlignedLayout/pod_support_buildable:acknowledgement_fragment"
-)
-gen_module_map(
-  "UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
-  "UICollectionViewLeftAlignedLayout_extended_module_map",
-  "UICollectionViewLeftAlignedLayout",
-  [
-    "UICollectionViewLeftAlignedLayout_public_hdrs"
-  ],
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  "UICollectionViewLeftAlignedLayout_module_map_module_map_file",
-  "UICollectionViewLeftAlignedLayout_module_map",
-  "UICollectionViewLeftAlignedLayout",
-  [
-    "UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
-    "UICollectionViewLeftAlignedLayout_public_hdrs"
-  ],
-  module_map_name = "UICollectionViewLeftAlignedLayout.modulemap",
-  visibility = [
-    "//visibility:public"
-  ]
 )

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "Weixin_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "SDK1.6.2/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SDK1.6.2/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "SDK1.6.2/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "SDK1.6.2/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "SDK1.6.2/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Weixin_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SDK1.6.2/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SDK1.6.2/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "SDK1.6.2/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SDK1.6.2/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SDK1.6.2/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -144,8 +127,6 @@ objc_library(
     }
   ) + [
     "-IVendor/Weixin/pod_support/Headers/Public/Weixin/"
-  ] + [
-    "-fmodule-name=Weixin"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -45,15 +45,23 @@ filegroup(
 filegroup(
   name = "ZipArchive_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "*.h",
-      "minizip/crypt.h",
-      "minizip/ioapi.h",
-      "minizip/mztools.h",
-      "minizip/unzip.h",
-      "minizip/zip.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h",
+        "minizip/crypt.h",
+        "minizip/ioapi.h",
+        "minizip/mztools.h",
+        "minizip/unzip.h",
+        "minizip/zip.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -64,7 +72,8 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -73,15 +82,23 @@ filegroup(
 filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "*.h",
-      "minizip/crypt.h",
-      "minizip/ioapi.h",
-      "minizip/mztools.h",
-      "minizip/unzip.h",
-      "minizip/zip.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "*.h",
+        "minizip/crypt.h",
+        "minizip/ioapi.h",
+        "minizip/mztools.h",
+        "minizip/unzip.h",
+        "minizip/zip.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -116,7 +133,8 @@ objc_library(
       "minizip/mztools.c",
       "minizip/unzip.c",
       "minizip/zip.c"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":ZipArchive_hdrs"

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -45,23 +45,15 @@ filegroup(
 filegroup(
   name = "ZipArchive_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h",
-        "minizip/crypt.h",
-        "minizip/ioapi.h",
-        "minizip/mztools.h",
-        "minizip/unzip.h",
-        "minizip/zip.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h",
+      "minizip/crypt.h",
+      "minizip/ioapi.h",
+      "minizip/mztools.h",
+      "minizip/unzip.h",
+      "minizip/zip.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +64,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -82,23 +73,15 @@ filegroup(
 filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h",
-        "minizip/crypt.h",
-        "minizip/ioapi.h",
-        "minizip/mztools.h",
-        "minizip/unzip.h",
-        "minizip/zip.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h",
+      "minizip/crypt.h",
+      "minizip/ioapi.h",
+      "minizip/mztools.h",
+      "minizip/unzip.h",
+      "minizip/zip.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -133,8 +116,7 @@ objc_library(
       "minizip/mztools.c",
       "minizip/unzip.c",
       "minizip/zip.c"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ZipArchive_hdrs"
@@ -160,8 +142,6 @@ objc_library(
     }
   ) + [
     "-IVendor/ZipArchive/pod_support/Headers/Public/ZipArchive/"
-  ] + [
-    "-fmodule-name=ZipArchive"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -45,12 +45,20 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "boost/**/*.h",
-      "boost/**/*.hpp",
-      "boost/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "boost/**/*.h",
+        "boost/**/*.hpp",
+        "boost/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -66,12 +74,20 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "boost/**/*.h",
-      "boost/**/*.hpp",
-      "boost/**/*.hxx"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "boost/**/*.h",
+        "boost/**/*.hpp",
+        "boost/**/*.hxx"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "boost/**/*.h",
-        "boost/**/*.hpp",
-        "boost/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "boost/**/*.h",
+      "boost/**/*.hpp",
+      "boost/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,20 +66,12 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "boost/**/*.h",
-        "boost/**/*.hpp",
-        "boost/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "boost/**/*.h",
+      "boost/**/*.hpp",
+      "boost/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -133,8 +117,6 @@ objc_library(
     }
   ) + [
     "-IVendor/boost-for-react-native/pod_support/Headers/Public/boost/"
-  ] + [
-    "-fmodule-name=boost"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -45,9 +45,12 @@ filegroup(
 filegroup(
   name = "glog_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -57,8 +60,10 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,7 +74,8 @@ filegroup(
   srcs = glob(
     [
       "src/glog/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -78,9 +84,12 @@ filegroup(
 filegroup(
   name = "glog_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*"
-    ] + glob(
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -90,8 +99,10 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ]
-    )
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -137,7 +148,8 @@ objc_library(
       "src/windows/**/*.m",
       "src/windows/**/*.mm",
       "src/windows/**/*.s"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":glog_hdrs"

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -45,12 +45,9 @@ filegroup(
 filegroup(
   name = "glog_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -60,10 +57,8 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +69,7 @@ filegroup(
   srcs = glob(
     [
       "src/glog/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,12 +78,9 @@ filegroup(
 filegroup(
   name = "glog_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -99,10 +90,8 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -148,8 +137,7 @@ objc_library(
       "src/windows/**/*.m",
       "src/windows/**/*.mm",
       "src/windows/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":glog_hdrs"
@@ -173,9 +161,7 @@ objc_library(
         "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
-  ) + [
-    "-fmodule-name=glog"
-  ],
+  ),
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -70,7 +71,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Messages_hdrs",
     ":Services_hdrs"
@@ -145,10 +147,18 @@ acknowledged_target(
 filegroup(
   name = "Messages_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "google/**/*.pbobjc.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbobjc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -159,7 +169,8 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbobjc.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -168,10 +179,18 @@ filegroup(
 filegroup(
   name = "Messages_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "google/**/*.pbobjc.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbobjc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -214,9 +233,13 @@ objc_library(
     [
       "google/**/*.pbobjc.m"
     ],
-    exclude = [
-      "google/**/*.pbrpc.m"
-    ]
+    exclude = glob(
+      [
+        "google/**/*.pbrpc.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":Messages_hdrs"
@@ -257,10 +280,18 @@ acknowledged_target(
 filegroup(
   name = "Services_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "google/**/*.pbrpc.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbrpc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -271,7 +302,8 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbrpc.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":Messages_public_hdrs"
   ],
@@ -282,10 +314,18 @@ filegroup(
 filegroup(
   name = "Services_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "google/**/*.pbrpc.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "google/**/*.pbrpc.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -329,7 +369,8 @@ objc_library(
   srcs = glob(
     [
       "google/**/*.pbrpc.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Services_hdrs"

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Messages_hdrs",
     ":Services_hdrs"
@@ -130,8 +128,6 @@ objc_library(
     }
   ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
-  ] + [
-    "-fmodule-name=googleapis"
   ],
   visibility = [
     "//visibility:public"
@@ -147,18 +143,10 @@ acknowledged_target(
 filegroup(
   name = "Messages_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbobjc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbobjc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -169,8 +157,7 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbobjc.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -179,18 +166,10 @@ filegroup(
 filegroup(
   name = "Messages_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbobjc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbobjc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -233,13 +212,9 @@ objc_library(
     [
       "google/**/*.pbobjc.m"
     ],
-    exclude = glob(
-      [
-        "google/**/*.pbrpc.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "google/**/*.pbrpc.m"
+    ]
   ),
   hdrs = [
     ":Messages_hdrs"
@@ -263,8 +238,6 @@ objc_library(
     }
   ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
-  ] + [
-    "-fmodule-name=googleapis"
   ],
   visibility = [
     "//visibility:public"
@@ -280,18 +253,10 @@ acknowledged_target(
 filegroup(
   name = "Services_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbrpc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbrpc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -302,8 +267,7 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbrpc.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Messages_public_hdrs"
   ],
@@ -314,18 +278,10 @@ filegroup(
 filegroup(
   name = "Services_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbrpc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbrpc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -369,8 +325,7 @@ objc_library(
   srcs = glob(
     [
       "google/**/*.pbrpc.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Services_hdrs"
@@ -395,8 +350,6 @@ objc_library(
     }
   ) + [
     "-IVendor/googleapis/pod_support/Headers/Public/googleapis/"
-  ] + [
-    "-fmodule-name=googleapis"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -70,8 +69,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":SwiftSupport_hdrs"
   ],
@@ -128,8 +126,6 @@ objc_library(
     }
   ) + [
     "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
-  ] + [
-    "-fmodule-name=FBSnapshotTestCase"
   ],
   visibility = [
     "//visibility:public"
@@ -143,25 +139,17 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSnapshotTestCase/**/*.h",
-        "FBSnapshotTestCase/*.h",
-        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-        "FBSnapshotTestCase/FBSnapshotTestCase.h",
-        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-        "FBSnapshotTestCase/FBSnapshotTestController.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSnapshotTestCase/**/*.h",
+      "FBSnapshotTestCase/*.h",
+      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+      "FBSnapshotTestCase/FBSnapshotTestCase.h",
+      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+      "FBSnapshotTestCase/FBSnapshotTestController.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -179,8 +167,7 @@ filegroup(
       "FBSnapshotTestCase/Categories/UIImage+Compare.h",
       "FBSnapshotTestCase/Categories/UIImage+Diff.h",
       "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -189,25 +176,17 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSnapshotTestCase/**/*.h",
-        "FBSnapshotTestCase/*.h",
-        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-        "FBSnapshotTestCase/FBSnapshotTestCase.h",
-        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-        "FBSnapshotTestCase/FBSnapshotTestController.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSnapshotTestCase/**/*.h",
+      "FBSnapshotTestCase/*.h",
+      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+      "FBSnapshotTestCase/FBSnapshotTestCase.h",
+      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+      "FBSnapshotTestCase/FBSnapshotTestController.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -248,8 +227,7 @@ objc_library(
     [
       "FBSnapshotTestCase/**/*.m",
       "FBSnapshotTestCase/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -276,8 +254,6 @@ objc_library(
     }
   ) + [
     "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
-  ] + [
-    "-fmodule-name=FBSnapshotTestCase"
   ],
   visibility = [
     "//visibility:public"
@@ -293,8 +269,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -314,8 +289,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -381,8 +355,6 @@ objc_library(
     }
   ) + [
     "-IVendor/iOSSnapshotTestCase/pod_support/Headers/Public/FBSnapshotTestCase/"
-  ] + [
-    "-fmodule-name=FBSnapshotTestCase"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -49,7 +49,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,7 +70,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":SwiftSupport_hdrs"
   ],
@@ -141,17 +143,25 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSnapshotTestCase/**/*.h",
-      "FBSnapshotTestCase/*.h",
-      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-      "FBSnapshotTestCase/FBSnapshotTestCase.h",
-      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-      "FBSnapshotTestCase/FBSnapshotTestController.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSnapshotTestCase/**/*.h",
+        "FBSnapshotTestCase/*.h",
+        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+        "FBSnapshotTestCase/FBSnapshotTestCase.h",
+        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+        "FBSnapshotTestCase/FBSnapshotTestController.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -169,7 +179,8 @@ filegroup(
       "FBSnapshotTestCase/Categories/UIImage+Compare.h",
       "FBSnapshotTestCase/Categories/UIImage+Diff.h",
       "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -178,17 +189,25 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "FBSnapshotTestCase/**/*.h",
-      "FBSnapshotTestCase/*.h",
-      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-      "FBSnapshotTestCase/FBSnapshotTestCase.h",
-      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-      "FBSnapshotTestCase/FBSnapshotTestController.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "FBSnapshotTestCase/**/*.h",
+        "FBSnapshotTestCase/*.h",
+        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+        "FBSnapshotTestCase/FBSnapshotTestCase.h",
+        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+        "FBSnapshotTestCase/FBSnapshotTestController.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -229,7 +248,8 @@ objc_library(
     [
       "FBSnapshotTestCase/**/*.m",
       "FBSnapshotTestCase/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":Core_hdrs"
@@ -273,7 +293,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -293,7 +314,8 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -46,18 +46,10 @@ filegroup(
 filegroup(
   name = "iRate_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "iRate/iRate.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "iRate/iRate.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "iRate/iRate.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,18 +69,10 @@ filegroup(
 filegroup(
   name = "iRate_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "iRate/iRate.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "iRate/iRate.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -119,8 +102,7 @@ objc_library(
   srcs = glob(
     [
       "iRate/iRate.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":iRate_hdrs"
@@ -141,8 +123,6 @@ objc_library(
     }
   ) + [
     "-IVendor/iRate/pod_support/Headers/Public/iRate/"
-  ] + [
-    "-fmodule-name=iRate"
   ],
   data = [
     ":iRate_Bundle_iRate"
@@ -161,8 +141,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "iRate/iRate.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -46,10 +46,18 @@ filegroup(
 filegroup(
   name = "iRate_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "iRate/iRate.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "iRate/iRate.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -60,7 +68,8 @@ filegroup(
   srcs = glob(
     [
       "iRate/iRate.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -69,10 +78,18 @@ filegroup(
 filegroup(
   name = "iRate_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "iRate/iRate.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "iRate/iRate.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -102,7 +119,8 @@ objc_library(
   srcs = glob(
     [
       "iRate/iRate.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":iRate_hdrs"
@@ -143,7 +161,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "iRate/iRate.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "kingpin_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "kingpin/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "kingpin/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "kingpin/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "kingpin/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "kingpin/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "kingpin/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":kingpin_hdrs"
@@ -144,8 +126,6 @@ objc_library(
     }
   ) + [
     "-IVendor/kingpin/pod_support/Headers/Public/kingpin/"
-  ] + [
-    "-fmodule-name=kingpin"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "kingpin_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "kingpin/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "kingpin/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "kingpin/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "kingpin/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "kingpin/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "kingpin/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":kingpin_hdrs"

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -46,33 +46,25 @@ filegroup(
 filegroup(
   name = "pop_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -97,8 +89,7 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -107,33 +98,25 @@ filegroup(
 filegroup(
   name = "pop_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -175,13 +158,9 @@ objc_library(
       "pop/**/*.cpp",
       "pop/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "pop/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "pop/**/*.m"
+    ]
   ),
   hdrs = [
     ":pop_cxx_hdrs"
@@ -209,8 +188,6 @@ objc_library(
     }
   ) + [
     "-IVendor/pop/pod_support/Headers/Public/pop/"
-  ] + [
-    "-fmodule-name=pop"
   ],
   visibility = [
     "//visibility:public"
@@ -224,33 +201,25 @@ acknowledged_target(
 filegroup(
   name = "pop_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -275,8 +244,7 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":pop_cxx_public_hdrs"
   ],
@@ -287,33 +255,25 @@ filegroup(
 filegroup(
   name = "pop_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ) + [
     ":pop_cxx_hdrs"
   ],
@@ -347,8 +307,7 @@ objc_library(
   srcs = glob(
     [
       "pop/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":pop_hdrs"
@@ -373,8 +332,6 @@ objc_library(
     }
   ) + [
     "-IVendor/pop/pod_support/Headers/Public/pop/"
-  ] + [
-    "-fmodule-name=pop"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -46,25 +46,33 @@ filegroup(
 filegroup(
   name = "pop_cxx_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "pop/**/*.h",
-      "pop/POP.h",
-      "pop/POPAnimatableProperty.h",
-      "pop/POPAnimation.h",
-      "pop/POPAnimationEvent.h",
-      "pop/POPAnimationExtras.h",
-      "pop/POPAnimationTracer.h",
-      "pop/POPAnimator.h",
-      "pop/POPBasicAnimation.h",
-      "pop/POPCustomAnimation.h",
-      "pop/POPDecayAnimation.h",
-      "pop/POPDefines.h",
-      "pop/POPGeometry.h",
-      "pop/POPLayerExtras.h",
-      "pop/POPPropertyAnimation.h",
-      "pop/POPSpringAnimation.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -89,7 +97,8 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -98,25 +107,33 @@ filegroup(
 filegroup(
   name = "pop_cxx_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "pop/**/*.h",
-      "pop/POP.h",
-      "pop/POPAnimatableProperty.h",
-      "pop/POPAnimation.h",
-      "pop/POPAnimationEvent.h",
-      "pop/POPAnimationExtras.h",
-      "pop/POPAnimationTracer.h",
-      "pop/POPAnimator.h",
-      "pop/POPBasicAnimation.h",
-      "pop/POPCustomAnimation.h",
-      "pop/POPDecayAnimation.h",
-      "pop/POPDefines.h",
-      "pop/POPGeometry.h",
-      "pop/POPLayerExtras.h",
-      "pop/POPPropertyAnimation.h",
-      "pop/POPSpringAnimation.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -158,9 +175,13 @@ objc_library(
       "pop/**/*.cpp",
       "pop/**/*.mm"
     ],
-    exclude = [
-      "pop/**/*.m"
-    ]
+    exclude = glob(
+      [
+        "pop/**/*.m"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   hdrs = [
     ":pop_cxx_hdrs"
@@ -203,25 +224,33 @@ acknowledged_target(
 filegroup(
   name = "pop_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "pop/**/*.h",
-      "pop/POP.h",
-      "pop/POPAnimatableProperty.h",
-      "pop/POPAnimation.h",
-      "pop/POPAnimationEvent.h",
-      "pop/POPAnimationExtras.h",
-      "pop/POPAnimationTracer.h",
-      "pop/POPAnimator.h",
-      "pop/POPBasicAnimation.h",
-      "pop/POPCustomAnimation.h",
-      "pop/POPDecayAnimation.h",
-      "pop/POPDefines.h",
-      "pop/POPGeometry.h",
-      "pop/POPLayerExtras.h",
-      "pop/POPPropertyAnimation.h",
-      "pop/POPSpringAnimation.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -246,7 +275,8 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":pop_cxx_public_hdrs"
   ],
@@ -257,25 +287,33 @@ filegroup(
 filegroup(
   name = "pop_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "pop/**/*.h",
-      "pop/POP.h",
-      "pop/POPAnimatableProperty.h",
-      "pop/POPAnimation.h",
-      "pop/POPAnimationEvent.h",
-      "pop/POPAnimationExtras.h",
-      "pop/POPAnimationTracer.h",
-      "pop/POPAnimator.h",
-      "pop/POPBasicAnimation.h",
-      "pop/POPCustomAnimation.h",
-      "pop/POPDecayAnimation.h",
-      "pop/POPDefines.h",
-      "pop/POPGeometry.h",
-      "pop/POPLayerExtras.h",
-      "pop/POPPropertyAnimation.h",
-      "pop/POPSpringAnimation.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "pop/**/*.h",
+        "pop/POP.h",
+        "pop/POPAnimatableProperty.h",
+        "pop/POPAnimation.h",
+        "pop/POPAnimationEvent.h",
+        "pop/POPAnimationExtras.h",
+        "pop/POPAnimationTracer.h",
+        "pop/POPAnimator.h",
+        "pop/POPBasicAnimation.h",
+        "pop/POPCustomAnimation.h",
+        "pop/POPDecayAnimation.h",
+        "pop/POPDefines.h",
+        "pop/POPGeometry.h",
+        "pop/POPLayerExtras.h",
+        "pop/POPPropertyAnimation.h",
+        "pop/POPSpringAnimation.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ) + [
     ":pop_cxx_hdrs"
   ],
@@ -309,7 +347,8 @@ objc_library(
   srcs = glob(
     [
       "pop/**/*.m"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":pop_hdrs"

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -45,10 +45,18 @@ filegroup(
 filegroup(
   name = "yoga_direct_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "yoga/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "yoga/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -59,7 +67,8 @@ filegroup(
   srcs = glob(
     [
       "yoga/**/*.h"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -68,10 +77,18 @@ filegroup(
 filegroup(
   name = "yoga_hdrs",
   srcs = glob(
-    [
-      "pod_support/Headers/Public/**/*",
-      "yoga/**/*.h"
-    ]
+    glob(
+      [
+        "pod_support/Headers/Public/**/*"
+      ],
+      exclude_directories = 1
+    ) + glob(
+      [
+        "yoga/**/*.h"
+      ],
+      exclude_directories = 1
+    ),
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -101,7 +118,8 @@ objc_library(
   srcs = glob(
     [
       "yoga/**/*.cpp"
-    ]
+    ],
+    exclude_directories = 1
   ),
   hdrs = [
     ":yoga_hdrs"

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "yoga_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "yoga/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "yoga/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "yoga/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "yoga_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "yoga/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "yoga/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "yoga/**/*.cpp"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":yoga_hdrs"
@@ -148,8 +130,6 @@ objc_library(
     }
   ) + [
     "-IVendor/yoga/pod_support/Headers/Public/yoga/"
-  ] + [
-    "-fmodule-name=yoga"
   ],
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -50,9 +50,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -62,13 +65,18 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -78,24 +86,42 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -110,7 +136,8 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ),
   visibility = [
     "//visibility:public"
@@ -121,9 +148,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -133,13 +163,18 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -149,24 +184,42 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -239,8 +292,10 @@ objc_library(
             "Classes/osx/**/*.m",
             "Classes/osx/**/*.mm",
             "Classes/osx/**/*.s"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -274,8 +329,10 @@ objc_library(
             "Classes/ios/**/*.m",
             "Classes/ios/**/*.mm",
             "Classes/ios/**/*.s"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -284,12 +341,16 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = [
-          "Classes/**/*.S",
-          "Classes/**/*.c",
-          "Classes/**/*.m",
-          "Classes/**/*.s"
-        ]
+        exclude = glob(
+          [
+            "Classes/**/*.S",
+            "Classes/**/*.c",
+            "Classes/**/*.m",
+            "Classes/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -298,12 +359,16 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = [
-          "Classes/**/*.S",
-          "Classes/**/*.c",
-          "Classes/**/*.m",
-          "Classes/**/*.s"
-        ]
+        exclude = glob(
+          [
+            "Classes/**/*.S",
+            "Classes/**/*.c",
+            "Classes/**/*.m",
+            "Classes/**/*.s"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -354,7 +419,8 @@ swift_library(
         ],
         exclude = [
           "Classes/osx/**/*.swift"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -362,17 +428,20 @@ swift_library(
         ],
         exclude = [
           "Classes/ios/**/*.swift"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
           "Classes/**/*.swift"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
           "Classes/**/*.swift"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -387,9 +456,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -399,13 +471,18 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -415,24 +492,42 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ),
@@ -447,7 +542,8 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ]
+    ],
+    exclude_directories = 1
   ) + [
     ":youtube-ios-player-helper_cxx_public_hdrs"
   ],
@@ -460,9 +556,12 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -472,13 +571,18 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":osxCase": glob(
-        [
-          "pod_support/Headers/Public/**/*"
-        ] + glob(
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -488,24 +592,42 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ]
-        )
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
-        [
-          "pod_support/Headers/Public/**/*",
-          "Classes/**/*.h",
-          "Classes/**/*.hpp",
-          "Classes/**/*.hxx"
-        ]
+        glob(
+          [
+            "pod_support/Headers/Public/**/*"
+          ],
+          exclude_directories = 1
+        ) + glob(
+          [
+            "Classes/**/*.h",
+            "Classes/**/*.hpp",
+            "Classes/**/*.hxx"
+          ],
+          exclude_directories = 1
+        ),
+        exclude_directories = 1
       )
     }
   ) + [
@@ -556,7 +678,8 @@ objc_library(
           "Classes/osx/**/*.m",
           "Classes/osx/**/*.mm",
           "Classes/osx/**/*.s"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":osxCase": glob(
         [
@@ -574,7 +697,8 @@ objc_library(
           "Classes/ios/**/*.m",
           "Classes/ios/**/*.mm",
           "Classes/ios/**/*.s"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":tvosCase": glob(
         [
@@ -582,7 +706,8 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ]
+        ],
+        exclude_directories = 1
       ),
       ":watchosCase": glob(
         [
@@ -590,7 +715,8 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ]
+        ],
+        exclude_directories = 1
       )
     }
   ),
@@ -660,7 +786,8 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "youtube-ios-player-helper/Assets.bundle/**"
-    ]
+    ],
+    exclude_directories = 1
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -1,4 +1,3 @@
-load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
 load('@build_bazel_rules_apple//apple:resources.bzl', 'apple_bundle_import')
 load(
   "//Vendor/rules_pods/BazelExtensions:extensions.bzl",
@@ -50,12 +49,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -65,18 +61,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -86,42 +77,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -136,8 +109,7 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -148,12 +120,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -163,18 +132,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -184,42 +148,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -292,10 +238,8 @@ objc_library(
             "Classes/osx/**/*.m",
             "Classes/osx/**/*.mm",
             "Classes/osx/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
@@ -329,10 +273,8 @@ objc_library(
             "Classes/ios/**/*.m",
             "Classes/ios/**/*.mm",
             "Classes/ios/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
         [
@@ -341,16 +283,12 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Classes/**/*.S",
-            "Classes/**/*.c",
-            "Classes/**/*.m",
-            "Classes/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Classes/**/*.S",
+          "Classes/**/*.c",
+          "Classes/**/*.m",
+          "Classes/**/*.s"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -359,20 +297,15 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Classes/**/*.S",
-            "Classes/**/*.c",
-            "Classes/**/*.m",
-            "Classes/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Classes/**/*.S",
+          "Classes/**/*.c",
+          "Classes/**/*.m",
+          "Classes/**/*.s"
+        ]
       )
     }
   ),
-  module_map = ":youtube_ios_player_helper_extended_module_map_module_map_file",
   hdrs = [
     ":youtube-ios-player-helper_cxx_hdrs"
   ],
@@ -394,8 +327,6 @@ objc_library(
     }
   ) + [
     "-IVendor/youtube-ios-player-helper/pod_support/Headers/Public/youtube-ios-player-helper/"
-  ] + [
-    "-fmodule-name=youtube-ios-player-helper"
   ],
   data = [
     ":youtube-ios-player-helper_Bundle_Assets"
@@ -409,59 +340,14 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
 )
-swift_library(
-  name = "youtube-ios-player-helper_swift",
-  srcs = select(
-    {
-      "//conditions:default": glob(
-        [
-          "Classes/**/*.swift"
-        ],
-        exclude = [
-          "Classes/osx/**/*.swift"
-        ],
-        exclude_directories = 1
-      ),
-      ":osxCase": glob(
-        [
-          "Classes/**/*.swift"
-        ],
-        exclude = [
-          "Classes/ios/**/*.swift"
-        ],
-        exclude_directories = 1
-      ),
-      ":tvosCase": glob(
-        [
-          "Classes/**/*.swift"
-        ],
-        exclude_directories = 1
-      ),
-      ":watchosCase": glob(
-        [
-          "Classes/**/*.swift"
-        ],
-        exclude_directories = 1
-      )
-    }
-  ),
-  deps = [],
-  data = [],
-  visibility = [
-    "//visibility:public"
-  ]
-)
 filegroup(
   name = "youtube-ios-player-helper_direct_hdrs",
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -471,18 +357,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -492,42 +373,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -542,8 +405,7 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":youtube-ios-player-helper_cxx_public_hdrs"
   ],
@@ -556,12 +418,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -571,18 +430,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -592,42 +446,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ) + [
@@ -678,8 +514,7 @@ objc_library(
           "Classes/osx/**/*.m",
           "Classes/osx/**/*.mm",
           "Classes/osx/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
         [
@@ -697,8 +532,7 @@ objc_library(
           "Classes/ios/**/*.m",
           "Classes/ios/**/*.mm",
           "Classes/ios/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -706,8 +540,7 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -715,19 +548,16 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
-  module_map = ":youtube_ios_player_helper_extended_module_map_module_map_file",
   hdrs = [
     ":youtube-ios-player-helper_hdrs"
   ],
   pch = "pod_support/Headers/Private/youtube-ios-player-helper-prefix.pch",
   deps = [
     ":youtube-ios-player-helper_cxx",
-    ":youtube-ios-player-helper_swift",
     ":youtube-ios-player-helper_includes"
   ],
   copts = select(
@@ -742,8 +572,6 @@ objc_library(
     }
   ) + [
     "-IVendor/youtube-ios-player-helper/pod_support/Headers/Public/youtube-ios-player-helper/"
-  ] + [
-    "-fmodule-name=youtube-ios-player-helper"
   ],
   data = [
     ":youtube-ios-player-helper_Bundle_Assets"
@@ -757,37 +585,12 @@ acknowledged_target(
   deps = [],
   value = "//Vendor/youtube-ios-player-helper/pod_support_buildable:acknowledgement_fragment"
 )
-gen_module_map(
-  "youtube_ios_player_helper_extended_module_map_module_map_file",
-  "youtube_ios_player_helper_extended_module_map",
-  "youtube_ios_player_helper",
-  [
-    "youtube_ios_player_helper_public_hdrs"
-  ],
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  "youtube_ios_player_helper_module_map_module_map_file",
-  "youtube_ios_player_helper_module_map",
-  "youtube_ios_player_helper",
-  [
-    "youtube_ios_player_helper_extended_module_map_module_map_file",
-    "youtube_ios_player_helper_public_hdrs"
-  ],
-  module_map_name = "youtube_ios_player_helper.modulemap",
-  visibility = [
-    "//visibility:public"
-  ]
-)
 apple_bundle_import(
   name = "youtube-ios-player-helper_Bundle_Assets",
   bundle_imports = glob(
     [
       "youtube-ios-player-helper/Assets.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ build-test: pod_test build archive init-sandbox
 	cd Examples/ChildPodspec && make all
 	cd Examples/ArcSplitting && make all
 	cd Examples/React && make all
+	cd Examples/FBSDK && make all
 
 build-example: EXAMPLE=Examples/PINCache.podspec.json
 build-example: CONFIG = debug

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ build-test: pod_test build archive init-sandbox
 	cd Examples/ChildPodspec && make all
 	cd Examples/ArcSplitting && make all
 	cd Examples/React && make all
-	cd Examples/FBSDK && make all
+	cd Examples/SwiftSubspec && make all
+	# cd Examples/FBSDK && make all
 
 build-example: EXAMPLE=Examples/PINCache.podspec.json
 build-example: CONFIG = debug

--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -200,29 +200,41 @@ public struct PodBuildFile: SkylarkConvertible {
         return libraries.isEmpty ? [] : [ObjcImport(name: "\(spec.moduleName ?? spec.name)_VendoredLibraries", archives: libraries)]
     }
 
-    static func getSourceTypes(fromPodspec spec: PodSpec) ->
+    private static func getOwnSourceTypes(fromPodspec spec: PodSpec) ->
         Set<BazelSourceLibType> {
         let sources = spec.attr(\.sourceFiles)
+        let arcSources = spec.attr(\.requiresArc).map {
+            srcs -> [String] in
+            if case let .right(srcsVal) = srcs {
+                return srcsVal
+            }
+            return []
+        }
 
-        let objcLike = extractFiles(fromPattern: sources, includingFileTypes:
-                ObjcLikeFileTypes)
+        let objcLike = extractFiles(fromPattern: sources <> arcSources,
+            includingFileTypes: ObjcLikeFileTypes)
         var result: Set<BazelSourceLibType> = Set()
         if !objcLike.isEmpty {
             result.insert(.objc)
         }
 
-        let cppLike = extractFiles(fromPattern: sources, includingFileTypes:
+        let cppLike = extractFiles(fromPattern: sources <> arcSources, includingFileTypes:
                 CppLikeFileTypes)
         if !cppLike.isEmpty {
             result.insert(.cpp)
         }
 
-        let swiftLike = extractFiles(fromPattern: sources, includingFileTypes:
-                SwiftLikeFileTypes)
-        if !swiftLike.isEmpty {
+        if SwiftLibrary.hasSwiftSources(spec: spec) {
             result.insert(.swift)
         }
         return result
+    }
+
+    private static func getSourceTypes(fromPodspec spec: PodSpec) -> Set<BazelSourceLibType> {
+        let sourceTypes = PodBuildFile.getOwnSourceTypes(fromPodspec: spec)
+        return sourceTypes <> spec.selectedSubspecs().reduce(Set<BazelSourceLibType>()) {
+            $0 <> PodBuildFile.getOwnSourceTypes(fromPodspec: $1)
+        }
     }
 
     /// Construct source libs
@@ -231,9 +243,9 @@ public struct PodBuildFile: SkylarkConvertible {
     static func makeSourceLibs(parentSpecs: [PodSpec], spec: PodSpec,
             extraDeps: [BazelTarget], isRootSpec: Bool = false) -> [BazelTarget] {
         var sourceLibs: [BazelTarget] = []
-        // Split libs based on the sources involved.
         let sourceTypes = getSourceTypes(fromPodspec: spec)
-
+        let rootSpec = parentSpecs.first ?? spec
+        let packageSourceTypes = getSourceTypes(fromPodspec: rootSpec)
         let fallbackSpec = FallbackSpec(specs: [spec] +  parentSpecs)
 
         let externalName = getNamePrefix() + (parentSpecs.first?.name ?? spec.name)
@@ -246,40 +258,36 @@ public struct PodBuildFile: SkylarkConvertible {
                 headerDirectoryName.denormalize()) ?? AttrSet<String>(value:
                 externalName)
         let clangModuleName = headerName.basic?.replacingOccurrences(of: "-", with: "_") ?? ""
-
-        let podName = GetBuildOptions().podName
-        let name = computeLibName(parentSpecs: parentSpecs, spec: spec, podName:
-            podName, isSplitDep: false, sourceType: .objc)
-
         let isTopLevelTarget = parentSpecs.isEmpty
         let moduleMap: ModuleMap?
         let moduleMapTargets: [BazelTarget]
         let extendedModuleMap: ModuleMap?
         let options = GetBuildOptions()
 
+        let podName = GetBuildOptions().podName
+        let rootName = computeLibName(parentSpecs: [], spec: rootSpec, podName:
+            podName, isSplitDep: false, sourceType: .objc)
+
+        let publicHeaders = rootName + "_public_hdrs" 
         // When there is swift and Objc
         // - generate a module map
         // - extend the module map with the generated swift header
-        if sourceTypes.count > 1 && sourceTypes.contains(.swift) {
-            // Extend the module map
-            let mrname = clangModuleName
+        if packageSourceTypes.count > 1 && packageSourceTypes.contains(.swift) {
             moduleMapTargets = [
                 ModuleMap(
-                    name: mrname + "_extended",
-                    dirname: mrname + "_extended_module_map",
+                    name: clangModuleName + "_extended_module_map",
                     moduleName: clangModuleName,
-                    headers: [mrname + "_public_hdrs"],
-                    swiftHeader: "../" + mrname + "-Swift.h"
+                    headers: [publicHeaders],
+                    swiftHeader: "../" + clangModuleName + "-Swift.h"
                 ),
                 ModuleMap(
-                    name: mrname,
-                    dirname: mrname + "_module_map",
+                    name: clangModuleName + "_module_map",
                     moduleName: clangModuleName,
                     headers: [
-                        mrname + "_extended_module_map_module_map_file",
-                        mrname + "_public_hdrs"
+                        clangModuleName + "_extended_module_map",
+                        publicHeaders
                     ],
-                    moduleMapName: mrname + ".modulemap"
+                    moduleMapName: clangModuleName + ".modulemap"
                 )
             ]
             extendedModuleMap = moduleMapTargets[0] as! ModuleMap
@@ -287,10 +295,9 @@ public struct PodBuildFile: SkylarkConvertible {
         } else if options.generateModuleMap {
             moduleMapTargets = [
                 ModuleMap(
-                name: moduleName.basic ?? "",
-                dirname: name + "_module_map",
-                moduleName: clangModuleName,
-                headers: [externalName + "_hdrs"]
+                    name: clangModuleName + "_module_map",
+                    moduleName: clangModuleName,
+                    headers: [publicHeaders]
                 )
             ]
             moduleMap = moduleMapTargets[0] as! ModuleMap
@@ -301,11 +308,17 @@ public struct PodBuildFile: SkylarkConvertible {
             moduleMapTargets = []
         }
 
+        // If there is an extended module map, we need a dependency on the
+        // swift lib to generate the -Swift header
+        let extraDepNames = extraDeps.map { $0.name }
+        let extraObjcDepNames = extraDepNames
+            + (extendedModuleMap != nil ? [rootName + "_swift"] : [])
+
         let objcModuleMap = extendedModuleMap ?? moduleMap
         let swiftModuleMap = sourceTypes.count == 0  ? nil : moduleMap
         if sourceTypes.count == 0 {
             sourceLibs.append(ObjcLibrary(parentSpecs: parentSpecs, spec: spec,
-                        extraDeps: extraDeps.map { $0.name }, sourceType:
+                        extraDeps: extraObjcDepNames, sourceType:
                         .objc, moduleMap: objcModuleMap))
         } else if sourceTypes.count == 1 && sourceTypes.first != .swift {
             // For swift, we _always_ generate a top level ObjcLibrary for now.
@@ -315,13 +328,13 @@ public struct PodBuildFile: SkylarkConvertible {
             if sourceTypes.first == .swift {
                 if isTopLevelTarget {
                     sourceLibs.append(SwiftLibrary(parentSpecs: parentSpecs, spec: spec,
-                                extraDeps: extraDeps.map { $0.name },
+                                extraDeps: extraDepNames,
                                 moduleMap: swiftModuleMap))
             
                 }
             } else {
                 sourceLibs.append(ObjcLibrary(parentSpecs: parentSpecs, spec: spec,
-                            extraDeps: extraDeps.map { $0.name },
+                            extraDeps: extraObjcDepNames,
                             sourceType: sourceTypes.first!, moduleMap: objcModuleMap))
             }
         } else {
@@ -341,7 +354,7 @@ public struct PodBuildFile: SkylarkConvertible {
             if isTopLevelTarget && sourceTypes.contains(.swift) {
                 // Append a swift library.
                 let swiftLib = SwiftLibrary(parentSpecs: parentSpecs, spec: spec,
-                        extraDeps: extraDeps.map { $0.name },
+                        extraDeps: extraDepNames,
                         isSplitDep: true, moduleMap: swiftModuleMap)
                 splitDeps.append(swiftLib)
                 sourceLibs.append(swiftLib)
@@ -349,7 +362,7 @@ public struct PodBuildFile: SkylarkConvertible {
 
             // In this case, the root lib is Objc
             let rootLib = ObjcLibrary(parentSpecs: parentSpecs, spec: spec,
-                    extraDeps: (extraDeps + splitDeps).map { $0.name },
+                    extraDeps: extraObjcDepNames + (splitDeps.map { $0.name }),
                     moduleMap: objcModuleMap)
             sourceLibs.append(rootLib)
         }
@@ -387,7 +400,6 @@ public struct PodBuildFile: SkylarkConvertible {
         // Note: we use `ObjcLibrary` here to get the name only.
         // Note: We don't currently support having the default being a nested subspec. This also doesn't do anything
         // with subspecs' default subspecs (for nested subspecs).
-        // TODO: how does filtering impact dep splitting?
         let filteredSpecs = podSpec.subspecs
             .filter { defaultSubspecs.contains($0.name) }
             .map { ObjcLibrary(parentSpecs: [podSpec], spec: $0, extraDeps: []).name }
@@ -403,14 +415,13 @@ public struct PodBuildFile: SkylarkConvertible {
         let allRootDeps = ((defaultSubspecTargets.isEmpty ? subspecTargets :
                     defaultSubspecTargets) + extraDeps)
             .filter { !($0 is AppleResourceBundle || $0 is AppleBundleImport) }
+
         let sourceLibs = makeSourceLibs(parentSpecs: [], spec: podSpec, extraDeps:
                 allRootDeps)
 
         var output: [BazelTarget] = sourceLibs + subspecTargets +
             bundleLibraries(withPodSpec: podSpec) + extraDeps
 
-        // Execute transforms manually
-        // Don't use unneeded abstractions to make a few function calls
         output = UserConfigurableTransform.transform(convertibles: output,
                                                      options: buildOptions,
                                                      podSpec: podSpec)

--- a/Sources/PodToBUILD/GlobUtils.swift
+++ b/Sources/PodToBUILD/GlobUtils.swift
@@ -143,11 +143,11 @@ public class Glob: Collection {
                 }
             } catch {
                 directories = []
-                print("Error parsing file system item: \(error)")
+                fputs("Error parsing file system item: \(error)", __stderrp)
             }
         } else {
             directories = []
-            print("Error parsing file system item: EMPTY")
+            fputs("Error parsing file system item: EMPTY\n", __stderrp)
         }
 
         if behavior.includesFilesFromRootOfGlobstar {

--- a/Sources/PodToBUILD/ModuleMap.swift
+++ b/Sources/PodToBUILD/ModuleMap.swift
@@ -1,15 +1,13 @@
 public struct ModuleMap: BazelTarget {
     public let name: String // A unique name for this rule.
-    public let dirname: String
     public let moduleName: String
     public let headers: [String]
     public let swiftHeader: String?
     public let moduleMapName: String?
 
-    public init(name: String, dirname: String, moduleName: String, headers:
+    public init(name: String, moduleName: String, headers:
                 [String], swiftHeader: String? = nil, moduleMapName: String? = nil) {
-        self.name = name + "_module_map_module_map_file"
-        self.dirname = dirname
+        self.name = name
         self.moduleName = moduleName
         self.headers = headers
         self.swiftHeader = swiftHeader
@@ -22,13 +20,15 @@ public struct ModuleMap: BazelTarget {
 
     public func toSkylark() -> SkylarkNode {
         var args: [SkylarkFunctionArgument] = [
-            .basic(name.toSkylark()),
-            .basic(dirname.toSkylark()),
-            .basic(moduleName.toSkylark()),
-            .basic(headers.toSkylark())
+            .named(name: "name", value: name.toSkylark()),
+            .named(name: "module_name", value: moduleName.toSkylark()),
+            .named(name: "hdrs", value: headers.toSkylark()),
         ]
         if let moduleMapName = self.moduleMapName {
             args.append(.named(name: "module_map_name", value: moduleMapName.toSkylark()))
+        }
+        if let swiftHeader = self.swiftHeader {
+            args.append(.named(name: "swift_header", value: swiftHeader.toSkylark()))
         }
         args.append(.named(name: "visibility", value: ["//visibility:public"].toSkylark()))
         return SkylarkNode.functionCall(

--- a/Sources/PodToBUILD/MultiPlatform.swift
+++ b/Sources/PodToBUILD/MultiPlatform.swift
@@ -229,6 +229,23 @@ public struct AttrSet<T: AttrSetConstraint>: Monoid, SkylarkConvertible, EmptyAw
         }
     }
 }
+
+extension AttrSet {
+    ///  Sequences a list of `AttrSet`s to a list of each input's value
+    public func sequence(_ input: [AttrSet<T>]) -> AttrSet<[T]> {
+        return ([self] + input).reduce(AttrSet<[T]>.empty) {
+            accum, next -> AttrSet<[T]> in
+            return accum.zip(next).map { zip in
+                let first = zip.first ?? []
+                guard let second = zip.second else {
+                    return first
+                }
+                return first + [second]
+            }
+        }
+    }
+}
+
 extension MultiPlatform where T == Optional<String> {
     public func denormalize() -> MultiPlatform<String> {
         return self.map { $0.denormalize() }

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -14,7 +14,10 @@
 public struct SwiftLibrary: BazelTarget {
     public let name: String
     public let sourceFiles: AttrSet<GlobNode>
+    public let moduleMap: ModuleMap?
     public let deps: AttrSet<[String]>
+    public let copts: AttrSet<[String]>
+    public let swiftcInputs: AttrSet<[String]>
 
     public let isTopLevelTarget: Bool
     public let externalName: String
@@ -22,78 +25,171 @@ public struct SwiftLibrary: BazelTarget {
 
     public init(name: String,
                 sourceFiles: AttrSet<GlobNode>,
+                moduleMap: ModuleMap?,
                 deps: AttrSet<[String]>,
+                copts: AttrSet<[String]>,
+                swiftcInputs: AttrSet<[String]>,
                 isTopLevelTarget: Bool,
                 externalName: String,
                 data: AttrSet<GlobNode>) {
         self.name = name
         self.sourceFiles = sourceFiles
+        self.moduleMap = moduleMap
         self.externalName = externalName
 
         self.isTopLevelTarget = isTopLevelTarget
         self.deps = deps
+        self.copts = copts
+        self.swiftcInputs = swiftcInputs
+
         self.data = data
     }
 
+    public static func hasSwiftSources(spec: PodSpec) -> Bool {
+        return SwiftLibrary.getSources(spec: spec).hasSourcesOnDisk()
+    }
 
-    init(parentSpecs: [PodSpec], spec: PodSpec, extraDeps: [String] = [],
-            isSplitDep: Bool = false, moduleMap: ModuleMap? = nil) {
-        let fallbackSpec = FallbackSpec(specs: parentSpecs + [spec])
-        self.isTopLevelTarget = parentSpecs.isEmpty && isSplitDep == false
-
-        let podName = GetBuildOptions().podName
-        self.name = computeLibName(
-                parentSpecs: parentSpecs,
-                spec: spec,
-                podName: podName,
-                isSplitDep: isSplitDep,
-                sourceType: .swift
-        )
-
+    /// For swift, we crush the podspec sources into 1 lib
+    /// The function returns a union all the the spec's sources
+    private static func getSources(spec: PodSpec) -> AttrSet<GlobNode> {
         let allSourceFiles = spec.attr(\.sourceFiles)
         let implFiles = extractFiles(fromPattern: allSourceFiles,
-                includingFileTypes: SwiftLikeFileTypes)
+             includingFileTypes: SwiftLikeFileTypes)
+            .unpackToMulti()
             .map { Set($0) }
-
 
         let allExcludes = spec.attr(\.excludeFiles)
         let implExcludes = extractFiles(fromPattern: allExcludes,
-                includingFileTypes: SwiftLikeFileTypes)
+            includingFileTypes: SwiftLikeFileTypes)
+            .unpackToMulti()
             .map { Set($0) }
 
-        self.sourceFiles = implFiles.zip(implExcludes).unpackToMulti().map {
-            t -> GlobNode in
-            return GlobNode(include: .left(t.first ?? Set()), exclude: .left(t.second ?? Set()))
+        // Apply excludes to the sources
+        let specSources = implFiles.zip(implExcludes).map {
+            GlobNode(include: .left($0.first ?? Set()), exclude: .left($0.second ?? Set()))
         }
+        let subspecSources: [AttrSet<GlobNode>] = spec.selectedSubspecs()
+            .map { getSources(spec: $0) }
+        return specSources.zip(AttrSet.empty.sequence(subspecSources))
+           .map {
+            attrTuple -> GlobNode in
+            let first = attrTuple.first ?? .empty
+            let second: [GlobNode] = attrTuple.second ?? []
+            if first != .empty, second.count > 0 {
+                let include = ([first] + second).map { Either<Set<String>, GlobNode>.right($0) }
+                return GlobNode(include: include, exclude: [])
+            } else if second.count > 0 {
+                return GlobNode(include: second.map { Either<Set<String>, GlobNode>.right($0) }, exclude: [])
+            } else if first != .empty {
+                return first
+            } else {
+                return .empty
+            }
+        }
+    }
+
+    /// Note: this initializer has assumptions on the way that it's used, and
+    /// all subspec sources are collected here.
+    /// there is 1 swift_library per podspec
+    init(parentSpecs: [PodSpec], spec: PodSpec, extraDeps: [String] = [],
+         isSplitDep: Bool = false,
+         moduleMap: ModuleMap? = nil) {
+        isTopLevelTarget = parentSpecs.isEmpty && isSplitDep == false
+        let podName = GetBuildOptions().podName
+        let name = computeLibName(
+            parentSpecs: parentSpecs,
+            spec: spec,
+            podName: podName,
+            isSplitDep: isSplitDep,
+            sourceType: .swift
+        )
+        self.name = name 
+
+        self.sourceFiles = SwiftLibrary.getSources(spec: spec)
 
         self.externalName = parentSpecs.first?.name ?? spec.name
 
         let resourceFiles = (spec.attr(\.resources).map { (strArr: [String]) -> [String] in
-            strArr.filter({ (str: String) -> Bool in
+            strArr.filter { (str: String) -> Bool in
                 !str.hasSuffix(".bundle")
-            })
+            }
         }).map(extractResources)
-        self.data = resourceFiles.map{ GlobNode(include: Set($0)) }
-        // Lift the deps to multiplatform, then get the names of these deps.
-        let mpDeps = fallbackSpec.attr(\.dependencies)
-        let mpPodSpecDeps = mpDeps.map { $0.map {
-            getDependencyName(fromPodDepName: $0, podName: podName) } }
+        self.data = resourceFiles.map { GlobNode(include: Set($0)) }
 
-        let extraDepNames = extraDeps.map { bazelLabel(fromString: ":\($0)") }
-
-        self.deps = AttrSet(basic: extraDepNames) <> mpPodSpecDeps
+        // Extract deps from the entire podspec
+        let allDepsArr: [AttrSet<[String]>] = ([spec] + spec.selectedSubspecs())
+            .map { $0.attr(\.dependencies) }
+        let allDeps = AttrSet.empty.sequence(allDepsArr).map {
+            depsArr -> [String] in
+            return depsArr.reduce([String]()) { $0 + $1 }
+        }
+        // `swift_library` depends on the public interface
+        self.deps = allDeps.map {
+	    $0.map {
+                getDependencyName(fromPodDepName: $0, podName: podName)
+            }.filter {
+                $0.hasPrefix("//") || $0.hasPrefix("@")
+            }
+        }
+ 
+        self.copts = AttrSet.empty
+        self.swiftcInputs = AttrSet.empty
+        self.moduleMap = moduleMap
     }
 
     public func toSkylark() -> SkylarkNode {
+        var swiftcInputs = self.swiftcInputs
+        var copts = self.copts
+        let options = GetBuildOptions()
+        // Note: we don't expose this module map upwards.
+        // Dependent top level objc libraries will expose an extended module map
+        let headerMapName = self.name.replacingOccurrences(of: "_swift", with: "")
+        if options.generateHeaderMap {
+            swiftcInputs = swiftcInputs <> AttrSet(basic: [
+                ":" + headerMapName + "_hmap",
+            ])
+            copts = copts <> AttrSet(basic: [
+                "-Xcc",
+                "-I$(execpath " + headerMapName + "_hmap)",
+            ])
+        }
+
+        copts = copts <> AttrSet(basic: [
+            "-Xcc",
+            "-I.",
+        ])
+        if let moduleMap = self.moduleMap {
+            copts = copts <> AttrSet(basic: [
+                "-Xcc",
+                "-D__SWIFTC__",
+                "-Xfrontend",
+                "-no-clang-module-breadcrumbs",
+                "-Xcc",
+                "-fmodule-map-file=$(execpath " + moduleMap.name + ")",
+                "-import-underlying-module",
+            ])
+
+            swiftcInputs = swiftcInputs <> AttrSet(basic: [moduleMap.name])
+        }
+
+        let deps = self.deps.map {
+            Set($0).sorted(by: (<))
+        }.toSkylark()
         return .functionCall(
             name: "swift_library",
             arguments: [
                 .named(name: "name", value: name.toSkylark()),
+                .named(name: "module_name", value: externalName.toSkylark()),
                 .named(name: "srcs", value: sourceFiles.toSkylark()),
-                .named(name: "deps", value: deps.sorted(by: (<)).toSkylark()),
+                .named(name: "deps", value: deps),
                 .named(name: "data", value: data.toSkylark()),
-                .named(name: "visibility", value: .list(["//visibility:public"]))
-            ])
+                .named(name: "copts", value: copts.toSkylark()),
+                .named(name: "swiftc_inputs", value: swiftcInputs.toSkylark()),
+                .named(name: "generated_header_name", value: (externalName + "-Swift.h").toSkylark()),
+                .named(name: "features", value: ["swift.no_generated_module_map"].toSkylark()),
+                .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
+            ]
+        )
     }
 }
 
@@ -103,3 +199,26 @@ private func extractResources(patterns: [String]) -> [String] {
     }
 }
 
+extension PodSpec {
+    func allSubspecs(_ isSubspec: Bool = false) -> [PodSpec] {
+        return (isSubspec ? [self] : []) + self.subspecs.reduce([PodSpec]()) {
+            return $0 + $1.allSubspecs(true)
+        }
+    }
+
+
+    /// Returns selected subspecs
+    /// Note: because we reduce sources into a single swift library, it must
+    /// consider subspecs that are included, otherwise, it would pull in sources
+    /// from the entire podspec.
+    /// Currently it uses `Default` subspecs.
+    /// Ideally, should be a way to add other sources to this.
+    func selectedSubspecs() -> [PodSpec] {
+        let defaultSubspecs = Set(self.defaultSubspecs)
+        let subspecs = allSubspecs()
+        guard !defaultSubspecs.isEmpty else {
+            return subspecs
+        }
+        return subspecs.filter { defaultSubspecs.contains($0.name) }
+    }
+}

--- a/Sources/PodToBUILD/XCConfig.swift
+++ b/Sources/PodToBUILD/XCConfig.swift
@@ -43,9 +43,13 @@ public struct XCConfigTransformer {
         let allValues = value.components(separatedBy: CharacterSet.whitespaces)
         return allValues.filter { $0 != "$(inherited)" }
             .compactMap { val in
+                let podDir = getPodBaseDir()
+                let targetDir = getGenfileOutputBaseDir()
                 return transformer.string(forXCConfigValue: val)?
-                    .replacingOccurrences(of: "$(PODS_ROOT)", with: getPodBaseDir())
-                    .replacingOccurrences(of: "$(PODS_TARGET_SRCROOT)", with: getPodBaseDir())
+                    .replacingOccurrences(of: "$(PODS_ROOT)", with: podDir)
+                    .replacingOccurrences(of: "${PODS_ROOT}", with: podDir)
+                    .replacingOccurrences(of: "$(PODS_TARGET_SRCROOT)", with: targetDir)
+                    .replacingOccurrences(of: "${PODS_TARGET_SRCROOT}", with: targetDir)
             }
     }
 

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -285,7 +285,6 @@ public enum RepoActions {
             target in
             let name = target.name
             let head = buildOptions.podName + "_"
-            //if target is AcknowledgmentNode {
             if head + "acknowledgement" == target.name {
                 return target.name
             }

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -280,6 +280,21 @@ public enum RepoActions {
         }
         let buildFile = PodBuildFile.with(podSpec: podSpec, buildOptions:
             buildOptions, assimilate: true)
+        
+        let getAliasName: (BazelTarget) -> String = {
+            target in
+            let name = target.name
+            let head = buildOptions.podName + "_"
+            //if target is AcknowledgmentNode {
+            if head + "acknowledgement" == target.name {
+                return target.name
+            }
+            if let headIdx = name.range(of: head) {
+                return String(name[headIdx.upperBound...])
+            } else {
+                return name
+            }
+        }
 
         let actualPath = parts[0] + "/" + parts[1]
         let aliases = buildFile.skylarkConvertibles.compactMap {
@@ -291,23 +306,27 @@ public enum RepoActions {
                 return nil
             }
             let name = target.name
-            let head = buildOptions.podName + "_"
-            let getName: () -> String = {
-                if head + "acknowledgement" == target.name {
-                    return target.name
-                }
-                if let headIdx = name.range(of: head) {
-                    return String(name[headIdx.upperBound...])
-                } else {
-                    return name
-                }
-            }
-            let alias = Alias(name: getName(),
+            let alias = Alias(name: getAliasName(target),
                 actual: "//" + actualPath + ":" + name)
             return alias.toSkylark()
         }
 
-        let lines = [visibility] + aliases
+        // Note: we currently have to alias here because header map isn't a
+        // BazelTarget
+        // TODO: Move ad-hoc bazel targets from ObjcLibrary to BuildFile
+        let hmapAliases = buildFile.skylarkConvertibles.compactMap {
+            convertible -> SkylarkNode? in
+            guard buildOptions.generateHeaderMap,
+                let target = convertible as? ObjcLibrary else {
+                return nil
+            }
+            let name = target.name
+            let alias = Alias(name: getAliasName(target) + "_hmap",
+                actual: "//" + actualPath + ":" + name + "_hmap")
+            return alias.toSkylark()
+        }
+
+        let lines = [visibility] + aliases + hmapAliases
         let compiler = SkylarkCompiler(lines)
         shell.write(value: compiler.run(), toPath:
             BazelConstants.buildFileURL())

--- a/Tests/PodToBUILDTests/BuildFileTests.swift
+++ b/Tests/PodToBUILDTests/BuildFileTests.swift
@@ -168,6 +168,16 @@ class BuildFileTests: XCTestCase {
         )
     }
 
+    // MARK: - Swift tests
+
+    func testSwiftExtractionSubspec() {
+        let podspec = examplePodSpecNamed(name: "ObjcParentWithSwiftSubspecs")
+        let convs = PodBuildFile.makeConvertables(fromPodspec: podspec)
+        XCTAssertEqual(convs.compactMap{ $0 as? ObjcLibrary }.count, 1)
+        XCTAssertEqual(convs.compactMap{ $0 as? SwiftLibrary }.count, 1)
+    }
+
+
     // MARK: - Source File Extraction Tests
 
     func testExtractionCurly() {

--- a/Tests/PodToBUILDTests/BuildFileTests.swift
+++ b/Tests/PodToBUILDTests/BuildFileTests.swift
@@ -173,8 +173,9 @@ class BuildFileTests: XCTestCase {
     func testSwiftExtractionSubspec() {
         let podspec = examplePodSpecNamed(name: "ObjcParentWithSwiftSubspecs")
         let convs = PodBuildFile.makeConvertables(fromPodspec: podspec)
-        XCTAssertEqual(convs.compactMap{ $0 as? ObjcLibrary }.count, 1)
-        XCTAssertEqual(convs.compactMap{ $0 as? SwiftLibrary }.count, 1)
+        XCTAssertEqual(convs.compactMap{ $0 as? ObjcLibrary }.count, 3)
+        // Note that we check for sources on disk to generate this.
+        XCTAssertEqual(convs.compactMap{ $0 as? SwiftLibrary }.count, 0)
     }
 
 


### PR DESCRIPTION
This PR adds mixed module swift support with the constraints that Xcode
and the PodSpec supports. An objc library may depend on a swiftmodule
and the swift module implicitly imports the public objc module.
Currently, all sources are propagated to a single `swift_library` to
produce a single `swiftc` invocation. The swift interface header is
included in a public module map, while the public headers are exposed
to the `swiftc` invocation through a private module map

Additionally, it cleans up the rule for module map to be simpler and
more easily used in this context. The `BazelTarget` for this rule
additionally passes named arguments to improve readability.

Note: because we reduce sources into a single swift library, it must
consider subspecs that are included, otherwise, it would pull in sources
from the entire podspec. Currently it uses `Default` subspecs. As a
followup, we need to add an option to `new_pod_repository` to select
subspecs. Additionally, I'll follow up to fix the ad-hoc targets in
`ObjcLibrary`

It also adds FBSDK as a build test.