### PR TITLE
Simplify globs, simplfy rendering

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -51,8 +51,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +71,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -153,19 +151,11 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Adjust/*.h",
-        "Adjust/ADJAdditions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Adjust/*.h",
+      "Adjust/ADJAdditions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -177,8 +167,7 @@ filegroup(
     [
       "Adjust/*.h",
       "Adjust/ADJAdditions/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -187,19 +176,11 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Adjust/*.h",
-        "Adjust/ADJAdditions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Adjust/*.h",
+      "Adjust/ADJAdditions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -241,23 +222,11 @@ objc_library(
       "Adjust/*.m",
       "Adjust/ADJAdditions/*.m"
     ],
-    exclude = glob(
-      [
-        "plugin/Sociomantic/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "plugin/Sociomantic/*.m",
+      "plugin/Criteo/*.m",
+      "plugin/Trademob/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -307,18 +276,10 @@ acknowledged_target(
 filegroup(
   name = "Sociomantic_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Sociomantic/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Sociomantic/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -329,8 +290,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Sociomantic/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -341,18 +301,10 @@ filegroup(
 filegroup(
   name = "Sociomantic_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Sociomantic/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Sociomantic/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -395,8 +347,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Sociomantic/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Sociomantic_hdrs"
@@ -447,18 +398,10 @@ acknowledged_target(
 filegroup(
   name = "Criteo_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Criteo/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -469,8 +412,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Criteo/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -481,18 +423,10 @@ filegroup(
 filegroup(
   name = "Criteo_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Criteo/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Criteo/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -535,8 +469,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Criteo/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Criteo_hdrs"
@@ -587,18 +520,10 @@ acknowledged_target(
 filegroup(
   name = "Trademob_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Trademob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -609,8 +534,7 @@ filegroup(
   srcs = glob(
     [
       "plugin/Trademob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -621,18 +545,10 @@ filegroup(
 filegroup(
   name = "Trademob_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "plugin/Trademob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "plugin/Trademob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -675,8 +591,7 @@ objc_library(
   srcs = glob(
     [
       "plugin/Trademob/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Trademob_hdrs"

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -50,8 +50,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +71,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_hdrs",
     ":Core_hdrs"
@@ -106,171 +104,6 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -331,19 +164,11 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -354,8 +179,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -364,19 +188,11 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -523,14 +339,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -637,14 +449,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -797,14 +605,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -911,14 +715,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),
@@ -947,10 +747,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1060,16 +858,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                   "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -1091,10 +884,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1201,16 +992,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -1278,10 +1064,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1434,16 +1218,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -1465,10 +1244,8 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
+            ]
+          )
         ),
         exclude = glob(
           [
@@ -1575,16 +1352,11 @@ objc_library(
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                   "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-                ],
-                exclude_directories = 1
-              ),
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+                ]
+              )
+            )
+          )
+        )
       )
     }
   ),
@@ -1651,8 +1423,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1665,12 +1436,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1685,18 +1453,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1708,18 +1471,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1763,18 +1521,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1786,10 +1539,8 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -1804,8 +1555,7 @@ filegroup(
       "FBSDKCoreKit/FBSDKCoreKit/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -1818,12 +1568,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1838,18 +1585,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.h",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1861,18 +1603,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1916,18 +1653,13 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h",
@@ -1939,10 +1671,8 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2089,12 +1819,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
               "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -2196,12 +1923,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -2349,12 +2073,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -2456,12 +2177,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       )
     }
   ),
@@ -2485,8 +2203,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
             "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2591,14 +2308,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceButton.m",
                 "FBSDKCoreKit/FBSDKCoreKit/FBSDKDeviceViewControllerBase.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -2615,8 +2328,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2718,14 +2430,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -2788,8 +2496,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -2937,14 +2644,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -2961,8 +2664,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -3064,14 +2766,10 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Basics/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":AppLinks_hdrs",
     ":Tasks_hdrs"
@@ -141,18 +139,10 @@ acknowledged_target(
 filegroup(
   name = "Tasks_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Bolts/Common/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Bolts/Common/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -163,8 +153,7 @@ filegroup(
   srcs = glob(
     [
       "Bolts/Common/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -173,18 +162,10 @@ filegroup(
 filegroup(
   name = "Tasks_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Bolts/Common/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Bolts/Common/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -227,31 +208,24 @@ objc_library(
         [
           "Bolts/Common/*.m"
         ],
-        exclude = glob(
-          [
-            "Bolts/iOS/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Bolts/iOS/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "Bolts/Common/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -291,37 +265,26 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Bolts/iOS/**/*.h",
-            "Bolts/iOS/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Bolts/iOS/**/*.h",
+          "Bolts/iOS/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -336,8 +299,7 @@ filegroup(
       "//conditions:default": glob(
         [
           "Bolts/iOS/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -352,37 +314,26 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Bolts/iOS/**/*.h",
-            "Bolts/iOS/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Bolts/iOS/**/*.h",
+          "Bolts/iOS/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -429,8 +380,7 @@ objc_library(
       "//conditions:default": glob(
         [
           "Bolts/iOS/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -60,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,8 +83,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_hdrs",
     ":Core_hdrs",
@@ -162,19 +160,11 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCore/**/*.h",
-        "BraintreeCore/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCore/**/*.h",
+      "BraintreeCore/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -185,8 +175,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCore/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -195,19 +184,11 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCore/**/*.h",
-        "BraintreeCore/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCore/**/*.h",
+      "BraintreeCore/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -248,58 +229,18 @@ objc_library(
     [
       "BraintreeCore/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeApplePay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeApplePay/**/*.m",
+      "BraintreeCard/**/*.m",
+      "BraintreeDataCollector/**/*.m",
+      "BraintreePayPal/*.m",
+      "BraintreeVenmo/**/*.m",
+      "BraintreeUI/**/*.m",
+      "BraintreeUnionPay/**/*.m",
+      "Braintree3DSecure/**/*.m",
+      "BraintreePayPal/PayPalOneTouch/**/*.m",
+      "BraintreePayPal/PayPalDataCollector/**/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -343,19 +284,11 @@ acknowledged_target(
 filegroup(
   name = "Apple-Pay_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeApplePay/**/*.h",
-        "BraintreeApplePay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeApplePay/**/*.h",
+      "BraintreeApplePay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -366,8 +299,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeApplePay/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -378,19 +310,11 @@ filegroup(
 filegroup(
   name = "Apple-Pay_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeApplePay/**/*.h",
-        "BraintreeApplePay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeApplePay/**/*.h",
+      "BraintreeApplePay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -433,8 +357,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeApplePay/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Apple-Pay_hdrs"
@@ -476,19 +399,11 @@ acknowledged_target(
 filegroup(
   name = "Card_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.h",
-        "BraintreeCard/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCard/**/*.h",
+      "BraintreeCard/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -499,8 +414,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeCard/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -511,19 +425,11 @@ filegroup(
 filegroup(
   name = "Card_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeCard/**/*.h",
-        "BraintreeCard/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeCard/**/*.h",
+      "BraintreeCard/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -567,23 +473,11 @@ objc_library(
     [
       "BraintreeCard/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeUI/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeUI/**/*.m",
+      "BraintreeUnionPay/**/*.m",
+      "Braintree3DSecure/**/*.m"
+    ]
   ),
   hdrs = [
     ":Card_hdrs"
@@ -622,19 +516,11 @@ acknowledged_target(
 filegroup(
   name = "DataCollector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.h",
-        "BraintreeDataCollector/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeDataCollector/**/*.h",
+      "BraintreeDataCollector/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -645,8 +531,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeDataCollector/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -657,19 +542,11 @@ filegroup(
 filegroup(
   name = "DataCollector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeDataCollector/**/*.h",
-        "BraintreeDataCollector/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeDataCollector/**/*.h",
+      "BraintreeDataCollector/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -712,8 +589,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeDataCollector/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":DataCollector_hdrs"
@@ -764,19 +640,11 @@ acknowledged_target(
 filegroup(
   name = "PayPal_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.h",
-        "BraintreePayPal/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/*.h",
+      "BraintreePayPal/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -787,8 +655,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalOneTouch_public_hdrs"
@@ -800,19 +667,11 @@ filegroup(
 filegroup(
   name = "PayPal_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.h",
-        "BraintreePayPal/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/*.h",
+      "BraintreePayPal/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -857,8 +716,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreePayPal/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PayPal_hdrs"
@@ -898,19 +756,11 @@ acknowledged_target(
 filegroup(
   name = "Venmo_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.h",
-        "BraintreeVenmo/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeVenmo/**/*.h",
+      "BraintreeVenmo/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -921,8 +771,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeVenmo/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs"
@@ -934,19 +783,11 @@ filegroup(
 filegroup(
   name = "Venmo_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeVenmo/**/*.h",
-        "BraintreeVenmo/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeVenmo/**/*.h",
+      "BraintreeVenmo/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -991,8 +832,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeVenmo/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Venmo_hdrs"
@@ -1034,8 +874,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Drop-In/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1048,8 +887,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "BraintreeUI/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1060,19 +898,11 @@ acknowledged_target(
 filegroup(
   name = "UI_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.h",
-        "BraintreeUI/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUI/**/*.h",
+      "BraintreeUI/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1083,8 +913,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUI/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1096,19 +925,11 @@ filegroup(
 filegroup(
   name = "UI_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUI/**/*.h",
-        "BraintreeUI/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUI/**/*.h",
+      "BraintreeUI/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1153,8 +974,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUI/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":UI_hdrs"
@@ -1201,19 +1021,11 @@ acknowledged_target(
 filegroup(
   name = "UnionPay_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.h",
-        "BraintreeUnionPay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUnionPay/**/*.h",
+      "BraintreeUnionPay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1224,8 +1036,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreeUnionPay/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1237,19 +1048,11 @@ filegroup(
 filegroup(
   name = "UnionPay_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreeUnionPay/**/*.h",
-        "BraintreeUnionPay/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreeUnionPay/**/*.h",
+      "BraintreeUnionPay/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1294,8 +1097,7 @@ objc_library(
   srcs = glob(
     [
       "BraintreeUnionPay/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":UnionPay_hdrs"
@@ -1340,8 +1142,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "Braintree3DSecure/Localization/*.lproj"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -1352,19 +1153,11 @@ acknowledged_target(
 filegroup(
   name = "3D-Secure_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.h",
-        "Braintree3DSecure/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Braintree3DSecure/**/*.h",
+      "Braintree3DSecure/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1375,8 +1168,7 @@ filegroup(
   srcs = glob(
     [
       "Braintree3DSecure/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Card_public_hdrs",
     ":Core_public_hdrs"
@@ -1388,19 +1180,11 @@ filegroup(
 filegroup(
   name = "3D-Secure_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Braintree3DSecure/**/*.h",
-        "Braintree3DSecure/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Braintree3DSecure/**/*.h",
+      "Braintree3DSecure/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1445,8 +1229,7 @@ objc_library(
   srcs = glob(
     [
       "Braintree3DSecure/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":3D-Secure_hdrs"
@@ -1492,19 +1275,11 @@ acknowledged_target(
 filegroup(
   name = "PayPalOneTouch_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.h",
-        "BraintreePayPal/PayPalOneTouch/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalOneTouch/**/*.h",
+      "BraintreePayPal/PayPalOneTouch/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1515,8 +1290,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalOneTouch/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalDataCollector_public_hdrs",
@@ -1529,19 +1303,11 @@ filegroup(
 filegroup(
   name = "PayPalOneTouch_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.h",
-        "BraintreePayPal/PayPalOneTouch/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalOneTouch/**/*.h",
+      "BraintreePayPal/PayPalOneTouch/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1589,13 +1355,9 @@ objc_library(
     [
       "BraintreePayPal/PayPalOneTouch/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreePayPal/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalOneTouch_hdrs"
@@ -1644,20 +1406,12 @@ acknowledged_target(
 filegroup(
   name = "PayPalDataCollector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.h",
-        "BraintreePayPal/PayPalDataCollector/Public/*.h",
-        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalDataCollector/**/*.h",
+      "BraintreePayPal/PayPalDataCollector/Public/*.h",
+      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1669,8 +1423,7 @@ filegroup(
     [
       "BraintreePayPal/PayPalDataCollector/Public/*.h",
       "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":PayPalUtils_public_hdrs"
@@ -1682,20 +1435,12 @@ filegroup(
 filegroup(
   name = "PayPalDataCollector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.h",
-        "BraintreePayPal/PayPalDataCollector/Public/*.h",
-        "BraintreePayPal/PayPalDataCollector/Risk/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalDataCollector/**/*.h",
+      "BraintreePayPal/PayPalDataCollector/Public/*.h",
+      "BraintreePayPal/PayPalDataCollector/Risk/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1741,18 +1486,10 @@ objc_library(
     [
       "BraintreePayPal/PayPalDataCollector/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreeVenmo/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreeVenmo/**/*.m",
+      "BraintreePayPal/PayPalOneTouch/**/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalDataCollector_hdrs"
@@ -1810,19 +1547,11 @@ acknowledged_target(
 filegroup(
   name = "PayPalUtils_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalUtils/**/*.h",
-        "BraintreePayPal/PayPalUtils/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalUtils/**/*.h",
+      "BraintreePayPal/PayPalUtils/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1833,8 +1562,7 @@ filegroup(
   srcs = glob(
     [
       "BraintreePayPal/PayPalUtils/Public/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1843,19 +1571,11 @@ filegroup(
 filegroup(
   name = "PayPalUtils_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalUtils/**/*.h",
-        "BraintreePayPal/PayPalUtils/Public/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "BraintreePayPal/PayPalUtils/**/*.h",
+      "BraintreePayPal/PayPalUtils/Public/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1896,23 +1616,11 @@ objc_library(
     [
       "BraintreePayPal/PayPalUtils/**/*.m"
     ],
-    exclude = glob(
-      [
-        "BraintreePayPal/PayPalOneTouch/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/PayPalDataCollector/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "BraintreePayPal/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "BraintreePayPal/PayPalOneTouch/**/*.m",
+      "BraintreePayPal/PayPalDataCollector/**/*.m",
+      "BraintreePayPal/*.m"
+    ]
   ),
   hdrs = [
     ":PayPalUtils_hdrs"

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs",
     ":without-IDFA_hdrs"
@@ -141,20 +139,12 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -170,8 +160,7 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -180,20 +169,12 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -234,8 +215,7 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -276,20 +256,12 @@ acknowledged_target(
 filegroup(
   name = "without-IDFA_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -305,8 +277,7 @@ filegroup(
     ],
     exclude = [
       "Branch-SDK/Fabric/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -315,20 +286,12 @@ filegroup(
 filegroup(
   name = "without-IDFA_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Branch-SDK/Branch-SDK/*.h",
-        "Branch-SDK/Branch-SDK/Requests/*.h",
-        "Branch-SDK/Fabric/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Branch-SDK/Branch-SDK/*.h",
+      "Branch-SDK/Branch-SDK/Requests/*.h",
+      "Branch-SDK/Fabric/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -369,8 +332,7 @@ objc_library(
     [
       "Branch-SDK/Branch-SDK/*.m",
       "Branch-SDK/Branch-SDK/Requests/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":without-IDFA_hdrs"

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -47,20 +47,12 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +65,7 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +74,12 @@ filegroup(
 filegroup(
   name = "Calabash_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -139,32 +122,24 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.cpp",
       "calabash.framework/Versions/A/Headers/*.cxx"
     ],
-    exclude = glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.S",
-        "calabash.framework/Versions/A/Headers/*.c",
-        "calabash.framework/Versions/A/Headers/*.m",
-        "calabash.framework/Versions/A/Headers/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "calabash.framework/Versions/A/Headers/*.S",
+      "calabash.framework/Versions/A/Headers/*.c",
+      "calabash.framework/Versions/A/Headers/*.m",
+      "calabash.framework/Versions/A/Headers/*.s"
+    ]
   ),
   non_arc_srcs = glob(
     glob(
       [
         "calabash.framework/Versions/A/Headers/*.mm"
       ],
-      exclude = glob(
-        [
-          "calabash.framework/Versions/A/Headers/*.S",
-          "calabash.framework/Versions/A/Headers/*.c",
-          "calabash.framework/Versions/A/Headers/*.m",
-          "calabash.framework/Versions/A/Headers/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "calabash.framework/Versions/A/Headers/*.S",
+        "calabash.framework/Versions/A/Headers/*.c",
+        "calabash.framework/Versions/A/Headers/*.m",
+        "calabash.framework/Versions/A/Headers/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -172,18 +147,13 @@ objc_library(
         "calabash.framework/Versions/A/Headers/*.cpp",
         "calabash.framework/Versions/A/Headers/*.cxx"
       ],
-      exclude = glob(
-        [
-          "calabash.framework/Versions/A/Headers/*.S",
-          "calabash.framework/Versions/A/Headers/*.c",
-          "calabash.framework/Versions/A/Headers/*.m",
-          "calabash.framework/Versions/A/Headers/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      exclude = [
+        "calabash.framework/Versions/A/Headers/*.S",
+        "calabash.framework/Versions/A/Headers/*.c",
+        "calabash.framework/Versions/A/Headers/*.m",
+        "calabash.framework/Versions/A/Headers/*.s"
+      ]
+    )
   ),
   module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [
@@ -234,8 +204,7 @@ swift_library(
   srcs = glob(
     [
       "calabash.framework/Versions/A/Headers/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [],
   data = [],
@@ -246,20 +215,12 @@ swift_library(
 filegroup(
   name = "Calabash_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -272,8 +233,7 @@ filegroup(
       "calabash.framework/Versions/A/Headers/*.h",
       "calabash.framework/Versions/A/Headers/*.hpp",
       "calabash.framework/Versions/A/Headers/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Calabash_cxx_public_hdrs"
   ],
@@ -284,20 +244,12 @@ filegroup(
 filegroup(
   name = "Calabash_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "calabash.framework/Versions/A/Headers/*.h",
-        "calabash.framework/Versions/A/Headers/*.hpp",
-        "calabash.framework/Versions/A/Headers/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "calabash.framework/Versions/A/Headers/*.h",
+      "calabash.framework/Versions/A/Headers/*.hpp",
+      "calabash.framework/Versions/A/Headers/*.hxx"
+    ]
   ) + [
     ":Calabash_cxx_hdrs"
   ],
@@ -334,8 +286,7 @@ objc_library(
       "calabash.framework/Versions/A/Headers/*.c",
       "calabash.framework/Versions/A/Headers/*.m",
       "calabash.framework/Versions/A/Headers/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   module_map = ":Calabash_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "CardIO_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "CardIO/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "CardIO/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "CardIO/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "CardIO_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "CardIO/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "CardIO/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -52,8 +52,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +73,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_hdrs",
     ":Extensions_hdrs"
@@ -144,19 +142,11 @@ acknowledged_target(
 filegroup(
   name = "Default_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/CocoaLumberjack.h",
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/CocoaLumberjack.h",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -168,8 +158,7 @@ filegroup(
     [
       "Classes/CocoaLumberjack.h",
       "Classes/DD*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -178,19 +167,11 @@ filegroup(
 filegroup(
   name = "Default_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/CocoaLumberjack.h",
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/CocoaLumberjack.h",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -231,13 +212,9 @@ objc_library(
     [
       "Classes/DD*.m"
     ],
-    exclude = glob(
-      [
-        "Classes/Extensions/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Classes/Extensions/*.m"
+    ]
   ),
   hdrs = [
     ":Default_hdrs"
@@ -273,18 +250,10 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -295,8 +264,7 @@ filegroup(
   srcs = glob(
     [
       "Classes/DD*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -305,18 +273,10 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/DD*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/DD*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -356,8 +316,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/DD*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -393,18 +352,10 @@ acknowledged_target(
 filegroup(
   name = "Extensions_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/Extensions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/Extensions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -415,8 +366,7 @@ filegroup(
   srcs = glob(
     [
       "Classes/Extensions/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_public_hdrs"
   ],
@@ -427,18 +377,10 @@ filegroup(
 filegroup(
   name = "Extensions_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/Extensions/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/Extensions/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -481,8 +423,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/Extensions/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Extensions_hdrs"
@@ -523,34 +464,23 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/CLI/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/CLI/*.h"
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -566,8 +496,7 @@ filegroup(
       ":osxCase": glob(
         [
           "Classes/CLI/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + select(
@@ -589,34 +518,23 @@ filegroup(
       "//conditions:default": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/CLI/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/CLI/*.h"
+        ]
       ),
       ":tvosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -675,8 +593,7 @@ objc_library(
       ":osxCase": glob(
         [
           "Classes/CLI/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -723,8 +640,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -744,8 +660,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "ColorCube_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ColorCube/ColorCube/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ColorCube/ColorCube/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "ColorCube_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ColorCube/ColorCube/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ColorCube/ColorCube/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "ColorCube/ColorCube/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ColorCube_hdrs"

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -146,8 +144,7 @@ apple_static_framework_import(
       "//conditions:default": glob(
         [
           "EarlGrey/EarlGrey.framework/**"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -47,23 +47,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +68,7 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -86,23 +77,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -162,36 +145,26 @@ objc_library(
           "FBAllocationTracker/**/*.cxx",
           "FBAllocationTracker/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "FBAllocationTracker/**/*.S",
-            "FBAllocationTracker/**/*.c",
-            "FBAllocationTracker/**/*.m",
-            "FBAllocationTracker/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        exclude = [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ]
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
       [
         "FBAllocationTracker/**/*.mm"
       ],
-      exclude = glob(
-        [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "FBAllocationTracker/**/*.S",
+        "FBAllocationTracker/**/*.c",
+        "FBAllocationTracker/**/*.m",
+        "FBAllocationTracker/**/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -216,22 +189,15 @@ objc_library(
             "FBAllocationTracker/**/*.cxx",
             "FBAllocationTracker/**/*.mm"
           ],
-          exclude = glob(
-            [
-              "FBAllocationTracker/**/*.S",
-              "FBAllocationTracker/**/*.c",
-              "FBAllocationTracker/**/*.m",
-              "FBAllocationTracker/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          exclude = [
+            "FBAllocationTracker/**/*.S",
+            "FBAllocationTracker/**/*.c",
+            "FBAllocationTracker/**/*.m",
+            "FBAllocationTracker/**/*.s"
+          ]
+        )
+      )
+    )
   ),
   module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [
@@ -278,8 +244,7 @@ swift_library(
   srcs = glob(
     [
       "FBAllocationTracker/**/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [],
   data = [],
@@ -290,23 +255,15 @@ swift_library(
 filegroup(
   name = "FBAllocationTracker_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -319,8 +276,7 @@ filegroup(
       "FBAllocationTracker/FBAllocationTracker.h",
       "FBAllocationTracker/FBAllocationTrackerManager.h",
       "FBAllocationTracker/FBAllocationTrackerSummary.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":FBAllocationTracker_cxx_public_hdrs"
   ],
@@ -331,23 +287,15 @@ filegroup(
 filegroup(
   name = "FBAllocationTracker_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBAllocationTracker/**/*.h",
-        "FBAllocationTracker/**/*.hpp",
-        "FBAllocationTracker/**/*.hxx",
-        "FBAllocationTracker/FBAllocationTracker.h",
-        "FBAllocationTracker/FBAllocationTrackerManager.h",
-        "FBAllocationTracker/FBAllocationTrackerSummary.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBAllocationTracker/**/*.h",
+      "FBAllocationTracker/**/*.hpp",
+      "FBAllocationTracker/**/*.hxx",
+      "FBAllocationTracker/FBAllocationTracker.h",
+      "FBAllocationTracker/FBAllocationTrackerManager.h",
+      "FBAllocationTracker/FBAllocationTrackerSummary.h"
+    ]
   ) + [
     ":FBAllocationTracker_cxx_hdrs"
   ],
@@ -394,29 +342,21 @@ objc_library(
         "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
         "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
       ],
-      exclude = glob(
-        [
-          "FBAllocationTracker/**/*.S",
-          "FBAllocationTracker/**/*.c",
-          "FBAllocationTracker/**/*.m",
-          "FBAllocationTracker/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    glob(
-      [
+      exclude = [
         "FBAllocationTracker/**/*.S",
         "FBAllocationTracker/**/*.c",
         "FBAllocationTracker/**/*.m",
         "FBAllocationTracker/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
+      ]
+    )
+  ),
+  non_arc_srcs = glob(
+    [
+      "FBAllocationTracker/**/*.S",
+      "FBAllocationTracker/**/*.c",
+      "FBAllocationTracker/**/*.m",
+      "FBAllocationTracker/**/*.s"
+    ],
     exclude = glob(
       [
         "FBAllocationTracker/FBAllocationTrackerImpl.mm",
@@ -433,20 +373,14 @@ objc_library(
           "FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm",
           "FBAllocationTracker/Generations/FBAllocationTrackerGenerationManager.mm"
         ],
-        exclude = glob(
-          [
-            "FBAllocationTracker/**/*.S",
-            "FBAllocationTracker/**/*.c",
-            "FBAllocationTracker/**/*.m",
-            "FBAllocationTracker/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        exclude = [
+          "FBAllocationTracker/**/*.S",
+          "FBAllocationTracker/**/*.c",
+          "FBAllocationTracker/**/*.m",
+          "FBAllocationTracker/**/*.s"
+        ]
+      )
+    )
   ),
   module_map = ":FBAllocationTracker_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -51,8 +51,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +72,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_hdrs",
     ":Core_hdrs"
@@ -107,200 +105,6 @@ gen_includes(
 objc_library(
   name = "FBSDKCoreKit",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "FBSDKCoreKit/FBSDKCoreKit/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-      "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-    ],
-    exclude = glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.s",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.S",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.c",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cc",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cpp",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.cxx",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.m",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
-        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -368,21 +172,13 @@ acknowledged_target(
 filegroup(
   name = "Basics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -399,8 +195,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -409,21 +204,13 @@ filegroup(
 filegroup(
   name = "Basics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
-        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+      "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -589,8 +376,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -613,14 +399,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -650,8 +432,7 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ) + glob(
         [
           "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -674,10 +455,8 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+        ]
+      )
     ),
     exclude = glob(
       [
@@ -808,8 +587,7 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
+            ]
           ) + glob(
             [
               "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
@@ -832,16 +610,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+            ]
+          )
+        )
+      )
+    )
   ),
   hdrs = [
     ":Basics_hdrs"
@@ -909,8 +682,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -921,12 +693,9 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -945,10 +714,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -968,8 +735,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs"
   ],
@@ -980,12 +746,9 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1004,10 +767,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1193,14 +954,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -1247,10 +1004,8 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+        ]
+      )
     ),
     exclude = glob(
       [
@@ -1398,16 +1153,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+            ]
+          )
+        )
+      )
+    )
   ),
   module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [
@@ -1480,12 +1230,9 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1504,10 +1251,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1527,8 +1272,7 @@ filegroup(
     exclude = [
       "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
       "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Basics_public_hdrs",
     ":Core_cxx_public_hdrs"
@@ -1540,12 +1284,9 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/**/*.hpp",
@@ -1564,10 +1305,8 @@ filegroup(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.h",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hpp",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -1733,12 +1472,9 @@ objc_library(
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
           "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+        ]
+      )
+    )
   ),
   non_arc_srcs = glob(
     glob(
@@ -1763,8 +1499,7 @@ objc_library(
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
         "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-      ],
-      exclude_directories = 1
+      ]
     ),
     exclude = glob(
       [
@@ -1890,14 +1625,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/include/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+          ]
+        )
+      )
+    )
   ),
   module_map = ":FBSDKCoreKit_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -48,12 +48,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -64,33 +61,20 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -123,25 +107,15 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       )
     }
   ),
@@ -154,8 +128,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKCoreKit/FBSDKCoreKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -166,12 +139,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -182,33 +152,20 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/*.h"
@@ -241,25 +198,15 @@ filegroup(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.h",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hpp",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
-            "FBSDKCoreKit/FBSDKCoreKit/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.h",
+          "FBSDKCoreKit/FBSDKCoreKit/*.h"
+        ]
       )
     }
   ),
@@ -349,12 +296,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -394,15 +338,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = glob(
-            [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ]
+        )
       ),
       ":tvosCase": glob(
         [
@@ -492,12 +431,9 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -537,15 +473,10 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
           ],
-          exclude = glob(
-            [
-              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          exclude = [
+            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+          ]
+        )
       )
     }
   ),
@@ -567,8 +498,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -623,22 +553,15 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/Device/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -677,17 +600,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = glob(
-              [
-                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -740,8 +657,7 @@ objc_library(
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
             "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -831,22 +747,15 @@ objc_library(
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.m",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.mm",
                 "FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/**/*.s"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
+        [
+          "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+        ],
         exclude = glob(
           [
             "FBSDKCoreKit/FBSDKCoreKit/*.S",
@@ -885,17 +794,11 @@ objc_library(
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.mm",
               "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.s"
             ],
-            exclude = glob(
-              [
-                "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            exclude = [
+              "FBSDKCoreKit/FBSDKCoreKit/**/*.m"
+            ]
+          )
+        )
       )
     }
   ),
@@ -970,8 +873,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "FacebookSDKStrings.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Login_hdrs"
   ],
@@ -158,12 +156,9 @@ acknowledged_target(
 filegroup(
   name = "Login_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -172,10 +167,8 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -186,8 +179,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -196,12 +188,9 @@ filegroup(
 filegroup(
   name = "Login_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/*.h"
@@ -210,10 +199,8 @@ filegroup(
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.h",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hpp",
         "FBSDKLoginKit/FBSDKLoginKit/include/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -265,8 +252,7 @@ objc_library(
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.m",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.mm",
       "FBSDKLoginKit/FBSDKLoginKit/include/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   module_map = ":FBSDKLoginKit_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -45,19 +45,11 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-        "FBSDKLoginKit/FBSDKLoginKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+      "FBSDKLoginKit/FBSDKLoginKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,19 +69,11 @@ filegroup(
 filegroup(
   name = "FBSDKLoginKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
-        "FBSDKLoginKit/FBSDKLoginKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKLoginKit/FBSDKLoginKit/**/*.h",
+      "FBSDKLoginKit/FBSDKLoginKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -122,8 +105,7 @@ objc_library(
   srcs = glob(
     [
       "FBSDKLoginKit/FBSDKLoginKit/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FBSDKLoginKit_hdrs"

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -45,19 +45,11 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,19 +69,11 @@ filegroup(
 filegroup(
   name = "FBSDKMessengerShareKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
-        "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.h",
+      "FBSDKMessengerShareKit/FBSDKMessengerShareKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -120,8 +103,7 @@ objc_library(
   srcs = glob(
     [
       "FBSDKMessengerShareKit/FBSDKMessengerShareKit/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FBSDKMessengerShareKit_hdrs"

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -47,12 +47,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -60,59 +57,47 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -127,8 +112,7 @@ filegroup(
       "//conditions:default": glob(
         [
           "FBSDKShareKit/FBSDKShareKit/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -149,8 +133,7 @@ filegroup(
           "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
           "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -163,12 +146,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "FBSDKShareKit/FBSDKShareKit/**/*.h",
             "FBSDKShareKit/FBSDKShareKit/*.h"
@@ -176,59 +156,47 @@ filegroup(
           exclude = [
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
             "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
-            "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
-            "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphValueContainer.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharePhotoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKShareVideoContent.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h",
+          "FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareLinkContent+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareOpenGraphValueContainer+Internal.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.h",
+          "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -268,8 +236,7 @@ objc_library(
         exclude = [
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.m",
           "FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -291,8 +258,7 @@ objc_library(
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareError.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.m",
           "FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FLAnimatedImage/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FLAnimatedImage/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FLAnimatedImage/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FLAnimatedImage/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "FLAnimatedImage/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "FLEX_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/**/*.h",
-        "Classes/**/FLEXManager.h",
-        "Classes/FLEX.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/**/*.h",
+      "Classes/**/FLEXManager.h",
+      "Classes/FLEX.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -70,8 +62,7 @@ filegroup(
     [
       "Classes/**/FLEXManager.h",
       "Classes/FLEX.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -80,20 +71,12 @@ filegroup(
 filegroup(
   name = "FLEX_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Classes/**/*.h",
-        "Classes/**/FLEXManager.h",
-        "Classes/FLEX.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Classes/**/*.h",
+      "Classes/**/FLEXManager.h",
+      "Classes/FLEX.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -123,8 +106,7 @@ objc_library(
   srcs = glob(
     [
       "Classes/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLEX_hdrs"

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -53,8 +53,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +73,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":standard_hdrs"
   ],
@@ -141,18 +139,10 @@ acknowledged_target(
 filegroup(
   name = "standard_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -163,8 +153,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -173,18 +162,10 @@ filegroup(
 filegroup(
   name = "standard_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -226,14 +207,9 @@ objc_library(
       "src/fmdb/FM*.m"
     ],
     exclude = [
-      "src/fmdb.m"
-    ] + glob(
-      [
-        "src/extra/fts3/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "src/fmdb.m",
+      "src/extra/fts3/*.m"
+    ]
   ),
   hdrs = [
     ":standard_hdrs"
@@ -272,18 +248,10 @@ acknowledged_target(
 filegroup(
   name = "FTS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -294,8 +262,7 @@ filegroup(
   srcs = glob(
     [
       "src/extra/fts3/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":standard_public_hdrs"
   ],
@@ -306,18 +273,10 @@ filegroup(
 filegroup(
   name = "FTS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -360,8 +319,7 @@ objc_library(
   srcs = glob(
     [
       "src/extra/fts3/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FTS_hdrs"
@@ -400,8 +358,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -419,8 +376,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -493,18 +449,10 @@ acknowledged_target(
 filegroup(
   name = "standalone_default_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -515,8 +463,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -525,18 +472,10 @@ filegroup(
 filegroup(
   name = "standalone_default_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -581,8 +520,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":standalone_default_hdrs"
@@ -623,19 +561,11 @@ acknowledged_target(
 filegroup(
   name = "standalone_FTS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h",
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -647,8 +577,7 @@ filegroup(
     [
       "src/extra/fts3/*.h",
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -657,19 +586,11 @@ filegroup(
 filegroup(
   name = "standalone_FTS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/extra/fts3/*.h",
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/extra/fts3/*.h",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -715,8 +636,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":standalone_FTS_hdrs"
@@ -757,18 +677,10 @@ acknowledged_target(
 filegroup(
   name = "SQLCipher_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -779,8 +691,7 @@ filegroup(
   srcs = glob(
     [
       "src/fmdb/FM*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -789,18 +700,10 @@ filegroup(
 filegroup(
   name = "SQLCipher_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "src/fmdb/FM*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "src/fmdb/FM*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -845,8 +748,7 @@ objc_library(
     ],
     exclude = [
       "src/fmdb.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SQLCipher_hdrs"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -50,8 +50,7 @@ swift_library(
       "Source/**/*.swift",
       "Source/*.swift",
       "Vendor/**/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [
     "//Vendor/AEXML:AEXML",
@@ -69,8 +68,7 @@ swift_library(
       "Source/Resources/*.xcassets",
       "Source/Resources/Fonts/**/*.otf",
       "Source/Resources/Fonts/**/*.ttf"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -79,18 +77,10 @@ swift_library(
 filegroup(
   name = "FolioReaderKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -101,8 +91,7 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -111,18 +100,10 @@ filegroup(
 filegroup(
   name = "FolioReaderKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -197,8 +178,7 @@ objc_library(
       "Source/Resources/*.xcassets",
       "Source/Resources/Fonts/**/*.otf",
       "Source/Resources/Fonts/**/*.ttf"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "Folly_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "folly/*.h",
-        "folly/detail/*.h",
-        "folly/portability/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "folly/*.h",
+      "folly/detail/*.h",
+      "folly/portability/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,20 +66,12 @@ filegroup(
 filegroup(
   name = "Folly_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "folly/*.h",
-        "folly/detail/*.h",
-        "folly/portability/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "folly/*.h",
+      "folly/detail/*.h",
+      "folly/portability/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -131,8 +115,7 @@ objc_library(
       "folly/dynamic.cpp",
       "folly/json.cpp",
       "folly/portability/BitsFunctexcept.cpp"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Folly_hdrs"

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -47,20 +47,12 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Changelog/**/*.h",
-        "Changelog/**/*.hpp",
-        "Changelog/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Changelog/**/*.h",
+      "Changelog/**/*.hpp",
+      "Changelog/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,20 +68,12 @@ filegroup(
 filegroup(
   name = "GoogleAppIndexing_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Changelog/**/*.h",
-        "Changelog/**/*.hpp",
-        "Changelog/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Changelog/**/*.h",
+      "Changelog/**/*.hpp",
+      "Changelog/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -160,8 +144,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleAppIndexingResources.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -174,8 +157,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleAppIndexing.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -137,8 +135,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAppUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -130,8 +128,7 @@ objc_library(
   data = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/Resources/GTMOAuth2ViewTouch.xib"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -150,8 +147,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleAuthUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -140,8 +138,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleNetworkingUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +67,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -155,8 +153,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "Resources/GoogleSignIn.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(
@@ -169,8 +166,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/GoogleSignIn.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -132,8 +130,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleSymbolUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +66,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -144,8 +142,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "Frameworks/frameworks/GoogleUtilities.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "IBActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "IBActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "IBActionSheetSample/IBActionSheetSample/IBActionSheet.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "IBActionSheetSample/IBActionSheetSample/IBActionSheet.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":IBActionSheet_hdrs"

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -51,8 +51,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +71,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_hdrs"
   ],
@@ -155,19 +153,11 @@ acknowledged_target(
 filegroup(
   name = "Diffing_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -181,8 +171,7 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -191,19 +180,11 @@ filegroup(
 filegroup(
   name = "Diffing_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -246,79 +227,39 @@ objc_library(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m",
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m",
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/Common/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/Common/**/*.m"
+        ]
       )
     }
   ),
@@ -376,19 +317,11 @@ acknowledged_target(
 filegroup(
   name = "Diffing_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -402,8 +335,7 @@ filegroup(
     ],
     exclude = [
       "Source/Common/Internal/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Diffing_cxx_public_hdrs"
   ],
@@ -414,19 +346,11 @@ filegroup(
 filegroup(
   name = "Diffing_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Common/**/*.h",
-        "Source/Common/Internal/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Common/**/*.h",
+      "Source/Common/Internal/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -472,57 +396,31 @@ objc_library(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
           "Source/Common/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/Common/**/*.m"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.mm",
+          "Source/**/*.m",
+          "Source/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
           "Source/Common/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -579,48 +477,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -639,8 +519,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -649,8 +528,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -665,48 +543,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -754,25 +614,17 @@ objc_library(
         [
           "Source/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Source/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Source/**/*.m"
+        ]
       )
     }
   ),
@@ -833,48 +685,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -893,8 +727,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -903,8 +736,7 @@ filegroup(
         exclude = [
           "Source/Common/Internal/*.h",
           "Source/Internal/*.h"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ) + [
@@ -920,48 +752,30 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":osxCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Source/**/*.h",
-            "Source/Common/Internal/*.h",
-            "Source/Internal/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Source/**/*.h",
+          "Source/Common/Internal/*.h",
+          "Source/Internal/*.h"
+        ]
       ),
       ":watchosCase": glob(
         [
           "pod_support/Headers/Public/**/*"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -1010,14 +824,12 @@ objc_library(
       "//conditions:default": glob(
         [
           "Source/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Source/**/*.m"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "KVOController_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBKVOController/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBKVOController/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "FBKVOController/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "KVOController_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBKVOController/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBKVOController/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "FBKVOController/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":KVOController_hdrs"

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -52,8 +52,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +75,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":KakaoLink_hdrs",
     ":KakaoNavi_hdrs",
@@ -158,8 +156,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -177,8 +174,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -256,8 +252,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoOpenSDK.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -273,8 +268,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -292,8 +286,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -370,8 +363,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoNavi.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -387,8 +379,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -406,8 +397,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -484,8 +474,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoLink.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -501,8 +490,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -520,8 +508,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -598,8 +585,7 @@ apple_static_framework_import(
   framework_imports = glob(
     [
       "KakaoS2.framework/**"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Masonry_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Masonry/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Masonry/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "Masonry/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Masonry_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Masonry/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Masonry/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "Masonry/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Masonry_hdrs"

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -47,12 +47,9 @@ filegroup(
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Sources/**/*.h"
       ],
@@ -60,10 +57,8 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +69,7 @@ filegroup(
   srcs = glob(
     [
       "Sources/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Default_public_hdrs",
     ":Subspec_public_hdrs"
@@ -87,12 +81,9 @@ filegroup(
 filegroup(
   name = "ObjcParentWithSwiftSubspecs_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Sources/**/*.h"
       ],
@@ -100,10 +91,8 @@ filegroup(
         "Classes/Exclude/**/*.h",
         "Classes/Exclude/**/*.hpp",
         "Classes/Exclude/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ) + [
     ":Default_hdrs",
     ":Subspec_hdrs"
@@ -149,8 +138,7 @@ objc_library(
       "Classes/Exclude/**/*.m",
       "Classes/Exclude/**/*.mm",
       "Classes/Exclude/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ObjcParentWithSwiftSubspecs_hdrs"
@@ -190,8 +178,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -209,8 +196,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -283,8 +269,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -302,8 +287,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -46,12 +46,9 @@ filegroup(
 filegroup(
   name = "OnePasswordExtension_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "*.h"
       ],
@@ -59,10 +56,8 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,12 +77,9 @@ filegroup(
 filegroup(
   name = "1PasswordExtension_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "*.h"
       ],
@@ -96,10 +87,8 @@ filegroup(
         "Demos/**/*.h",
         "Demos/**/*.hpp",
         "Demos/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -146,8 +135,7 @@ objc_library(
       "Demos/**/*.m",
       "Demos/**/*.mm",
       "Demos/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":1PasswordExtension_hdrs"
@@ -197,8 +185,7 @@ apple_resource_bundle(
     [
       "1Password.xcassets",
       "1Password.xcassets/*.imageset/*.png"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Arc-exception-safe_hdrs",
     ":Core_hdrs"
@@ -154,18 +152,10 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -176,8 +166,7 @@ filegroup(
   srcs = glob(
     [
       "Source/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -186,18 +175,10 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -240,13 +221,9 @@ objc_library(
     [
       "Source/*.m"
     ],
-    exclude = glob(
-      [
-        "Source/PINDiskCache.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Source/PINDiskCache.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -300,8 +277,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -321,8 +297,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -365,8 +340,7 @@ objc_library(
   srcs = glob(
     [
       "Source/PINDiskCache.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Arc-exception-safe_hdrs"

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -46,18 +46,10 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,18 +69,10 @@ filegroup(
 filegroup(
   name = "PINOperation_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -130,13 +113,9 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "Source/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Source/**/*.m"
+    ]
   ),
   hdrs = [
     ":PINOperation_cxx_hdrs"
@@ -177,18 +156,10 @@ acknowledged_target(
 filegroup(
   name = "PINOperation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -199,8 +170,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":PINOperation_cxx_public_hdrs"
   ],
@@ -211,18 +181,10 @@ filegroup(
 filegroup(
   name = "PINOperation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ) + [
     ":PINOperation_cxx_hdrs"
   ],
@@ -256,8 +218,7 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PINOperation_hdrs"

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -54,8 +54,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -76,8 +75,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":FLAnimatedImage_hdrs",
     ":PINCache_hdrs"
@@ -146,22 +144,17 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -172,8 +165,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -182,22 +174,17 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "Source/Classes/**/*.h"
       ],
       exclude = [
         "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
         "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -242,19 +229,10 @@ objc_library(
     ],
     exclude = [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
+      "Source/Classes/PINCache/*.m",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m",
       "Source/Classes/PINCache/*.m"
-    ] + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -299,8 +277,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -320,8 +297,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -401,8 +377,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -422,8 +397,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -504,8 +478,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -525,8 +498,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -601,18 +573,10 @@ acknowledged_target(
 filegroup(
   name = "FLAnimatedImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -623,8 +587,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -635,18 +598,10 @@ filegroup(
 filegroup(
   name = "FLAnimatedImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -690,8 +645,7 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":FLAnimatedImage_hdrs"
@@ -733,8 +687,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -754,8 +707,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -836,18 +788,10 @@ acknowledged_target(
 filegroup(
   name = "PINCache_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/PINCache/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -858,8 +802,7 @@ filegroup(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -870,18 +813,10 @@ filegroup(
 filegroup(
   name = "PINCache_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/Classes/PINCache/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/Classes/PINCache/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -925,8 +860,7 @@ objc_library(
   srcs = glob(
     [
       "Source/Classes/PINCache/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PINCache_hdrs"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "PaymentKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PaymentKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PaymentKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "PaymentKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "PaymentKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PaymentKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PaymentKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "PaymentKit/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":PaymentKit_hdrs"
@@ -147,8 +129,7 @@ objc_library(
     [
       "PaymentKit/Resources/*.png",
       "PaymentKit/Resources/Cards/*.png"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "RadarKit_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "RadarKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "RadarKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "RadarKit/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "RadarKit_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "RadarKit/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "RadarKit/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "RadarKit/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RadarKit_hdrs"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -91,8 +91,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -112,8 +111,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -181,12 +179,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -215,18 +210,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -252,18 +242,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -310,18 +295,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -347,10 +327,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -363,8 +341,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -375,12 +352,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -409,18 +383,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -446,18 +415,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -504,18 +468,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -541,10 +500,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -729,43 +686,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -779,8 +723,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -796,102 +739,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
@@ -1018,43 +905,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1068,8 +942,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1085,102 +958,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -1419,43 +1236,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1469,8 +1273,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1486,102 +1289,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -1708,43 +1455,30 @@ objc_library(
             "ReactCommon/yoga/*.m",
             "ReactCommon/yoga/*.mm",
             "ReactCommon/yoga/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
+          ]
+        ) + [
+          "React/Cxx*/*.mm"
+        ] + [
+          "React/Cxx*/*.m"
+        ] + [
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm"
+        ] + [
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
+        ] + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -1758,8 +1492,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -1775,102 +1508,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       )
     }
   ),
@@ -1921,12 +1598,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -1955,18 +1629,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -1992,18 +1661,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2050,18 +1714,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2087,10 +1746,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2103,8 +1760,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -2117,12 +1773,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2151,18 +1804,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2188,18 +1836,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2246,18 +1889,13 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "React/**/*.h"
           ],
@@ -2283,10 +1921,8 @@ filegroup(
             "ReactCommon/yoga/*.h",
             "ReactCommon/yoga/*.hpp",
             "ReactCommon/yoga/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -2402,42 +2038,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2451,8 +2071,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2468,102 +2087,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":osxCase": glob(
         [
@@ -2627,42 +2190,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2676,8 +2223,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2693,102 +2239,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -2908,42 +2398,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -2957,8 +2431,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -2974,102 +2447,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -3133,42 +2550,26 @@ objc_library(
           "ReactCommon/yoga/*.cxx",
           "ReactCommon/yoga/*.m",
           "ReactCommon/yoga/*.mm",
-          "ReactCommon/yoga/*.s"
+          "ReactCommon/yoga/*.s",
+          "React/Cxx*/*.mm",
+          "React/Cxx*/*.m",
+          "React/DevSupport/*.cc",
+          "React/DevSupport/*.cpp",
+          "React/DevSupport/*.cxx",
+          "React/DevSupport/*.mm",
+          "React/Inspector/*.cc",
+          "React/Inspector/*.cpp",
+          "React/Inspector/*.cxx",
+          "React/Inspector/*.mm",
+          "React/DevSupport/*.S",
+          "React/DevSupport/*.c",
+          "React/DevSupport/*.m",
+          "React/DevSupport/*.s",
+          "React/Inspector/*.S",
+          "React/Inspector/*.c",
+          "React/Inspector/*.m",
+          "React/Inspector/*.s"
         ] + glob(
-          [
-            "React/Cxx*/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/Cxx*/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.cc",
-            "React/DevSupport/*.cpp",
-            "React/DevSupport/*.cxx",
-            "React/DevSupport/*.mm",
-            "React/Inspector/*.cc",
-            "React/Inspector/*.cpp",
-            "React/Inspector/*.cxx",
-            "React/Inspector/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/DevSupport/*.S",
-            "React/DevSupport/*.c",
-            "React/DevSupport/*.m",
-            "React/DevSupport/*.s",
-            "React/Inspector/*.S",
-            "React/Inspector/*.c",
-            "React/Inspector/*.m",
-            "React/Inspector/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
           [
             "React/Fabric/**/*.cpp",
             "React/Fabric/**/*.mm"
@@ -3182,8 +2583,7 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
+          ]
         ) + glob(
           [
             "React/Fabric/**/*.S",
@@ -3199,102 +2599,46 @@ objc_library(
             "**/tests/*.m",
             "**/tests/*.mm",
             "**/tests/*.s"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "React/**/RCTTV*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ART/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/ActionSheetIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/NativeAnimation/*.m",
-            "Libraries/NativeAnimation/Drivers/*.m",
-            "Libraries/NativeAnimation/Nodes/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Blob/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/CameraRoll/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Geolocation/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Image/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.mm"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Network/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/PushNotificationIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Settings/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Text/**/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/Vibration/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/WebSocket/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/LinkingIOS/*.m"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Libraries/RCTTest/**/*.m"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        ) + [
+          "React/**/RCTTV*.m"
+        ] + [
+          "Libraries/ART/**/*.m"
+        ] + [
+          "Libraries/ActionSheetIOS/*.m"
+        ] + [
+          "Libraries/NativeAnimation/*.m",
+          "Libraries/NativeAnimation/Drivers/*.m",
+          "Libraries/NativeAnimation/Nodes/*.m"
+        ] + [
+          "Libraries/Blob/*.mm"
+        ] + [
+          "Libraries/Blob/*.m"
+        ] + [
+          "Libraries/CameraRoll/*.m"
+        ] + [
+          "Libraries/Geolocation/*.m"
+        ] + [
+          "Libraries/Image/*.m"
+        ] + [
+          "Libraries/Network/*.mm"
+        ] + [
+          "Libraries/Network/*.m"
+        ] + [
+          "Libraries/PushNotificationIOS/*.m"
+        ] + [
+          "Libraries/Settings/*.m"
+        ] + [
+          "Libraries/Text/**/*.m"
+        ] + [
+          "Libraries/Vibration/*.m"
+        ] + [
+          "Libraries/WebSocket/*.m"
+        ] + [
+          "Libraries/LinkingIOS/*.m"
+        ] + [
+          "Libraries/RCTTest/**/*.m"
+        ]
       )
     }
   ),
@@ -3342,18 +2686,10 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3372,18 +2708,10 @@ filegroup(
 filegroup(
   name = "CxxBridge_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3430,13 +2758,9 @@ objc_library(
     [
       "React/Cxx*/*.mm"
     ],
-    exclude = glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":CxxBridge_cxx_hdrs"
@@ -3481,18 +2805,10 @@ acknowledged_target(
 filegroup(
   name = "CxxBridge_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3512,18 +2828,10 @@ filegroup(
 filegroup(
   name = "CxxBridge_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/Cxx*/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3571,8 +2879,7 @@ objc_library(
   srcs = glob(
     [
       "React/Cxx*/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":CxxBridge_hdrs"
@@ -3616,23 +2923,15 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3648,8 +2947,7 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTWebSocket_public_hdrs"
@@ -3661,23 +2959,15 @@ filegroup(
 filegroup(
   name = "DevSupport_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3730,20 +3020,16 @@ objc_library(
       "React/Inspector/*.cxx",
       "React/Inspector/*.mm"
     ],
-    exclude = glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
@@ -3785,23 +3071,15 @@ acknowledged_target(
 filegroup(
   name = "DevSupport_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3817,8 +3095,7 @@ filegroup(
       "React/Inspector/*.h",
       "React/Inspector/*.hpp",
       "React/Inspector/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":DevSupport_cxx_public_hdrs",
@@ -3831,23 +3108,15 @@ filegroup(
 filegroup(
   name = "DevSupport_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.h",
-        "React/DevSupport/*.hpp",
-        "React/DevSupport/*.hxx",
-        "React/Inspector/*.h",
-        "React/Inspector/*.hpp",
-        "React/Inspector/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/DevSupport/*.h",
+      "React/DevSupport/*.hpp",
+      "React/DevSupport/*.hxx",
+      "React/Inspector/*.h",
+      "React/Inspector/*.hpp",
+      "React/Inspector/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -3901,8 +3170,7 @@ objc_library(
       "React/Inspector/*.c",
       "React/Inspector/*.m",
       "React/Inspector/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   module_map = ":React_extended_module_map_module_map_file",
   hdrs = [
@@ -3942,12 +3210,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3955,10 +3220,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -3969,8 +3232,7 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":fabric_public_hdrs"
@@ -3982,12 +3244,9 @@ filegroup(
 filegroup(
   name = "RCTFabric_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -3995,10 +3254,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4071,10 +3328,8 @@ objc_library(
         "**/tests/*.m",
         "**/tests/*.mm",
         "**/tests/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   hdrs = [
     ":RCTFabric_cxx_hdrs"
@@ -4121,12 +3376,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabric_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -4134,10 +3386,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4148,8 +3398,7 @@ filegroup(
   srcs = glob(
     [
       "React/Fabric/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTFabric_cxx_public_hdrs",
@@ -4162,12 +3411,9 @@ filegroup(
 filegroup(
   name = "RCTFabric_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "React/Fabric/**/*.h"
       ],
@@ -4175,10 +3421,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4239,8 +3483,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTFabric_hdrs"
@@ -4287,18 +3530,10 @@ acknowledged_target(
 filegroup(
   name = "tvOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/**/RCTTV*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/**/RCTTV*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4309,8 +3544,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/RCTTV*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -4321,18 +3555,10 @@ filegroup(
 filegroup(
   name = "tvOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/**/RCTTV*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "React/**/RCTTV*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4375,8 +3601,7 @@ objc_library(
   srcs = glob(
     [
       "React/**/RCTTV*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":tvOS_hdrs"
@@ -4413,18 +3638,10 @@ acknowledged_target(
 filegroup(
   name = "jschelpers_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jschelpers/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jschelpers/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4442,18 +3659,10 @@ filegroup(
 filegroup(
   name = "jschelpers_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jschelpers/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jschelpers/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4512,25 +3721,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":jschelpers_hdrs"
@@ -4576,18 +3774,10 @@ acknowledged_target(
 filegroup(
   name = "jsinspector_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jsinspector/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jsinspector/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4603,18 +3793,10 @@ filegroup(
 filegroup(
   name = "jsinspector_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/jsinspector/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/jsinspector/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4669,25 +3851,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":jsinspector_hdrs"
@@ -4725,18 +3896,10 @@ acknowledged_target(
 filegroup(
   name = "PrivateDatabase_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/privatedata/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/privatedata/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4752,18 +3915,10 @@ filegroup(
 filegroup(
   name = "PrivateDatabase_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "ReactCommon/privatedata/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "ReactCommon/privatedata/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -4805,12 +3960,9 @@ objc_library(
     [
       "ReactCommon/privatedata/*.cpp"
     ],
-    exclude = glob(
-      [
-        "ReactCommon/jschelpers/*.cpp"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    exclude = [
+      "ReactCommon/jschelpers/*.cpp"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.cpp"
       ],
@@ -4823,25 +3975,14 @@ objc_library(
         "ReactCommon/cxxreact/SampleCxxModule.m",
         "ReactCommon/cxxreact/SampleCxxModule.mm",
         "ReactCommon/cxxreact/SampleCxxModule.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    ) + [
+      "React/Cxx*/*.mm"
+    ] + [
+      "React/Cxx*/*.m"
+    ] + [
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":PrivateDatabase_hdrs"
@@ -4879,12 +4020,9 @@ acknowledged_target(
 filegroup(
   name = "cxxreact_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4892,10 +4030,8 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4914,12 +4050,9 @@ filegroup(
 filegroup(
   name = "cxxreact_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/cxxreact/*.h"
       ],
@@ -4927,10 +4060,8 @@ filegroup(
         "ReactCommon/cxxreact/SampleCxxModule.h",
         "ReactCommon/cxxreact/SampleCxxModule.hpp",
         "ReactCommon/cxxreact/SampleCxxModule.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -4990,24 +4121,11 @@ objc_library(
       "ReactCommon/cxxreact/SampleCxxModule.cxx",
       "ReactCommon/cxxreact/SampleCxxModule.m",
       "ReactCommon/cxxreact/SampleCxxModule.mm",
-      "ReactCommon/cxxreact/SampleCxxModule.s"
-    ] + glob(
-      [
-        "React/Cxx*/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/Cxx*/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "ReactCommon/cxxreact/SampleCxxModule.s",
+      "React/Cxx*/*.mm",
+      "React/Cxx*/*.m",
+      "React/Cxx*/*.m"
+    ]
   ),
   hdrs = [
     ":cxxreact_hdrs"
@@ -5055,8 +4173,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5074,8 +4191,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5146,12 +4262,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_activityindicator_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -5159,10 +4272,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5173,8 +4284,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/activityindicator/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5183,12 +4293,9 @@ filegroup(
 filegroup(
   name = "fabric_activityindicator_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/activityindicator/**/*.h"
       ],
@@ -5196,10 +4303,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5253,8 +4358,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_activityindicator_hdrs"
@@ -5296,12 +4400,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_attributedstring_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -5309,10 +4410,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5323,8 +4422,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/attributedstring/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5333,12 +4431,9 @@ filegroup(
 filegroup(
   name = "fabric_attributedstring_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/attributedstring/**/*.h"
       ],
@@ -5346,10 +4441,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5403,8 +4496,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_attributedstring_hdrs"
@@ -5446,12 +4538,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -5459,10 +4548,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5473,8 +4560,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/core/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5483,12 +4569,9 @@ filegroup(
 filegroup(
   name = "fabric_core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/core/**/*.h"
       ],
@@ -5496,10 +4579,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5553,8 +4634,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_core_hdrs"
@@ -5596,12 +4676,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_debug_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -5609,10 +4686,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5623,8 +4698,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/debug/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5633,12 +4707,9 @@ filegroup(
 filegroup(
   name = "fabric_debug_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/debug/**/*.h"
       ],
@@ -5646,10 +4717,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5703,8 +4772,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_debug_hdrs"
@@ -5746,12 +4814,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_graphics_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -5759,10 +4824,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5773,8 +4836,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/graphics/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5783,12 +4845,9 @@ filegroup(
 filegroup(
   name = "fabric_graphics_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/graphics/**/*.h"
       ],
@@ -5796,10 +4855,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5853,8 +4910,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_graphics_hdrs"
@@ -5896,12 +4952,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_scrollview_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -5909,10 +4962,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -5923,8 +4974,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/scrollview/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -5933,12 +4983,9 @@ filegroup(
 filegroup(
   name = "fabric_scrollview_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/scrollview/**/*.h"
       ],
@@ -5946,10 +4993,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6003,8 +5048,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_scrollview_hdrs"
@@ -6046,12 +5090,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_text_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -6059,10 +5100,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6073,8 +5112,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/text/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6083,12 +5121,9 @@ filegroup(
 filegroup(
   name = "fabric_text_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/text/**/*.h"
       ],
@@ -6096,10 +5131,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6153,8 +5186,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_text_hdrs"
@@ -6196,12 +5228,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_textlayoutmanager_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -6209,10 +5238,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6223,8 +5250,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/textlayoutmanager/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6233,12 +5259,9 @@ filegroup(
 filegroup(
   name = "fabric_textlayoutmanager_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/textlayoutmanager/**/*.h"
       ],
@@ -6246,10 +5269,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6304,8 +5325,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_textlayoutmanager_hdrs"
@@ -6347,12 +5367,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_uimanager_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -6360,10 +5377,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6374,8 +5389,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/uimanager/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6384,12 +5398,9 @@ filegroup(
 filegroup(
   name = "fabric_uimanager_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/uimanager/**/*.h"
       ],
@@ -6397,10 +5408,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6454,8 +5463,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_uimanager_hdrs"
@@ -6497,12 +5505,9 @@ acknowledged_target(
 filegroup(
   name = "fabric_view_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -6510,10 +5515,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6524,8 +5527,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/view/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6534,12 +5536,9 @@ filegroup(
 filegroup(
   name = "fabric_view_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/view/**/*.h"
       ],
@@ -6547,10 +5546,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6605,8 +5602,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":fabric_view_hdrs"
@@ -6650,12 +5646,9 @@ acknowledged_target(
 filegroup(
   name = "RCTFabricSample_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -6663,10 +5656,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6677,8 +5668,7 @@ filegroup(
   srcs = glob(
     [
       "ReactCommon/fabric/sample/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6687,12 +5677,9 @@ filegroup(
 filegroup(
   name = "RCTFabricSample_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "ReactCommon/fabric/sample/**/*.h"
       ],
@@ -6700,10 +5687,8 @@ filegroup(
         "**/tests/*.h",
         "**/tests/*.hpp",
         "**/tests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -6757,8 +5742,7 @@ objc_library(
       "**/tests/*.m",
       "**/tests/*.mm",
       "**/tests/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTFabricSample_hdrs"
@@ -6800,18 +5784,10 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6822,8 +5798,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6834,18 +5809,10 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6888,8 +5855,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ART_hdrs"
@@ -6926,18 +5892,10 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -6948,8 +5906,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -6960,18 +5917,10 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7014,8 +5963,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -7052,20 +6000,12 @@ acknowledged_target(
 filegroup(
   name = "RCTAnimation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/NativeAnimation/*.h",
-        "Libraries/NativeAnimation/Drivers/*.h",
-        "Libraries/NativeAnimation/Nodes/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7078,8 +6018,7 @@ filegroup(
       "Libraries/NativeAnimation/*.h",
       "Libraries/NativeAnimation/Drivers/*.h",
       "Libraries/NativeAnimation/Nodes/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7090,20 +6029,12 @@ filegroup(
 filegroup(
   name = "RCTAnimation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/NativeAnimation/*.h",
-        "Libraries/NativeAnimation/Drivers/*.h",
-        "Libraries/NativeAnimation/Nodes/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/NativeAnimation/*.h",
+      "Libraries/NativeAnimation/Drivers/*.h",
+      "Libraries/NativeAnimation/Nodes/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7148,8 +6079,7 @@ objc_library(
       "Libraries/NativeAnimation/*.m",
       "Libraries/NativeAnimation/Drivers/*.m",
       "Libraries/NativeAnimation/Nodes/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTAnimation_hdrs"
@@ -7186,18 +6116,10 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7208,8 +6130,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7220,18 +6141,10 @@ filegroup(
 filegroup(
   name = "RCTBlob_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7275,54 +6188,34 @@ objc_library(
     [
       "Libraries/Blob/*.mm"
     ],
-    exclude = glob(
-      [
-        "Libraries/Blob/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Blob/*.m",
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTBlob_cxx_hdrs"
@@ -7362,18 +6255,10 @@ acknowledged_target(
 filegroup(
   name = "RCTBlob_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7384,8 +6269,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Blob/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_cxx_public_hdrs"
@@ -7397,18 +6281,10 @@ filegroup(
 filegroup(
   name = "RCTBlob_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Blob/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Blob/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7454,49 +6330,33 @@ objc_library(
     [
       "Libraries/Blob/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTBlob_hdrs"
@@ -7534,18 +6394,10 @@ acknowledged_target(
 filegroup(
   name = "RCTCameraRoll_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/CameraRoll/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7556,8 +6408,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTImage_public_hdrs"
@@ -7569,18 +6420,10 @@ filegroup(
 filegroup(
   name = "RCTCameraRoll_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/CameraRoll/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7625,8 +6468,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/CameraRoll/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTCameraRoll_hdrs"
@@ -7664,18 +6506,10 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7686,8 +6520,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7698,18 +6531,10 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7752,8 +6577,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -7790,18 +6614,10 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7812,8 +6628,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_public_hdrs"
@@ -7825,18 +6640,10 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7882,13 +6689,9 @@ objc_library(
     [
       "Libraries/Image/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -7926,18 +6729,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -7948,8 +6743,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -7960,18 +6754,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8015,23 +6801,11 @@ objc_library(
     [
       "Libraries/Network/*.mm"
     ],
-    exclude = glob(
-      [
-        "Libraries/Network/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Network/*.m",
+      "Libraries/Image/*.m",
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTNetwork_cxx_hdrs"
@@ -8071,18 +6845,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8093,8 +6859,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTNetwork_cxx_public_hdrs"
@@ -8106,18 +6871,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8163,18 +6920,10 @@ objc_library(
     [
       "Libraries/Network/*.m"
     ],
-    exclude = glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/CameraRoll/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/Image/*.m",
+      "Libraries/CameraRoll/*.m"
+    ]
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -8212,18 +6961,10 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8234,8 +6975,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8246,18 +6986,10 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8300,8 +7032,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -8338,18 +7069,10 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8360,8 +7083,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8372,18 +7094,10 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8426,8 +7140,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -8464,18 +7177,10 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8486,8 +7191,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8498,18 +7202,10 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8552,8 +7248,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -8590,18 +7285,10 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8612,8 +7299,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -8624,18 +7310,10 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8678,8 +7356,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -8716,18 +7393,10 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8738,8 +7407,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs",
     ":RCTBlob_public_hdrs",
@@ -8752,18 +7420,10 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8811,44 +7471,32 @@ objc_library(
     [
       "Libraries/WebSocket/*.m"
     ],
-    exclude = glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -8887,18 +7535,10 @@ acknowledged_target(
 filegroup(
   name = "fishhook_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/fishhook/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/fishhook/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8909,8 +7549,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/fishhook/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8919,18 +7558,10 @@ filegroup(
 filegroup(
   name = "fishhook_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/fishhook/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/fishhook/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -8971,49 +7602,33 @@ objc_library(
     [
       "Libraries/fishhook/*.c"
     ],
-    exclude = glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.cc",
-        "React/DevSupport/*.cpp",
-        "React/DevSupport/*.cxx",
-        "React/DevSupport/*.mm",
-        "React/Inspector/*.cc",
-        "React/Inspector/*.cpp",
-        "React/Inspector/*.cxx",
-        "React/Inspector/*.mm"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "React/DevSupport/*.S",
-        "React/DevSupport/*.c",
-        "React/DevSupport/*.m",
-        "React/DevSupport/*.s",
-        "React/Inspector/*.S",
-        "React/Inspector/*.c",
-        "React/Inspector/*.m",
-        "React/Inspector/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Libraries/WebSocket/*.m",
+      "React/DevSupport/*.cc",
+      "React/DevSupport/*.cpp",
+      "React/DevSupport/*.cxx",
+      "React/DevSupport/*.mm",
+      "React/Inspector/*.cc",
+      "React/Inspector/*.cpp",
+      "React/Inspector/*.cxx",
+      "React/Inspector/*.mm",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s",
+      "React/DevSupport/*.S",
+      "React/DevSupport/*.c",
+      "React/DevSupport/*.m",
+      "React/DevSupport/*.s",
+      "React/Inspector/*.S",
+      "React/Inspector/*.c",
+      "React/Inspector/*.m",
+      "React/Inspector/*.s"
+    ]
   ),
   hdrs = [
     ":fishhook_hdrs"
@@ -9049,18 +7664,10 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9071,8 +7678,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -9083,18 +7689,10 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9137,8 +7735,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"
@@ -9175,18 +7772,10 @@ acknowledged_target(
 filegroup(
   name = "RCTTest_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/RCTTest/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/RCTTest/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9197,8 +7786,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -9209,18 +7797,10 @@ filegroup(
 filegroup(
   name = "RCTTest_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/RCTTest/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/RCTTest/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9263,8 +7843,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/RCTTest/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTTest_hdrs"
@@ -9306,8 +7885,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -9328,8 +7906,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -58,32 +58,24 @@ filegroup(
 filegroup(
   name = "React_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -101,32 +93,24 @@ filegroup(
 filegroup(
   name = "React_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "PATENTS/**/*.h",
-        "PATENTS/**/*.hpp",
-        "PATENTS/**/*.hxx",
-        "lint/**/*.h",
-        "lint/**/*.hpp",
-        "lint/**/*.hxx",
-        "node_modules/**/*.h",
-        "node_modules/**/*.hpp",
-        "node_modules/**/*.hxx",
-        "packager/**/*.h",
-        "packager/**/*.hpp",
-        "packager/**/*.hxx",
-        "react-native-cli/**/*.h",
-        "react-native-cli/**/*.hpp",
-        "react-native-cli/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "PATENTS/**/*.h",
+      "PATENTS/**/*.hpp",
+      "PATENTS/**/*.hxx",
+      "lint/**/*.h",
+      "lint/**/*.hpp",
+      "lint/**/*.hxx",
+      "node_modules/**/*.h",
+      "node_modules/**/*.hpp",
+      "node_modules/**/*.hxx",
+      "packager/**/*.h",
+      "packager/**/*.hpp",
+      "packager/**/*.hxx",
+      "react-native-cli/**/*.h",
+      "react-native-cli/**/*.hpp",
+      "react-native-cli/**/*.hxx"
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -192,12 +176,9 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -223,10 +204,8 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -237,8 +216,7 @@ filegroup(
   srcs = glob(
     [
       "React/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -247,12 +225,9 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "PATENTS/**/*.h",
         "PATENTS/**/*.hpp",
@@ -278,10 +253,8 @@ filegroup(
         "IntegrationTests/*.h",
         "IntegrationTests/*.hpp",
         "IntegrationTests/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -339,69 +312,20 @@ objc_library(
       "IntegrationTests/*.cxx",
       "IntegrationTests/*.m",
       "IntegrationTests/*.mm",
-      "IntegrationTests/*.s"
-    ] + glob(
-      [
-        "Libraries/ART/**/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.m"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      "IntegrationTests/*.s",
+      "Libraries/ART/**/*.m",
+      "Libraries/ActionSheetIOS/*.m",
+      "Libraries/AdSupport/*.m",
+      "Libraries/Geolocation/*.m",
+      "Libraries/Image/*.m",
+      "Libraries/Network/*.m",
+      "Libraries/PushNotificationIOS/*.m",
+      "Libraries/Settings/*.m",
+      "Libraries/Text/*.m",
+      "Libraries/Vibration/*.m",
+      "Libraries/WebSocket/*.m",
+      "Libraries/LinkingIOS/*.m"
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -440,18 +364,10 @@ acknowledged_target(
 filegroup(
   name = "ART_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -462,8 +378,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ART/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -474,18 +389,10 @@ filegroup(
 filegroup(
   name = "ART_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ART/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ART/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -528,8 +435,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ART/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ART_hdrs"
@@ -566,18 +472,10 @@ acknowledged_target(
 filegroup(
   name = "RCTActionSheet_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -588,8 +486,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -600,18 +497,10 @@ filegroup(
 filegroup(
   name = "RCTActionSheet_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/ActionSheetIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/ActionSheetIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -654,8 +543,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/ActionSheetIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTActionSheet_hdrs"
@@ -692,18 +580,10 @@ acknowledged_target(
 filegroup(
   name = "RCTAdSupport_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/AdSupport/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -714,8 +594,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/AdSupport/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -726,18 +605,10 @@ filegroup(
 filegroup(
   name = "RCTAdSupport_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/AdSupport/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/AdSupport/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -780,8 +651,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/AdSupport/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTAdSupport_hdrs"
@@ -818,18 +688,10 @@ acknowledged_target(
 filegroup(
   name = "RCTGeolocation_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -840,8 +702,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Geolocation/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -852,18 +713,10 @@ filegroup(
 filegroup(
   name = "RCTGeolocation_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Geolocation/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Geolocation/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -906,8 +759,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Geolocation/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTGeolocation_hdrs"
@@ -944,18 +796,10 @@ acknowledged_target(
 filegroup(
   name = "RCTImage_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -966,8 +810,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Image/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -978,18 +821,10 @@ filegroup(
 filegroup(
   name = "RCTImage_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Image/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Image/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1032,8 +867,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Image/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTImage_hdrs"
@@ -1070,18 +904,10 @@ acknowledged_target(
 filegroup(
   name = "RCTNetwork_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1092,8 +918,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Network/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1104,18 +929,10 @@ filegroup(
 filegroup(
   name = "RCTNetwork_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Network/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Network/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1158,8 +975,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Network/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTNetwork_hdrs"
@@ -1196,18 +1012,10 @@ acknowledged_target(
 filegroup(
   name = "RCTPushNotification_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1218,8 +1026,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1230,18 +1037,10 @@ filegroup(
 filegroup(
   name = "RCTPushNotification_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/PushNotificationIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/PushNotificationIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1284,8 +1083,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/PushNotificationIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTPushNotification_hdrs"
@@ -1322,18 +1120,10 @@ acknowledged_target(
 filegroup(
   name = "RCTSettings_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1344,8 +1134,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Settings/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1356,18 +1145,10 @@ filegroup(
 filegroup(
   name = "RCTSettings_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Settings/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Settings/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1410,8 +1191,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Settings/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTSettings_hdrs"
@@ -1448,18 +1228,10 @@ acknowledged_target(
 filegroup(
   name = "RCTText_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1470,8 +1242,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Text/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1482,18 +1253,10 @@ filegroup(
 filegroup(
   name = "RCTText_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Text/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Text/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1536,8 +1299,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Text/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTText_hdrs"
@@ -1574,18 +1336,10 @@ acknowledged_target(
 filegroup(
   name = "RCTVibration_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1596,8 +1350,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/Vibration/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1608,18 +1361,10 @@ filegroup(
 filegroup(
   name = "RCTVibration_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/Vibration/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/Vibration/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1662,8 +1407,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/Vibration/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTVibration_hdrs"
@@ -1700,18 +1444,10 @@ acknowledged_target(
 filegroup(
   name = "RCTWebSocket_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1722,8 +1458,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/WebSocket/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1734,18 +1469,10 @@ filegroup(
 filegroup(
   name = "RCTWebSocket_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/WebSocket/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/WebSocket/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1788,8 +1515,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/WebSocket/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTWebSocket_hdrs"
@@ -1826,18 +1552,10 @@ acknowledged_target(
 filegroup(
   name = "RCTLinkingIOS_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1848,8 +1566,7 @@ filegroup(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_public_hdrs"
   ],
@@ -1860,18 +1577,10 @@ filegroup(
 filegroup(
   name = "RCTLinkingIOS_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Libraries/LinkingIOS/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Libraries/LinkingIOS/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1914,8 +1623,7 @@ objc_library(
   srcs = glob(
     [
       "Libraries/LinkingIOS/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":RCTLinkingIOS_hdrs"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -47,20 +47,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +65,7 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +74,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -139,32 +122,24 @@ objc_library(
       "security/**/*.cpp",
       "security/**/*.cxx"
     ],
-    exclude = glob(
-      [
-        "security/**/*.S",
-        "security/**/*.c",
-        "security/**/*.m",
-        "security/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "security/**/*.S",
+      "security/**/*.c",
+      "security/**/*.m",
+      "security/**/*.s"
+    ]
   ),
   non_arc_srcs = glob(
     glob(
       [
         "security/**/*.mm"
       ],
-      exclude = glob(
-        [
-          "security/**/*.S",
-          "security/**/*.c",
-          "security/**/*.m",
-          "security/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
+      exclude = [
+        "security/**/*.S",
+        "security/**/*.c",
+        "security/**/*.m",
+        "security/**/*.s"
+      ]
     ),
     exclude = glob(
       [
@@ -172,18 +147,13 @@ objc_library(
         "security/**/*.cpp",
         "security/**/*.cxx"
       ],
-      exclude = glob(
-        [
-          "security/**/*.S",
-          "security/**/*.c",
-          "security/**/*.m",
-          "security/**/*.s"
-        ],
-        exclude_directories = 1
-      ),
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      exclude = [
+        "security/**/*.S",
+        "security/**/*.c",
+        "security/**/*.m",
+        "security/**/*.s"
+      ]
+    )
   ),
   module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [
@@ -227,8 +197,7 @@ swift_library(
   srcs = glob(
     [
       "security/**/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [],
   data = [],
@@ -239,20 +208,12 @@ swift_library(
 filegroup(
   name = "SFHFKeychainUtils_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -265,8 +226,7 @@ filegroup(
       "security/**/*.h",
       "security/**/*.hpp",
       "security/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":SFHFKeychainUtils_cxx_public_hdrs"
   ],
@@ -277,20 +237,12 @@ filegroup(
 filegroup(
   name = "SFHFKeychainUtils_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "security/**/*.h",
-        "security/**/*.hpp",
-        "security/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "security/**/*.h",
+      "security/**/*.hpp",
+      "security/**/*.hxx"
+    ]
   ) + [
     ":SFHFKeychainUtils_cxx_hdrs"
   ],
@@ -327,8 +279,7 @@ objc_library(
       "security/**/*.c",
       "security/**/*.m",
       "security/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   module_map = ":SFHFKeychainUtils_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SPUserResizableView/SPUserResizableView.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SPUserResizableView/SPUserResizableView.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "SPUserResizableView+Pion_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SPUserResizableView/SPUserResizableView.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SPUserResizableView/SPUserResizableView.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "SPUserResizableView/SPUserResizableView.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SPUserResizableView+Pion_hdrs"

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -51,8 +51,7 @@ swift_library(
     ],
     exclude = [
       "Classes/Exclude/**/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [],
   data = [],
@@ -65,8 +64,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,8 +82,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "Source/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "SlackTextViewController_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Source/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Source/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":SlackTextViewController_hdrs"

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Smartling_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Smartling_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -46,19 +46,11 @@ filegroup(
 filegroup(
   name = "Stripe_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Stripe/*.h",
-        "Stripe/PublicHeaders/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Stripe/*.h",
+      "Stripe/PublicHeaders/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +61,7 @@ filegroup(
   srcs = glob(
     [
       "Stripe/PublicHeaders/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -79,19 +70,11 @@ filegroup(
 filegroup(
   name = "Stripe_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Stripe/*.h",
-        "Stripe/PublicHeaders/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Stripe/*.h",
+      "Stripe/PublicHeaders/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -121,8 +104,7 @@ objc_library(
   srcs = glob(
     [
       "Stripe/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Stripe_hdrs"
@@ -174,8 +156,7 @@ apple_resource_bundle(
   resources = glob(
     [
       "Stripe/Resources/**/*"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -48,8 +48,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -69,8 +68,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_hdrs"
   ],
@@ -108,30 +106,6 @@ alias(
 objc_library(
   name = "TestArcPatternsWithExcludes",
   enable_modules = 0,
-  srcs = glob(
-    [
-      "POD_REQUIRES_ARC/*.m"
-    ],
-    exclude = glob(
-      [
-        "POD_REQUIRES_ARC/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
-  non_arc_srcs = glob(
-    [
-      "POD_REQUIRES_ARC/*.m"
-    ],
-    exclude = glob(
-      [
-        "POD_REQUIRES_ARC/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
-  ),
   hdrs = [
     ":FBSDKCoreKit_hdrs"
   ],
@@ -169,74 +143,54 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -249,8 +203,7 @@ filegroup(
   srcs = glob(
     [
       "**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -261,74 +214,54 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_IOS/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h",
             "CORE_EXCLUDE_TV/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "**/*.h"
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.h"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       )
     }
   ),
@@ -384,12 +317,9 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_IOS/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":osxCase": glob(
         [
@@ -405,12 +335,9 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":tvosCase": glob(
         [
@@ -427,12 +354,9 @@ objc_library(
             exclude = [
               "CORE_EXCLUDE/**/*.m",
               "CORE_EXCLUDE_TV/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       ),
       ":watchosCase": glob(
         [
@@ -448,12 +372,9 @@ objc_library(
             ],
             exclude = [
               "CORE_EXCLUDE/**/*.m"
-            ],
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+            ]
+          )
+        )
       )
     }
   ),
@@ -467,8 +388,7 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_IOS/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -485,14 +405,10 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_IOS/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":osxCase": glob(
         glob(
@@ -501,8 +417,7 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -518,14 +433,10 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":tvosCase": glob(
         glob(
@@ -535,8 +446,7 @@ objc_library(
           exclude = [
             "CORE_EXCLUDE/**/*.m",
             "CORE_EXCLUDE_TV/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -553,14 +463,10 @@ objc_library(
               exclude = [
                 "CORE_EXCLUDE/**/*.m",
                 "CORE_EXCLUDE_TV/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       ),
       ":watchosCase": glob(
         glob(
@@ -569,8 +475,7 @@ objc_library(
           ],
           exclude = [
             "CORE_EXCLUDE/**/*.m"
-          ],
-          exclude_directories = 1
+          ]
         ),
         exclude = glob(
           [
@@ -586,14 +491,10 @@ objc_library(
               ],
               exclude = [
                 "CORE_EXCLUDE/**/*.m"
-              ],
-              exclude_directories = 1
-            ),
-            exclude_directories = 1
-          ),
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+              ]
+            )
+          )
+        )
       )
     }
   ),

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -55,8 +55,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -79,8 +78,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":AssetsLibrary_hdrs",
     ":MapKit_hdrs",
@@ -158,27 +156,19 @@ acknowledged_target(
 filegroup(
   name = "Core_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -195,8 +185,7 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -205,27 +194,19 @@ filegroup(
 filegroup(
   name = "Core_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -266,14 +247,10 @@ objc_library(
     [
       "Source/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "Base/*.m",
-        "Source/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "Base/*.m",
+      "Source/**/*.m"
+    ]
   ),
   hdrs = [
     ":Core_cxx_hdrs"
@@ -317,27 +294,19 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -354,8 +323,7 @@ filegroup(
       "Source/Layout/**/*.h",
       "Source/TextKit/ASTextKitComponents.h",
       "Source/TextKit/ASTextNodeTypes.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Core_cxx_public_hdrs"
   ],
@@ -366,27 +334,19 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "Base/*.h",
-        "Source/**/*.h",
-        "Source/*.h",
-        "Source/Base/*.h",
-        "Source/Debug/**/*.h",
-        "Source/Details/**/*.h",
-        "Source/Layout/**/*.h",
-        "Source/TextKit/*.h",
-        "Source/TextKit/ASTextKitComponents.h",
-        "Source/TextKit/ASTextNodeTypes.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "Base/*.h",
+      "Source/**/*.h",
+      "Source/*.h",
+      "Source/Base/*.h",
+      "Source/Debug/**/*.h",
+      "Source/Details/**/*.h",
+      "Source/Layout/**/*.h",
+      "Source/TextKit/*.h",
+      "Source/TextKit/ASTextKitComponents.h",
+      "Source/TextKit/ASTextNodeTypes.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -430,8 +390,7 @@ objc_library(
     [
       "Base/*.m",
       "Source/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -475,8 +434,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -496,8 +454,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -584,8 +541,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -605,8 +561,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -690,8 +645,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -711,8 +665,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -798,8 +751,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -819,8 +771,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -905,8 +856,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -926,8 +876,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1012,8 +961,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -1033,8 +981,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -47,20 +47,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -73,8 +65,7 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -83,20 +74,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -140,16 +123,12 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.cxx",
       "UICollectionViewLeftAlignedLayout/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.S",
-        "UICollectionViewLeftAlignedLayout/**/*.c",
-        "UICollectionViewLeftAlignedLayout/**/*.m",
-        "UICollectionViewLeftAlignedLayout/**/*.s"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "UICollectionViewLeftAlignedLayout/**/*.S",
+      "UICollectionViewLeftAlignedLayout/**/*.c",
+      "UICollectionViewLeftAlignedLayout/**/*.m",
+      "UICollectionViewLeftAlignedLayout/**/*.s"
+    ]
   ),
   module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [
@@ -190,8 +169,7 @@ swift_library(
   srcs = glob(
     [
       "UICollectionViewLeftAlignedLayout/**/*.swift"
-    ],
-    exclude_directories = 1
+    ]
   ),
   deps = [],
   data = [],
@@ -202,20 +180,12 @@ swift_library(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -228,8 +198,7 @@ filegroup(
       "UICollectionViewLeftAlignedLayout/**/*.h",
       "UICollectionViewLeftAlignedLayout/**/*.hpp",
       "UICollectionViewLeftAlignedLayout/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_public_hdrs"
   ],
@@ -240,20 +209,12 @@ filegroup(
 filegroup(
   name = "UICollectionViewLeftAlignedLayout_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "UICollectionViewLeftAlignedLayout/**/*.h",
-        "UICollectionViewLeftAlignedLayout/**/*.hpp",
-        "UICollectionViewLeftAlignedLayout/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "UICollectionViewLeftAlignedLayout/**/*.h",
+      "UICollectionViewLeftAlignedLayout/**/*.hpp",
+      "UICollectionViewLeftAlignedLayout/**/*.hxx"
+    ]
   ) + [
     ":UICollectionViewLeftAlignedLayout_cxx_hdrs"
   ],
@@ -290,8 +251,7 @@ objc_library(
       "UICollectionViewLeftAlignedLayout/**/*.c",
       "UICollectionViewLeftAlignedLayout/**/*.m",
       "UICollectionViewLeftAlignedLayout/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   module_map = ":UICollectionViewLeftAlignedLayout_extended_module_map_module_map_file",
   hdrs = [

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "Weixin_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SDK1.6.2/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SDK1.6.2/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "SDK1.6.2/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "Weixin_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "SDK1.6.2/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "SDK1.6.2/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -45,23 +45,15 @@ filegroup(
 filegroup(
   name = "ZipArchive_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h",
-        "minizip/crypt.h",
-        "minizip/ioapi.h",
-        "minizip/mztools.h",
-        "minizip/unzip.h",
-        "minizip/zip.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h",
+      "minizip/crypt.h",
+      "minizip/ioapi.h",
+      "minizip/mztools.h",
+      "minizip/unzip.h",
+      "minizip/zip.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -72,8 +64,7 @@ filegroup(
   srcs = glob(
     [
       "*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -82,23 +73,15 @@ filegroup(
 filegroup(
   name = "ZipArchive_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "*.h",
-        "minizip/crypt.h",
-        "minizip/ioapi.h",
-        "minizip/mztools.h",
-        "minizip/unzip.h",
-        "minizip/zip.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "*.h",
+      "minizip/crypt.h",
+      "minizip/ioapi.h",
+      "minizip/mztools.h",
+      "minizip/unzip.h",
+      "minizip/zip.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -133,8 +116,7 @@ objc_library(
       "minizip/mztools.c",
       "minizip/unzip.c",
       "minizip/zip.c"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":ZipArchive_hdrs"

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -45,20 +45,12 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "boost/**/*.h",
-        "boost/**/*.hpp",
-        "boost/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "boost/**/*.h",
+      "boost/**/*.hpp",
+      "boost/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -74,20 +66,12 @@ filegroup(
 filegroup(
   name = "boost-for-react-native_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "boost/**/*.h",
-        "boost/**/*.hpp",
-        "boost/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "boost/**/*.h",
+      "boost/**/*.hpp",
+      "boost/**/*.hxx"
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -45,12 +45,9 @@ filegroup(
 filegroup(
   name = "glog_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -60,10 +57,8 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -74,8 +69,7 @@ filegroup(
   srcs = glob(
     [
       "src/glog/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -84,12 +78,9 @@ filegroup(
 filegroup(
   name = "glog_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
+    [
+      "pod_support/Headers/Public/**/*"
+    ] + glob(
       [
         "src/*.h",
         "src/base/*.h",
@@ -99,10 +90,8 @@ filegroup(
         "src/windows/**/*.h",
         "src/windows/**/*.hpp",
         "src/windows/**/*.hxx"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+      ]
+    )
   ),
   visibility = [
     "//visibility:public"
@@ -148,8 +137,7 @@ objc_library(
       "src/windows/**/*.m",
       "src/windows/**/*.mm",
       "src/windows/**/*.s"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":glog_hdrs"

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -71,8 +70,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Messages_hdrs",
     ":Services_hdrs"
@@ -147,18 +145,10 @@ acknowledged_target(
 filegroup(
   name = "Messages_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbobjc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbobjc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -169,8 +159,7 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbobjc.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -179,18 +168,10 @@ filegroup(
 filegroup(
   name = "Messages_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbobjc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbobjc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -233,13 +214,9 @@ objc_library(
     [
       "google/**/*.pbobjc.m"
     ],
-    exclude = glob(
-      [
-        "google/**/*.pbrpc.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "google/**/*.pbrpc.m"
+    ]
   ),
   hdrs = [
     ":Messages_hdrs"
@@ -280,18 +257,10 @@ acknowledged_target(
 filegroup(
   name = "Services_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbrpc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbrpc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -302,8 +271,7 @@ filegroup(
   srcs = glob(
     [
       "google/**/*.pbrpc.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":Messages_public_hdrs"
   ],
@@ -314,18 +282,10 @@ filegroup(
 filegroup(
   name = "Services_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "google/**/*.pbrpc.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "google/**/*.pbrpc.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -369,8 +329,7 @@ objc_library(
   srcs = glob(
     [
       "google/**/*.pbrpc.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Services_hdrs"

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -49,8 +49,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -70,8 +69,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":SwiftSupport_hdrs"
   ],
@@ -143,25 +141,17 @@ acknowledged_target(
 filegroup(
   name = "Core_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSnapshotTestCase/**/*.h",
-        "FBSnapshotTestCase/*.h",
-        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-        "FBSnapshotTestCase/FBSnapshotTestCase.h",
-        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-        "FBSnapshotTestCase/FBSnapshotTestController.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSnapshotTestCase/**/*.h",
+      "FBSnapshotTestCase/*.h",
+      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+      "FBSnapshotTestCase/FBSnapshotTestCase.h",
+      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+      "FBSnapshotTestCase/FBSnapshotTestController.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -179,8 +169,7 @@ filegroup(
       "FBSnapshotTestCase/Categories/UIImage+Compare.h",
       "FBSnapshotTestCase/Categories/UIImage+Diff.h",
       "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -189,25 +178,17 @@ filegroup(
 filegroup(
   name = "Core_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "FBSnapshotTestCase/**/*.h",
-        "FBSnapshotTestCase/*.h",
-        "FBSnapshotTestCase/Categories/UIImage+Compare.h",
-        "FBSnapshotTestCase/Categories/UIImage+Diff.h",
-        "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
-        "FBSnapshotTestCase/FBSnapshotTestCase.h",
-        "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
-        "FBSnapshotTestCase/FBSnapshotTestController.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "FBSnapshotTestCase/**/*.h",
+      "FBSnapshotTestCase/*.h",
+      "FBSnapshotTestCase/Categories/UIImage+Compare.h",
+      "FBSnapshotTestCase/Categories/UIImage+Diff.h",
+      "FBSnapshotTestCase/Categories/UIImage+Snapshot.h",
+      "FBSnapshotTestCase/FBSnapshotTestCase.h",
+      "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h",
+      "FBSnapshotTestCase/FBSnapshotTestController.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -248,8 +229,7 @@ objc_library(
     [
       "FBSnapshotTestCase/**/*.m",
       "FBSnapshotTestCase/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":Core_hdrs"
@@ -293,8 +273,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -314,8 +293,7 @@ filegroup(
   srcs = glob(
     [
       "pod_support/Headers/Public/**/*"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -46,18 +46,10 @@ filegroup(
 filegroup(
   name = "iRate_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "iRate/iRate.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "iRate/iRate.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -68,8 +60,7 @@ filegroup(
   srcs = glob(
     [
       "iRate/iRate.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -78,18 +69,10 @@ filegroup(
 filegroup(
   name = "iRate_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "iRate/iRate.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "iRate/iRate.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -119,8 +102,7 @@ objc_library(
   srcs = glob(
     [
       "iRate/iRate.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":iRate_hdrs"
@@ -161,8 +143,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "iRate/iRate.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "kingpin_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "kingpin/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "kingpin/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "kingpin/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "kingpin_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "kingpin/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "kingpin/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "kingpin/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":kingpin_hdrs"

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -46,33 +46,25 @@ filegroup(
 filegroup(
   name = "pop_cxx_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -97,8 +89,7 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -107,33 +98,25 @@ filegroup(
 filegroup(
   name = "pop_cxx_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -175,13 +158,9 @@ objc_library(
       "pop/**/*.cpp",
       "pop/**/*.mm"
     ],
-    exclude = glob(
-      [
-        "pop/**/*.m"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    exclude = [
+      "pop/**/*.m"
+    ]
   ),
   hdrs = [
     ":pop_cxx_hdrs"
@@ -224,33 +203,25 @@ acknowledged_target(
 filegroup(
   name = "pop_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -275,8 +246,7 @@ filegroup(
       "pop/POPLayerExtras.h",
       "pop/POPPropertyAnimation.h",
       "pop/POPSpringAnimation.h"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":pop_cxx_public_hdrs"
   ],
@@ -287,33 +257,25 @@ filegroup(
 filegroup(
   name = "pop_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "pop/**/*.h",
-        "pop/POP.h",
-        "pop/POPAnimatableProperty.h",
-        "pop/POPAnimation.h",
-        "pop/POPAnimationEvent.h",
-        "pop/POPAnimationExtras.h",
-        "pop/POPAnimationTracer.h",
-        "pop/POPAnimator.h",
-        "pop/POPBasicAnimation.h",
-        "pop/POPCustomAnimation.h",
-        "pop/POPDecayAnimation.h",
-        "pop/POPDefines.h",
-        "pop/POPGeometry.h",
-        "pop/POPLayerExtras.h",
-        "pop/POPPropertyAnimation.h",
-        "pop/POPSpringAnimation.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "pop/**/*.h",
+      "pop/POP.h",
+      "pop/POPAnimatableProperty.h",
+      "pop/POPAnimation.h",
+      "pop/POPAnimationEvent.h",
+      "pop/POPAnimationExtras.h",
+      "pop/POPAnimationTracer.h",
+      "pop/POPAnimator.h",
+      "pop/POPBasicAnimation.h",
+      "pop/POPCustomAnimation.h",
+      "pop/POPDecayAnimation.h",
+      "pop/POPDefines.h",
+      "pop/POPGeometry.h",
+      "pop/POPLayerExtras.h",
+      "pop/POPPropertyAnimation.h",
+      "pop/POPSpringAnimation.h"
+    ]
   ) + [
     ":pop_cxx_hdrs"
   ],
@@ -347,8 +309,7 @@ objc_library(
   srcs = glob(
     [
       "pop/**/*.m"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":pop_hdrs"

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -45,18 +45,10 @@ filegroup(
 filegroup(
   name = "yoga_direct_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "yoga/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "yoga/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -67,8 +59,7 @@ filegroup(
   srcs = glob(
     [
       "yoga/**/*.h"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -77,18 +68,10 @@ filegroup(
 filegroup(
   name = "yoga_hdrs",
   srcs = glob(
-    glob(
-      [
-        "pod_support/Headers/Public/**/*"
-      ],
-      exclude_directories = 1
-    ) + glob(
-      [
-        "yoga/**/*.h"
-      ],
-      exclude_directories = 1
-    ),
-    exclude_directories = 1
+    [
+      "pod_support/Headers/Public/**/*",
+      "yoga/**/*.h"
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -118,8 +101,7 @@ objc_library(
   srcs = glob(
     [
       "yoga/**/*.cpp"
-    ],
-    exclude_directories = 1
+    ]
   ),
   hdrs = [
     ":yoga_hdrs"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -50,12 +50,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -65,18 +62,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -86,42 +78,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -136,8 +110,7 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ),
   visibility = [
     "//visibility:public"
@@ -148,12 +121,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -163,18 +133,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -184,42 +149,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -292,10 +239,8 @@ objc_library(
             "Classes/osx/**/*.m",
             "Classes/osx/**/*.mm",
             "Classes/osx/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
         [
@@ -329,10 +274,8 @@ objc_library(
             "Classes/ios/**/*.m",
             "Classes/ios/**/*.mm",
             "Classes/ios/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
         [
@@ -341,16 +284,12 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Classes/**/*.S",
-            "Classes/**/*.c",
-            "Classes/**/*.m",
-            "Classes/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Classes/**/*.S",
+          "Classes/**/*.c",
+          "Classes/**/*.m",
+          "Classes/**/*.s"
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -359,16 +298,12 @@ objc_library(
           "Classes/**/*.cxx",
           "Classes/**/*.mm"
         ],
-        exclude = glob(
-          [
-            "Classes/**/*.S",
-            "Classes/**/*.c",
-            "Classes/**/*.m",
-            "Classes/**/*.s"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        exclude = [
+          "Classes/**/*.S",
+          "Classes/**/*.c",
+          "Classes/**/*.m",
+          "Classes/**/*.s"
+        ]
       )
     }
   ),
@@ -419,8 +354,7 @@ swift_library(
         ],
         exclude = [
           "Classes/osx/**/*.swift"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
         [
@@ -428,20 +362,17 @@ swift_library(
         ],
         exclude = [
           "Classes/ios/**/*.swift"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
           "Classes/**/*.swift"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
           "Classes/**/*.swift"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -456,12 +387,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -471,18 +399,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -492,42 +415,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ),
@@ -542,8 +447,7 @@ filegroup(
       "Classes/**/*.h",
       "Classes/**/*.hpp",
       "Classes/**/*.hxx"
-    ],
-    exclude_directories = 1
+    ]
   ) + [
     ":youtube-ios-player-helper_cxx_public_hdrs"
   ],
@@ -556,12 +460,9 @@ filegroup(
   srcs = select(
     {
       "//conditions:default": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -571,18 +472,13 @@ filegroup(
             "Classes/osx/**/*.h",
             "Classes/osx/**/*.hpp",
             "Classes/osx/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":osxCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
+        [
+          "pod_support/Headers/Public/**/*"
+        ] + glob(
           [
             "Classes/**/*.h",
             "Classes/**/*.hpp",
@@ -592,42 +488,24 @@ filegroup(
             "Classes/ios/**/*.h",
             "Classes/ios/**/*.hpp",
             "Classes/ios/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+          ]
+        )
       ),
       ":tvosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       ),
       ":watchosCase": glob(
-        glob(
-          [
-            "pod_support/Headers/Public/**/*"
-          ],
-          exclude_directories = 1
-        ) + glob(
-          [
-            "Classes/**/*.h",
-            "Classes/**/*.hpp",
-            "Classes/**/*.hxx"
-          ],
-          exclude_directories = 1
-        ),
-        exclude_directories = 1
+        [
+          "pod_support/Headers/Public/**/*",
+          "Classes/**/*.h",
+          "Classes/**/*.hpp",
+          "Classes/**/*.hxx"
+        ]
       )
     }
   ) + [
@@ -678,8 +556,7 @@ objc_library(
           "Classes/osx/**/*.m",
           "Classes/osx/**/*.mm",
           "Classes/osx/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":osxCase": glob(
         [
@@ -697,8 +574,7 @@ objc_library(
           "Classes/ios/**/*.m",
           "Classes/ios/**/*.mm",
           "Classes/ios/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":tvosCase": glob(
         [
@@ -706,8 +582,7 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       ),
       ":watchosCase": glob(
         [
@@ -715,8 +590,7 @@ objc_library(
           "Classes/**/*.c",
           "Classes/**/*.m",
           "Classes/**/*.s"
-        ],
-        exclude_directories = 1
+        ]
       )
     }
   ),
@@ -786,8 +660,7 @@ apple_bundle_import(
   bundle_imports = glob(
     [
       "youtube-ios-player-helper/Assets.bundle/**"
-    ],
-    exclude_directories = 1
+    ]
   )
 )
 acknowledged_target(

--- a/Sources/PodToBUILD/GlobNode.swift
+++ b/Sources/PodToBUILD/GlobNode.swift
@@ -109,7 +109,7 @@ extension Either: Equatable where T == Set<String>, U == GlobNode {
 extension Array where Iterator.Element == Either<Set<String>, GlobNode> {
     var isEmpty: Bool {
         return self.reduce(true) {
-            $0 == false ? $0 | $1.isEmpty
+            $0 == false ? $0 : $1.isEmpty
         }
     }
 

--- a/Sources/PodToBUILD/GlobNode.swift
+++ b/Sources/PodToBUILD/GlobNode.swift
@@ -70,17 +70,9 @@ extension Either: Equatable where T == Set<String>, U == GlobNode {
         if case let .right(lhsR) = lhs, case let .right(rhsR) = rhs {
             return lhsR == rhsR
         }
-        if case let .left(lhsL) = lhs, case let .right(rhsR) = rhs {
-            if lhsL.isEmpty, rhsR.isEmpty {
-                return true
-            }
-        }
-        if case let .right(lhsR) = lhs, case let .left(rhsR) = rhs {
-            if lhsR.isEmpty, rhsR.isEmpty {
-                return true
-            }
-        }
-
+	if lhs.isEmpty && rhs.isEmpty {
+	    return true
+	}
         return false
     }
 
@@ -121,12 +113,7 @@ extension Array where Iterator.Element == Either<Set<String>, GlobNode> {
             if accum == false {
                 return false
             }
-            switch next {
-            case .left(let val):
-                return val.isEmpty
-            case .right(let val):
-                return val.isEmpty
-            }
+	    return next.isEmpty
         }
     }
 
@@ -134,15 +121,7 @@ extension Array where Iterator.Element == Either<Set<String>, GlobNode> {
         // First simplify the elements and then filter the empty elements
         return self
         .map { $0.simplify() }
-        .filter {
-            element in
-            switch element {
-            case let .left(val):
-                return !val.isEmpty
-            case let .right(val):
-                return !val.isEmpty
-            }
-        }
+        .filter { !$0.isEmpty }
     }
 }
 
@@ -154,6 +133,15 @@ extension Either: SkylarkConvertible where T == Set<String>, U == GlobNode {
         case let .right(globVal):
             return globVal.toSkylark()
         }
+    }
+
+    var isEmpty: Bool {
+	switch self {
+	case let .left(val):
+	    return val.isEmpty
+	case let .right(val):
+	    return val.isEmpty
+	}
     }
 
     public func simplify() -> Either<Set<String>, GlobNode> {

--- a/Sources/PodToBUILD/GlobNode.swift
+++ b/Sources/PodToBUILD/GlobNode.swift
@@ -17,11 +17,11 @@ public struct GlobNode: SkylarkConvertible {
         = Either.left(Set([String]()))
 
     public init(include: Set<String> = Set(), exclude: Set<String> = Set()) {
-        self.init(include:  [.left(include)], exclude: [.left(exclude)])
+        self.init(include: [.left(include)], exclude: [.left(exclude)])
     }
 
     public init(include: Either<Set<String>, GlobNode>, exclude: Either<Set<String>, GlobNode>) {
-        self.init(include:  [include], exclude: [exclude])
+        self.init(include: [include], exclude: [exclude])
     }
 
     public init(include: [Either<Set<String>, GlobNode>] = [], exclude: [Either<Set<String>, GlobNode>] = []) {
@@ -70,9 +70,9 @@ extension Either: Equatable where T == Set<String>, U == GlobNode {
         if case let .right(lhsR) = lhs, case let .right(rhsR) = rhs {
             return lhsR == rhsR
         }
-	if lhs.isEmpty && rhs.isEmpty {
-	    return true
-	}
+        if lhs.isEmpty && rhs.isEmpty {
+            return true
+        }
         return false
     }
 
@@ -109,19 +109,15 @@ extension Either: Equatable where T == Set<String>, U == GlobNode {
 extension Array where Iterator.Element == Either<Set<String>, GlobNode> {
     var isEmpty: Bool {
         return self.reduce(true) {
-            accum, next -> Bool in
-            if accum == false {
-                return false
-            }
-	    return next.isEmpty
+            $0 == false ? $0 | $1.isEmpty
         }
     }
 
     public func simplify() -> [Either<Set<String>, GlobNode>] {
         // First simplify the elements and then filter the empty elements
         return self
-        .map { $0.simplify() }
-        .filter { !$0.isEmpty }
+            .map { $0.simplify() }
+            .filter { !$0.isEmpty }
     }
 }
 
@@ -136,12 +132,12 @@ extension Either: SkylarkConvertible where T == Set<String>, U == GlobNode {
     }
 
     var isEmpty: Bool {
-	switch self {
-	case let .left(val):
-	    return val.isEmpty
-	case let .right(val):
-	    return val.isEmpty
-	}
+        switch self {
+        case let .left(val):
+            return val.isEmpty
+        case let .right(val):
+            return val.isEmpty
+        }
     }
 
     public func simplify() -> Either<Set<String>, GlobNode> {


### PR DESCRIPTION
This PR simplifies GlobNodes upon allocation reduce the complexity of
the glob at runtime algorithms and visually.

Logically, the output is the same, but it cleans up build files where
possible, especially in the case of combining subspec deps, arc, and
exclusions.

Additionally, it adds a few cleanups and removed the default argument
for `exclude_directories` as it's unneeded

This was pointed out in
https://github.com/pinterest/PodToBUILD/pull/153
and submitted as a follow up for simplicity