### PR TITLE
Add fobjc-weak and FBSDKCoreKit 7.x test to CI

### DIFF
--- a/Examples/FBSDK/Vendor/Podspecs/FBSDKCoreKit.podspec.json
+++ b/Examples/FBSDK/Vendor/Podspecs/FBSDKCoreKit.podspec.json
@@ -1,0 +1,120 @@
+{
+  "name": "FBSDKCoreKit",
+  "version": "7.1.1",
+  "summary": "Official Facebook SDK for iOS to access Facebook Platform core features",
+  "description": "The Facebook SDK for iOS CoreKit framework provides:\n* App Events (for App Analytics)\n* Graph API Access and Error Recovery\n* Working with Access Tokens and User Profiles",
+  "homepage": "https://developers.facebook.com/docs/ios/",
+  "license": {
+    "type": "Facebook Platform License",
+    "file": "LICENSE"
+  },
+  "authors": "Facebook",
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "10.0"
+  },
+  "source": {
+    "git": "https://github.com/facebook/facebook-ios-sdk.git",
+    "tag": "v7.1.1"
+  },
+  "ios": {
+    "weak_frameworks": [
+      "Accelerate",
+      "Accounts",
+      "Social",
+      "Security",
+      "QuartzCore",
+      "CoreGraphics",
+      "UIKit",
+      "Foundation",
+      "AudioToolbox"
+    ]
+  },
+  "tvos": {
+    "weak_frameworks": [
+      "CoreLocation",
+      "Security",
+      "QuartzCore",
+      "CoreGraphics",
+      "UIKit",
+      "Foundation",
+      "AudioToolbox"
+    ]
+  },
+  "requires_arc": [
+    "FBSDKCoreKit/FBSDKCoreKit/*",
+    "FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*",
+    "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*",
+    "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*"
+  ],
+  "default_subspecs": [
+    "Core",
+    "Basics"
+  ],
+  "swift_versions": "5.0",
+  "pod_target_xcconfig": {
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) FBSDKCOCOAPODS=1",
+    "DEFINES_MODULE": "YES"
+  },
+  "user_target_xcconfig": {
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) FBSDKCOCOAPODS=1"
+  },
+  "libraries": [
+    "c++",
+    "stdc++"
+  ],
+  "subspecs": [
+    {
+      "name": "Basics",
+      "source_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.{h,m}",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}"
+      ],
+      "public_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*.h"
+      ],
+      "private_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/Instrument/**/*.h"
+      ],
+      "libraries": "z"
+    },
+    {
+      "name": "Core",
+      "dependencies": {
+        "FBSDKCoreKit/Basics": [
+
+        ]
+      },
+      "exclude_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/*",
+        "FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}",
+        "FBSDKCoreKit/FBSDKCoreKit/include/**/*",
+        "FBSDKCoreKit/FBSDKCoreKit/Swift/Exports.swift"
+      ],
+      "source_files": "FBSDKCoreKit/FBSDKCoreKit/**/*.{h,hpp,m,mm,swift}",
+      "public_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppLink/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h"
+      ],
+      "private_header_files": [
+        "FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h",
+        "FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h"
+      ],
+      "resources": "FacebookSDKStrings.bundle",
+      "libraries": [
+        "c++",
+        "stdc++"
+      ]
+    }
+  ],
+  "swift_version": "5.0"
+}

--- a/Examples/FBSDK/Vendor/Podspecs/FBSDKLoginKit.podspec.json
+++ b/Examples/FBSDK/Vendor/Podspecs/FBSDKLoginKit.podspec.json
@@ -1,0 +1,63 @@
+{
+  "name": "FBSDKLoginKit",
+  "version": "7.1.1",
+  "summary": "Official Facebook SDK for iOS to access Facebook Platform with features like Login, Share and Message Dialog, App Links, and Graph API",
+  "description": "The Facebook SDK for iOS LoginKit framework provides:\n* Facebook Login to easily sign in users.\n* Sharing features like the Share or Message Dialog to grow your app.\n* Simpler Graph API access to provide more social context.",
+  "homepage": "https://developers.facebook.com/docs/ios/",
+  "license": {
+    "type": "Facebook Platform License",
+    "file": "LICENSE"
+  },
+  "authors": "Facebook",
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "10.0"
+  },
+  "source": {
+    "git": "https://github.com/facebook/facebook-ios-sdk.git",
+    "tag": "v7.1.1"
+  },
+  "ios": {
+    "weak_frameworks": [
+      "Accounts",
+      "Social",
+      "Security",
+      "QuartzCore",
+      "CoreGraphics",
+      "UIKit",
+      "Foundation",
+      "AudioToolbox"
+    ]
+  },
+  "tvos": {
+    "weak_frameworks": [
+      "AudioToolbox",
+      "CoreGraphics",
+      "Foundation",
+      "QuartzCore",
+      "Security",
+      "UIKit"
+    ]
+  },
+  "requires_arc": true,
+  "default_subspecs": "Login",
+  "swift_versions": "5.0",
+  "prefix_header_contents": "#define FBSDKCOCOAPODS",
+  "subspecs": [
+    {
+      "name": "Login",
+      "dependencies": {
+        "FBSDKCoreKit": [
+          "~> 7.1.1"
+        ]
+      },
+      "exclude_files": [
+        "FBSDKLoginKit/FBSDKLoginKit/include/**/*",
+        "FBSDKLoginKit/FBSDKLoginKit/Swift/Exports.swift"
+      ],
+      "source_files": "FBSDKLoginKit/FBSDKLoginKit/**/*.{h,m,swift}",
+      "public_header_files": "FBSDKLoginKit/FBSDKLoginKit/*.{h}"
+    }
+  ],
+  "swift_version": "5.0"
+}

--- a/Examples/FBSDK/Vendor/Podspecs/FBSDKShareKit.podspec.json
+++ b/Examples/FBSDK/Vendor/Podspecs/FBSDKShareKit.podspec.json
@@ -1,0 +1,64 @@
+{
+  "name": "FBSDKShareKit",
+  "version": "7.1.1",
+  "summary": "Official Facebook SDK for iOS to access Facebook Platform Sharing Features",
+  "description": "The Facebook SDK for iOS ShareKit framework provides:\n* Share content with Share Dialog and Message Dialog.\n* Send Game Requests or App Invites to grow your app.\n* Publish content and open graph stories with the Graph API",
+  "homepage": "https://developers.facebook.com/docs/ios/",
+  "license": {
+    "type": "Facebook Platform License",
+    "file": "LICENSE"
+  },
+  "authors": "Facebook",
+  "platforms": {
+    "ios": "8.0",
+    "tvos": "10.0"
+  },
+  "source": {
+    "git": "https://github.com/facebook/facebook-ios-sdk.git",
+    "tag": "v7.1.1"
+  },
+  "ios": {
+    "weak_frameworks": [
+      "Accounts",
+      "AudioToolbox",
+      "CoreGraphics",
+      "Foundation",
+      "QuartzCore",
+      "Security",
+      "Social",
+      "UIKit"
+    ]
+  },
+  "tvos": {
+    "weak_frameworks": [
+      "AudioToolbox",
+      "CoreGraphics",
+      "Foundation",
+      "QuartzCore",
+      "Security",
+      "UIKit"
+    ]
+  },
+  "requires_arc": true,
+  "default_subspecs": "Share",
+  "swift_versions": "5.0",
+  "header_dir": "FBSDKShareKit",
+  "prefix_header_contents": "#define FBSDKCOCOAPODS",
+  "subspecs": [
+    {
+      "name": "Share",
+      "dependencies": {
+        "FBSDKCoreKit": [
+          "~> 7.1.1"
+        ]
+      },
+      "exclude_files": [
+        "FBSDKShareKit/FBSDKShareKit/include/**/*",
+        "FBSDKShareKit/FBSDKShareKit/Swift/Exports.swift"
+      ],
+      "public_header_files": "FBSDKShareKit/FBSDKShareKit/*.{h}",
+      "source_files": "FBSDKShareKit/FBSDKShareKit/**/*.{h,m,swift}"
+    }
+  ],
+  "swift_version": "5.0"
+}

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -124,7 +124,9 @@ objc_library(
     ":Core",
     ":Adjust_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -247,7 +249,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -367,7 +371,9 @@ objc_library(
     ":Core",
     ":Sociomantic_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -487,7 +493,9 @@ objc_library(
     ":Core",
     ":Criteo_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -607,7 +615,9 @@ objc_library(
     ":Core",
     ":Trademob_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -267,7 +267,9 @@ objc_library(
     ":FBSDKCoreKit_cxx",
     ":FBSDKCoreKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1522,7 +1524,9 @@ objc_library(
   deps = [
     ":Basics_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2931,7 +2935,9 @@ objc_library(
     ":Basics",
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -112,7 +112,9 @@ objc_library(
     ":Tasks",
     ":Bolts_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -234,7 +236,9 @@ objc_library(
   deps = [
     ":Tasks_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -388,7 +392,9 @@ objc_library(
     ":Tasks",
     ":AppLinks_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -132,6 +132,7 @@ objc_library(
     ":Braintree_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -254,6 +255,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -367,6 +369,7 @@ objc_library(
     ":Apple-Pay_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -482,6 +485,7 @@ objc_library(
     ":Card_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -593,6 +597,7 @@ objc_library(
     ":DataCollector_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -718,6 +723,7 @@ objc_library(
     ":PayPal_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -832,6 +838,7 @@ objc_library(
     ":Venmo_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -975,6 +982,7 @@ objc_library(
     ":UI_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -1096,6 +1104,7 @@ objc_library(
     ":UnionPay_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -1226,6 +1235,7 @@ objc_library(
     ":3D-Secure_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -1356,6 +1366,7 @@ objc_library(
     ":PayPalOneTouch_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-ObjC",
     "-lc++",
     "-Wall -Werror -Wextra"
@@ -1486,6 +1497,7 @@ objc_library(
     ":PayPalDataCollector_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
@@ -1612,6 +1624,7 @@ objc_library(
     ":PayPalUtils_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -112,7 +112,9 @@ objc_library(
     ":without-IDFA",
     ":Branch_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -227,7 +229,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -341,7 +345,9 @@ objc_library(
   deps = [
     ":without-IDFA_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -287,6 +287,7 @@ objc_library(
     ":Calabash_includes"
   ],
   copts = [
+    "-fobjc-weak",
     ""Vendor/Calabash/calabash.framework/calabash"",
     "-ObjC",
     "-force_load"

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -121,7 +121,9 @@ objc_library(
     ":CardIO_VendoredLibraries",
     ":CardIO_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -115,7 +115,9 @@ objc_library(
     ":Extensions",
     ":CocoaLumberjack_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -221,7 +223,9 @@ objc_library(
   deps = [
     ":Default_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -321,7 +325,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -427,7 +433,9 @@ objc_library(
     ":Default",
     ":Extensions_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -603,7 +611,9 @@ objc_library(
   ) + [
     ":CLI_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -698,7 +708,9 @@ objc_library(
     ":Default",
     ":Swift_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
   deps = [
     ":ColorCube_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -112,6 +112,7 @@ objc_library(
     ":EarlGrey_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -379,7 +379,9 @@ objc_library(
     ":FBAllocationTracker_cxx",
     ":FBAllocationTracker_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -279,6 +279,7 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
@@ -785,6 +786,7 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
@@ -1797,6 +1799,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -1122,7 +1122,9 @@ objc_library(
   ) + [
     ":FBSDKCoreKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -129,7 +129,9 @@ objc_library(
     ":Login",
     ":FBSDKLoginKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -282,7 +284,9 @@ objc_library(
     "//Vendor/FBSDKCoreKit:FBSDKCoreKit",
     ":Login_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -127,6 +127,7 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -112,7 +112,9 @@ objc_library(
   deps = [
     ":FBSDKMessengerShareKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -295,6 +295,7 @@ objc_library(
     ":FBSDKShareKit_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -116,7 +116,9 @@ objc_library(
   deps = [
     ":FLAnimatedImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -124,7 +124,9 @@ objc_library(
   deps = [
     ":FLEX_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -112,7 +112,9 @@ objc_library(
     ":standard",
     ":FMDB_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -219,7 +221,9 @@ objc_library(
   deps = [
     ":standard_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -325,7 +329,9 @@ objc_library(
     ":standard",
     ":FTS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -415,6 +421,7 @@ objc_library(
     ":standalone_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
@@ -523,6 +530,7 @@ objc_library(
     ":standalone_default_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
@@ -637,6 +645,7 @@ objc_library(
     ":standalone_FTS_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
@@ -747,6 +756,7 @@ objc_library(
     ":SQLCipher_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DHAVE_USLEEP=1",
     "-DSQLITE_HAS_CODEC"
   ] + select(

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -123,7 +123,9 @@ objc_library(
     "//Vendor/ZFDragableModalTransition:ZFDragableModalTransition",
     ":FolioReaderKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -112,7 +112,9 @@ objc_library(
     ":GoogleAppIndexing_VendoredFrameworks",
     ":GoogleAppIndexing_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -104,7 +104,9 @@ objc_library(
     ":GoogleAppUtilities_VendoredFrameworks",
     ":GoogleAppUtilities_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
     ":GoogleAuthUtilities_VendoredFrameworks",
     ":GoogleAuthUtilities_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -107,7 +107,9 @@ objc_library(
     ":GoogleNetworkingUtilities_VendoredFrameworks",
     ":GoogleNetworkingUtilities_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -116,7 +116,9 @@ objc_library(
     ":GoogleSignIn_VendoredFrameworks",
     ":GoogleSignIn_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -101,7 +101,9 @@ objc_library(
     ":GoogleSymbolUtilities_VendoredFrameworks",
     ":GoogleSymbolUtilities_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -111,7 +111,9 @@ objc_library(
     ":GoogleUtilities_VendoredFrameworks",
     ":GoogleUtilities_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -113,7 +113,9 @@ objc_library(
   deps = [
     ":IBActionSheet_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -246,7 +246,9 @@ objc_library(
     ":IGListKit_cxx",
     ":IGListKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -564,7 +566,9 @@ objc_library(
     ":Diffing_cxx",
     ":Diffing_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -970,7 +974,9 @@ objc_library(
     ":Diffing",
     ":Default_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
   deps = [
     ":KVOController_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -127,7 +127,9 @@ objc_library(
     ":KakaoS2_VendoredFrameworks",
     ":KakaoOpenSDK_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -221,7 +223,9 @@ objc_library(
     ":KakaoOpenSDK_VendoredFrameworks",
     ":KakaoOpenSDK_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -330,7 +334,9 @@ objc_library(
     ":KakaoNavi_VendoredFrameworks",
     ":KakaoNavi_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -439,7 +445,9 @@ objc_library(
     ":KakaoLink_VendoredFrameworks",
     ":KakaoLink_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -548,7 +556,9 @@ objc_library(
     ":KakaoS2_VendoredFrameworks",
     ":KakaoS2_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -126,7 +126,9 @@ objc_library(
   deps = [
     ":Masonry_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -186,7 +186,9 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_includes",
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -301,7 +303,9 @@ objc_library(
     ":Default_includes",
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -393,7 +397,9 @@ objc_library(
     ":Subspec_includes",
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -152,7 +152,9 @@ objc_library(
   deps = [
     ":OnePasswordExtension_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -125,7 +125,9 @@ objc_library(
     ":Core",
     ":PINCache_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -244,7 +246,9 @@ objc_library(
     "//Vendor/PINOperation:PINOperation",
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -360,6 +364,7 @@ objc_library(
     ":Arc-exception-safe_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -229,7 +229,9 @@ objc_library(
     ":PINOperation_cxx",
     ":PINOperation_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -117,7 +117,9 @@ objc_library(
     ":PINCache",
     ":PINRemoteImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -244,7 +246,9 @@ objc_library(
     "//Vendor/PINOperation:PINOperation",
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -344,7 +348,9 @@ objc_library(
     ":Core",
     ":iOS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -443,7 +449,9 @@ objc_library(
     ":Core",
     ":OSX_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -538,7 +546,9 @@ objc_library(
     ":iOS",
     ":tvOS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -646,7 +656,9 @@ objc_library(
     ":Core",
     ":FLAnimatedImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -746,6 +758,7 @@ objc_library(
     ":WebP_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DPIN_WEBP=1"
   ] + select(
     {
@@ -857,7 +870,9 @@ objc_library(
     ":Core",
     ":PINCache_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
   deps = [
     ":PaymentKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -114,7 +114,9 @@ objc_library(
   deps = [
     ":RadarKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -253,7 +253,9 @@ objc_library(
     ":React_cxx",
     ":React_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2756,7 +2758,9 @@ objc_library(
     ":Core_cxx",
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -2988,6 +2992,7 @@ objc_library(
     ":CxxBridge_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
@@ -3272,7 +3277,9 @@ objc_library(
     ":RCTWebSocket",
     ":DevSupport_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -3585,6 +3592,7 @@ objc_library(
     ":RCTFabric_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
@@ -3694,7 +3702,9 @@ objc_library(
     ":Core",
     ":tvOS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -5917,7 +5927,9 @@ objc_library(
     ":Core",
     ":ART_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6023,7 +6035,9 @@ objc_library(
     ":Core",
     ":RCTActionSheet_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6137,7 +6151,9 @@ objc_library(
     ":Core",
     ":RCTAnimation_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6411,7 +6427,9 @@ objc_library(
     ":RCTBlob_cxx",
     ":RCTBlob_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6521,7 +6539,9 @@ objc_library(
     ":RCTImage",
     ":RCTCameraRoll_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6627,7 +6647,9 @@ objc_library(
     ":Core",
     ":RCTGeolocation_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6740,7 +6762,9 @@ objc_library(
     ":RCTNetwork",
     ":RCTImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -6968,7 +6992,9 @@ objc_library(
     ":RCTNetwork_cxx",
     ":RCTNetwork_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7074,7 +7100,9 @@ objc_library(
     ":Core",
     ":RCTPushNotification_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7180,7 +7208,9 @@ objc_library(
     ":Core",
     ":RCTSettings_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7286,7 +7316,9 @@ objc_library(
     ":Core",
     ":RCTText_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7392,7 +7424,9 @@ objc_library(
     ":Core",
     ":RCTVibration_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7532,7 +7566,9 @@ objc_library(
     ":fishhook",
     ":RCTWebSocket_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7659,7 +7695,9 @@ objc_library(
   deps = [
     ":fishhook_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7765,7 +7803,9 @@ objc_library(
     ":Core",
     ":RCTLinkingIOS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7874,7 +7914,9 @@ objc_library(
     ":Core",
     ":RCTTest_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -7973,7 +8015,9 @@ objc_library(
     ":CxxBridge",
     ":_ignore_me_subspec_for_linting__includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -149,7 +149,9 @@ objc_library(
     ":Core",
     ":React_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -335,7 +337,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -441,7 +445,9 @@ objc_library(
     ":Core",
     ":ART_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -547,7 +553,9 @@ objc_library(
     ":Core",
     ":RCTActionSheet_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -653,7 +661,9 @@ objc_library(
     ":Core",
     ":RCTAdSupport_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -759,7 +769,9 @@ objc_library(
     ":Core",
     ":RCTGeolocation_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -865,7 +877,9 @@ objc_library(
     ":Core",
     ":RCTImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -971,7 +985,9 @@ objc_library(
     ":Core",
     ":RCTNetwork_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1077,7 +1093,9 @@ objc_library(
     ":Core",
     ":RCTPushNotification_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1183,7 +1201,9 @@ objc_library(
     ":Core",
     ":RCTSettings_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1289,7 +1309,9 @@ objc_library(
     ":Core",
     ":RCTText_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1395,7 +1417,9 @@ objc_library(
     ":Core",
     ":RCTVibration_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1501,7 +1525,9 @@ objc_library(
     ":Core",
     ":RCTWebSocket_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -1607,7 +1633,9 @@ objc_library(
     ":Core",
     ":RCTLinkingIOS_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -275,7 +275,9 @@ objc_library(
     ":SFHFKeychainUtils_cxx",
     ":SFHFKeychainUtils_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
   deps = [
     ":SPUserResizableView+Pion_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -103,7 +103,9 @@ objc_library(
   deps = [
     ":SevenSwitch_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -110,7 +110,9 @@ objc_library(
   deps = [
     ":SlackTextViewController_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -111,7 +111,9 @@ objc_library(
   deps = [
     ":Smartling_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -120,7 +120,9 @@ objc_library(
   deps = [
     ":Stripe_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -114,7 +114,9 @@ objc_library(
     ":Core",
     ":TestArcPatternsWithExcludes_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -503,7 +505,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -129,7 +129,9 @@ objc_library(
     ":Photos",
     ":Texture_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -400,6 +402,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-fno-exceptions -fno-objc-arc-exceptions"
   ] + select(
     {
@@ -503,7 +506,9 @@ objc_library(
     ":Core",
     ":PINRemoteImage_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -606,7 +611,9 @@ objc_library(
     ":Core",
     ":IGListKit_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -709,6 +716,7 @@ objc_library(
     ":Yoga_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DYOGA=1"
   ] + select(
     {
@@ -814,6 +822,7 @@ objc_library(
     ":MapKit_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DAS_USE_MAPKIT=1"
   ] + select(
     {
@@ -917,6 +926,7 @@ objc_library(
     ":Photos_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DAS_USE_PHOTOS=1"
   ] + select(
     {
@@ -1020,6 +1030,7 @@ objc_library(
     ":AssetsLibrary_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DAS_USE_ASSETS_LIBRARY=1"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -244,7 +244,9 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_cxx",
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -115,7 +115,9 @@ objc_library(
     ":Weixin_VendoredLibraries",
     ":Weixin_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -129,6 +129,7 @@ objc_library(
     ":ZipArchive_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-Dunix"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -105,7 +105,9 @@ objc_library(
   deps = [
     ":boost-for-react-native_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -115,6 +115,7 @@ objc_library(
     ":googleapis_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
@@ -225,6 +226,7 @@ objc_library(
     ":Messages_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
@@ -337,6 +339,7 @@ objc_library(
     ":Services_includes"
   ],
   copts = [
+    "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -114,7 +114,9 @@ objc_library(
     ":SwiftSupport",
     ":iOSSnapshotTestCase_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -242,7 +244,9 @@ objc_library(
   deps = [
     ":Core_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"
@@ -343,7 +347,9 @@ objc_library(
     ":Core",
     ":SwiftSupport_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -111,7 +111,9 @@ objc_library(
   deps = [
     ":iRate_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -114,7 +114,9 @@ objc_library(
   deps = [
     ":kingpin_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -320,7 +320,9 @@ objc_library(
     ":pop_cxx",
     ":pop_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -560,7 +560,9 @@ objc_library(
     ":youtube-ios-player-helper_cxx",
     ":youtube-ios-player-helper_includes"
   ],
-  copts = select(
+  copts = [
+    "-fobjc-weak"
+  ] + select(
     {
       "//conditions:default": [
         "-DPOD_CONFIGURATION_RELEASE=0"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-test: pod_test build archive init-sandbox
 	cd Examples/ArcSplitting && make all
 	cd Examples/React && make all
 	cd Examples/SwiftSubspec && make all
-	# cd Examples/FBSDK && make all
+	cd Examples/FBSDK && make all
 
 build-example: EXAMPLE=Examples/PINCache.podspec.json
 build-example: CONFIG = debug

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -388,11 +388,12 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         let extraDepNames = extraDeps.map { bazelLabel(fromString: ":\($0)") }
         deps = AttrSet(basic: extraDepNames) <> mpPodSpecDeps
 
+        // Adds minimal, non specified Xcode defaults
         let extraCopts: AttrSet<[String]>
         if case .cpp = sourceType {
             extraCopts = AttrSet(basic: ["-std=c++14"])
         } else {
-            extraCopts = AttrSet.empty
+            extraCopts = AttrSet(basic: ["-fobjc-weak"])
         }
         copts = extraCopts <> AttrSet(basic: xcconfigCopts.sorted(by: <)) <>
         fallbackSpec.attr(\.compilerFlags)


### PR DESCRIPTION
This adds the default `fobjc-weak` which is now required by a few
pods. Also, it adds FBSDKCoreKit as a build test to the CI