### PR TITLE
Build swift library with umbrella header import

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -5,7 +5,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -5,7 +5,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode
@@ -68,7 +69,8 @@ swift_library(
     "-import-underlying-module"
   ],
   swiftc_inputs = [
-    "ObjcParentWithSwiftSubspecs_module_map"
+    ":ObjcParentWithSwiftSubspecs_module_map",
+    ":ObjcParentWithSwiftSubspecs_umbrella_header"
   ],
   generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
   features = [
@@ -211,24 +213,30 @@ acknowledged_target(
   value = "//Vendor/ObjcParentWithSwiftSubspecs/pod_support_buildable:acknowledgement_fragment"
 )
 gen_module_map(
+  name = "ObjcParentWithSwiftSubspecs_module_map",
+  module_name = "ObjcParentWithSwiftSubspecs",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_public_hdrs"
+  ],
+  module_map_name = "ObjcParentWithSwiftSubspecs.modulemap",
+  umbrella_hdr = "ObjcParentWithSwiftSubspecs_umbrella_header",
+  visibility = [
+    "//visibility:public"
+  ]
+)
+umbrella_header(
+  name = "ObjcParentWithSwiftSubspecs_umbrella_header",
+  hdrs = [
+    "ObjcParentWithSwiftSubspecs_public_hdrs"
+  ]
+)
+gen_module_map(
   name = "ObjcParentWithSwiftSubspecs_extended_module_map",
   module_name = "ObjcParentWithSwiftSubspecs",
   hdrs = [
     "ObjcParentWithSwiftSubspecs_public_hdrs"
   ],
-  swift_header = "../ObjcParentWithSwiftSubspecs-Swift.h",
-  visibility = [
-    "//visibility:public"
-  ]
-)
-gen_module_map(
-  name = "ObjcParentWithSwiftSubspecs_module_map",
-  module_name = "ObjcParentWithSwiftSubspecs",
-  hdrs = [
-    "ObjcParentWithSwiftSubspecs_extended_module_map",
-    "ObjcParentWithSwiftSubspecs_public_hdrs"
-  ],
-  module_map_name = "ObjcParentWithSwiftSubspecs.modulemap",
+  swift_hdr = "../ObjcParentWithSwiftSubspecs-Swift.h",
   visibility = [
     "//visibility:public"
   ]

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -3,7 +3,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -4,7 +4,8 @@ load(
   "acknowledged_target",
   "gen_module_map",
   "gen_includes",
-  "headermap"
+  "headermap",
+  "umbrella_header"
 )
 # Add a config setting release for compilation mode
 # Assume that people are using `opt` for release mode

--- a/Sources/PodToBUILD/ModuleMap.swift
+++ b/Sources/PodToBUILD/ModuleMap.swift
@@ -4,14 +4,17 @@ public struct ModuleMap: BazelTarget {
     public let headers: [String]
     public let swiftHeader: String?
     public let moduleMapName: String?
+    public let umbrellaHeader: String?
 
-    public init(name: String, moduleName: String, headers:
-                [String], swiftHeader: String? = nil, moduleMapName: String? = nil) {
+    public init(name: String, moduleName: String, headers: [String],
+        swiftHeader: String? = nil, moduleMapName: String? = nil,
+        umbrellaHeader: String? = nil) {
         self.name = name
         self.moduleName = moduleName
         self.headers = headers
         self.swiftHeader = swiftHeader
         self.moduleMapName = moduleMapName
+        self.umbrellaHeader = umbrellaHeader
     }
 
     public var acknowledged: Bool {
@@ -28,7 +31,10 @@ public struct ModuleMap: BazelTarget {
             args.append(.named(name: "module_map_name", value: moduleMapName.toSkylark()))
         }
         if let swiftHeader = self.swiftHeader {
-            args.append(.named(name: "swift_header", value: swiftHeader.toSkylark()))
+            args.append(.named(name: "swift_hdr", value: swiftHeader.toSkylark()))
+        }
+        if let umbrellaHeader = self.umbrellaHeader {
+            args.append(.named(name: "umbrella_hdr", value: umbrellaHeader.toSkylark()))
         }
         args.append(.named(name: "visibility", value: ["//visibility:public"].toSkylark()))
         return SkylarkNode.functionCall(

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -186,8 +186,15 @@ public struct SwiftLibrary: BazelTarget {
                 "-fmodule-map-file=$(execpath " + moduleMap.name + ")",
                 "-import-underlying-module",
             ])
+            swiftcInputs = swiftcInputs <> AttrSet(basic: [
+                ":" + moduleMap.name,
+            ])
 
-            swiftcInputs = swiftcInputs <> AttrSet(basic: [moduleMap.name])
+            if let umbrellaHeader = moduleMap.umbrellaHeader {
+                swiftcInputs = swiftcInputs <> AttrSet(basic: [
+                    ":" + umbrellaHeader
+                ])
+            }
         }
 
         let deps = self.deps.map {

--- a/Sources/PodToBUILD/UmbrellaHeader.swift
+++ b/Sources/PodToBUILD/UmbrellaHeader.swift
@@ -1,0 +1,32 @@
+//
+//  UmbrellaHeader.swift
+//  PodToBUILD
+//
+//  Created by Jerry Marino on 7/31/20.
+//  Copyright © 2020 Pinterest Inc. All rights reserved.
+//
+public struct UmbrellaHeader: BazelTarget {
+    public let name: String // A unique name for this rule.
+    public let headers: [String]
+    
+    public init(name: String, headers: [String]) {
+        self.name = name
+        self.headers = headers
+    }
+
+    public var acknowledged: Bool {
+        return false
+    }
+
+    public func toSkylark() -> SkylarkNode {
+        var args: [SkylarkFunctionArgument] = [
+            .named(name: "name", value: name.toSkylark()),
+            .named(name: "hdrs", value: headers.toSkylark()),
+        ]
+        return SkylarkNode.functionCall(
+                name: "umbrella_header",
+                arguments: args
+         )
+    }
+}
+


### PR DESCRIPTION
This reproduces identically what CocoaPods + Xcode is doing. There's a
few hidden side effects of not building pods as mixed modules which is
apparent in a few pods. The main issue I've found so far, is implicit
importing of umbrella header contents that doesn't happen.

This is not 100% the most effective approach but reproduces identically
what CocoaPods + Xcode is doing. In the future, we should consider
reducing module merging, but it will need more testing to deviate
from the default behavior. For now, this atleast gets it working.