### PR TITLE
    Add copts for SwiftLibrary

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -126,7 +126,6 @@ objc_library(
     ":Adjust_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Adjust/",
     "-fobjc-weak"
   ] + select(
     {
@@ -253,7 +252,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Adjust/",
     "-fobjc-weak"
   ] + select(
     {
@@ -377,7 +375,6 @@ objc_library(
     ":Sociomantic_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Adjust/",
     "-fobjc-weak"
   ] + select(
     {
@@ -501,7 +498,6 @@ objc_library(
     ":Criteo_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Adjust/",
     "-fobjc-weak"
   ] + select(
     {
@@ -625,7 +621,6 @@ objc_library(
     ":Trademob_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Adjust/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -126,10 +126,7 @@ objc_library(
     ":Adjust_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Adjust/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -256,10 +253,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Adjust/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -383,10 +377,7 @@ objc_library(
     ":Sociomantic_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Adjust/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -510,10 +501,7 @@ objc_library(
     ":Criteo_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Adjust/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -637,10 +625,7 @@ objc_library(
     ":Trademob_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Adjust/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -126,11 +126,16 @@ objc_library(
     ":Adjust_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Adjust/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -251,11 +256,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Adjust/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -373,11 +383,16 @@ objc_library(
     ":Sociomantic_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Adjust/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -495,11 +510,16 @@ objc_library(
     ":Criteo_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Adjust/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -617,11 +637,16 @@ objc_library(
     ":Trademob_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Adjust/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -271,10 +271,7 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1533,10 +1530,7 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -2949,10 +2943,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -149,7 +149,6 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14"
   ] + select(
     {
@@ -271,7 +270,6 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1530,7 +1528,6 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak"
   ] + select(
     {
@@ -2943,7 +2940,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -149,11 +149,13 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -269,11 +271,16 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1526,11 +1533,16 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -2937,11 +2949,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -114,10 +114,7 @@ objc_library(
     ":Bolts_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Bolts/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -243,10 +240,7 @@ objc_library(
     ":Tasks_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Bolts/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -404,10 +398,7 @@ objc_library(
     ":AppLinks_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Bolts/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -114,7 +114,6 @@ objc_library(
     ":Bolts_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Bolts/",
     "-fobjc-weak"
   ] + select(
     {
@@ -240,7 +239,6 @@ objc_library(
     ":Tasks_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Bolts/",
     "-fobjc-weak"
   ] + select(
     {
@@ -398,7 +396,6 @@ objc_library(
     ":AppLinks_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Bolts/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -114,11 +114,16 @@ objc_library(
     ":Bolts_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Bolts/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -238,11 +243,16 @@ objc_library(
     ":Tasks_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Bolts/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -394,11 +404,16 @@ objc_library(
     ":AppLinks_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Bolts/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -133,12 +133,17 @@ objc_library(
     ":Braintree_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -256,12 +261,17 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -370,12 +380,17 @@ objc_library(
     ":Apple-Pay_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -486,12 +501,17 @@ objc_library(
     ":Card_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -598,12 +618,17 @@ objc_library(
     ":DataCollector_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -724,12 +749,17 @@ objc_library(
     ":PayPal_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -839,12 +869,17 @@ objc_library(
     ":Venmo_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -983,12 +1018,17 @@ objc_library(
     ":UI_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1105,12 +1145,17 @@ objc_library(
     ":UnionPay_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1236,12 +1281,17 @@ objc_library(
     ":3D-Secure_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1367,6 +1417,10 @@ objc_library(
     ":PayPalOneTouch_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-ObjC",
     "-lc++",
@@ -1374,7 +1428,8 @@ objc_library(
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1498,12 +1553,17 @@ objc_library(
     ":PayPalDataCollector_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1625,12 +1685,17 @@ objc_library(
     ":PayPalUtils_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Braintree/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -133,10 +133,7 @@ objc_library(
     ":Braintree_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -261,10 +258,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -380,10 +374,7 @@ objc_library(
     ":Apple-Pay_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -501,10 +492,7 @@ objc_library(
     ":Card_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -618,10 +606,7 @@ objc_library(
     ":DataCollector_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -749,10 +734,7 @@ objc_library(
     ":PayPal_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -869,10 +851,7 @@ objc_library(
     ":Venmo_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1018,10 +997,7 @@ objc_library(
     ":UI_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1145,10 +1121,7 @@ objc_library(
     ":UnionPay_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1281,10 +1254,7 @@ objc_library(
     ":3D-Secure_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1417,10 +1387,7 @@ objc_library(
     ":PayPalOneTouch_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-ObjC",
     "-lc++",
@@ -1553,10 +1520,7 @@ objc_library(
     ":PayPalDataCollector_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1685,10 +1649,7 @@ objc_library(
     ":PayPalUtils_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Braintree/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -133,7 +133,6 @@ objc_library(
     ":Braintree_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -258,7 +257,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -374,7 +372,6 @@ objc_library(
     ":Apple-Pay_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -492,7 +489,6 @@ objc_library(
     ":Card_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -606,7 +602,6 @@ objc_library(
     ":DataCollector_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -734,7 +729,6 @@ objc_library(
     ":PayPal_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -851,7 +845,6 @@ objc_library(
     ":Venmo_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -997,7 +990,6 @@ objc_library(
     ":UI_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1121,7 +1113,6 @@ objc_library(
     ":UnionPay_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1254,7 +1245,6 @@ objc_library(
     ":3D-Secure_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1387,7 +1377,6 @@ objc_library(
     ":PayPalOneTouch_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-ObjC",
     "-lc++",
@@ -1520,7 +1509,6 @@ objc_library(
     ":PayPalDataCollector_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(
@@ -1649,7 +1637,6 @@ objc_library(
     ":PayPalUtils_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Braintree/",
     "-fobjc-weak",
     "-Wall -Werror -Wextra"
   ] + select(

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -114,11 +114,16 @@ objc_library(
     ":Branch_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Branch/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -231,11 +236,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Branch/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -347,11 +357,16 @@ objc_library(
     ":without-IDFA_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Branch/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -114,10 +114,7 @@ objc_library(
     ":Branch_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Branch/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -236,10 +233,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Branch/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -357,10 +351,7 @@ objc_library(
     ":without-IDFA_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Branch/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -114,7 +114,6 @@ objc_library(
     ":Branch_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Branch/",
     "-fobjc-weak"
   ] + select(
     {
@@ -233,7 +232,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Branch/",
     "-fobjc-weak"
   ] + select(
     {
@@ -351,7 +349,6 @@ objc_library(
     ":without-IDFA_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Branch/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -170,7 +170,6 @@ objc_library(
     ":Calabash_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Calabash/",
     "-std=c++14",
     "-ObjC",
     "-force_load",
@@ -290,7 +289,6 @@ objc_library(
     ":Calabash_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Calabash/",
     "-fobjc-weak",
     "-ObjC",
     "-force_load",

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -290,13 +290,8 @@ objc_library(
     ":Calabash_includes"
   ],
   copts = [
-<<<<<<< HEAD
-    "-fobjc-weak",
-    ""Vendor/Calabash/calabash.framework/calabash"",
-=======
     "-I$(GENDIR)/Vendor/Calabash/",
     "-fobjc-weak",
->>>>>>> Add copts for SwiftLibrary
     "-ObjC",
     "-force_load",
     ""Vendor/Calabash/calabash.framework/calabash""

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -170,14 +170,16 @@ objc_library(
     ":Calabash_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/Calabash/",
     "-std=c++14",
-    ""Vendor/Calabash/calabash.framework/calabash"",
     "-ObjC",
-    "-force_load"
+    "-force_load",
+    ""Vendor/Calabash/calabash.framework/calabash""
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -288,14 +290,21 @@ objc_library(
     ":Calabash_includes"
   ],
   copts = [
+<<<<<<< HEAD
     "-fobjc-weak",
     ""Vendor/Calabash/calabash.framework/calabash"",
+=======
+    "-I$(GENDIR)/Vendor/Calabash/",
+    "-fobjc-weak",
+>>>>>>> Add copts for SwiftLibrary
     "-ObjC",
-    "-force_load"
+    "-force_load",
+    ""Vendor/Calabash/calabash.framework/calabash""
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -123,11 +123,16 @@ objc_library(
     ":CardIO_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CardIO/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -123,7 +123,6 @@ objc_library(
     ":CardIO_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CardIO/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -123,10 +123,7 @@ objc_library(
     ":CardIO_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CardIO/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -117,7 +117,6 @@ objc_library(
     ":CocoaLumberjack_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {
@@ -227,7 +226,6 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {
@@ -331,7 +329,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {
@@ -441,7 +438,6 @@ objc_library(
     ":Extensions_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {
@@ -621,7 +617,6 @@ objc_library(
     ":CLI_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {
@@ -720,7 +715,6 @@ objc_library(
     ":Swift_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -117,10 +117,7 @@ objc_library(
     ":CocoaLumberjack_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -230,10 +227,7 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -337,10 +331,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -450,10 +441,7 @@ objc_library(
     ":Extensions_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -633,10 +621,7 @@ objc_library(
     ":CLI_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -735,10 +720,7 @@ objc_library(
     ":Swift_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/CocoaLumberjack/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -117,11 +117,16 @@ objc_library(
     ":CocoaLumberjack_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -225,11 +230,16 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -327,11 +337,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -435,11 +450,16 @@ objc_library(
     ":Extensions_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -613,11 +633,16 @@ objc_library(
     ":CLI_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -710,11 +735,16 @@ objc_library(
     ":Swift_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/CocoaLumberjack/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":ColorCube_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/ColorCube/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":ColorCube_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/ColorCube/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":ColorCube_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/ColorCube/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -113,10 +113,7 @@ objc_library(
     ":EarlGrey_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/EarlGrey/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -113,12 +113,17 @@ objc_library(
     ":EarlGrey_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/EarlGrey/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -113,7 +113,6 @@ objc_library(
     ":EarlGrey_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/EarlGrey/",
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -213,7 +213,6 @@ objc_library(
     ":FBAllocationTracker_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBAllocationTracker/",
     "-std=c++14"
   ] + select(
     {
@@ -383,7 +382,6 @@ objc_library(
     ":FBAllocationTracker_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBAllocationTracker/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -213,11 +213,13 @@ objc_library(
     ":FBAllocationTracker_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/FBAllocationTracker/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -381,11 +383,16 @@ objc_library(
     ":FBAllocationTracker_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBAllocationTracker/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -383,10 +383,7 @@ objc_library(
     ":FBAllocationTracker_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBAllocationTracker/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -282,10 +282,7 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -794,10 +791,7 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -1814,10 +1808,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -154,7 +154,6 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -282,7 +281,6 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -791,7 +789,6 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -1337,7 +1334,6 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
@@ -1808,7 +1804,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -154,13 +154,15 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -280,13 +282,18 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -787,13 +794,18 @@ objc_library(
     ":Basics_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1331,13 +1343,15 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1800,13 +1814,18 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFBSDKCOCOAPODS=1",
     "-DFBSDKCOCOAPODS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -291,11 +291,13 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1124,11 +1126,16 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -1126,10 +1126,7 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -291,7 +291,6 @@ objc_library(
     ":FBSDKCoreKit_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-std=c++14"
   ] + select(
     {
@@ -1126,7 +1125,6 @@ objc_library(
     ":FBSDKCoreKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKCoreKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -131,7 +131,6 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
     "-fobjc-weak"
   ] + select(
     {
@@ -288,7 +287,6 @@ objc_library(
     ":Login_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -131,11 +131,16 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -286,11 +291,16 @@ objc_library(
     ":Login_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -131,10 +131,7 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -291,10 +288,7 @@ objc_library(
     ":Login_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -128,7 +128,6 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -128,10 +128,7 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -128,12 +128,17 @@ objc_library(
     ":FBSDKLoginKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKLoginKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -114,11 +114,16 @@ objc_library(
     ":FBSDKMessengerShareKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKMessengerShareKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -114,7 +114,6 @@ objc_library(
     ":FBSDKMessengerShareKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKMessengerShareKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -114,10 +114,7 @@ objc_library(
     ":FBSDKMessengerShareKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKMessengerShareKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -296,10 +296,7 @@ objc_library(
     ":FBSDKShareKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FBSDKShareKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -296,12 +296,17 @@ objc_library(
     ":FBSDKShareKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FBSDKShareKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -296,7 +296,6 @@ objc_library(
     ":FBSDKShareKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FBSDKShareKit/",
     "-fobjc-weak",
     "-Wno-non-modular-include-in-framework-module -Wno-error=noon-modular-include-in-framework-module"
   ] + select(

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -118,11 +118,16 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FLAnimatedImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -118,10 +118,7 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FLAnimatedImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -118,7 +118,6 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FLAnimatedImage/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -126,7 +126,6 @@ objc_library(
     ":FLEX_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FLEX/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -126,11 +126,16 @@ objc_library(
     ":FLEX_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FLEX/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -126,10 +126,7 @@ objc_library(
     ":FLEX_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FLEX/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -114,10 +114,7 @@ objc_library(
     ":FMDB_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -228,10 +225,7 @@ objc_library(
     ":standard_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -341,10 +335,7 @@ objc_library(
     ":FTS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -437,10 +428,7 @@ objc_library(
     ":standalone_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -551,10 +539,7 @@ objc_library(
     ":standalone_default_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -671,10 +656,7 @@ objc_library(
     ":standalone_FTS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -787,16 +769,10 @@ objc_library(
     ":SQLCipher_includes"
   ],
   copts = [
-<<<<<<< HEAD
-    "-fobjc-weak",
-    "-DHAVE_USLEEP=1",
-    "-DSQLITE_HAS_CODEC"
-=======
     "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak",
     "-DSQLITE_HAS_CODEC",
     "-DHAVE_USLEEP=1"
->>>>>>> Add copts for SwiftLibrary
   ] + select(
     {
       "//conditions:default": [

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -114,11 +114,16 @@ objc_library(
     ":FMDB_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -223,11 +228,16 @@ objc_library(
     ":standard_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -331,11 +341,16 @@ objc_library(
     ":FTS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -422,12 +437,17 @@ objc_library(
     ":standalone_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -531,12 +551,17 @@ objc_library(
     ":standalone_default_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -646,12 +671,17 @@ objc_library(
     ":standalone_FTS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -757,13 +787,21 @@ objc_library(
     ":SQLCipher_includes"
   ],
   copts = [
+<<<<<<< HEAD
     "-fobjc-weak",
     "-DHAVE_USLEEP=1",
     "-DSQLITE_HAS_CODEC"
+=======
+    "-I$(GENDIR)/Vendor/FMDB/",
+    "-fobjc-weak",
+    "-DSQLITE_HAS_CODEC",
+    "-DHAVE_USLEEP=1"
+>>>>>>> Add copts for SwiftLibrary
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -114,7 +114,6 @@ objc_library(
     ":FMDB_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak"
   ] + select(
     {
@@ -225,7 +224,6 @@ objc_library(
     ":standard_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak"
   ] + select(
     {
@@ -335,7 +333,6 @@ objc_library(
     ":FTS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak"
   ] + select(
     {
@@ -428,7 +425,6 @@ objc_library(
     ":standalone_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -539,7 +535,6 @@ objc_library(
     ":standalone_default_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -656,7 +651,6 @@ objc_library(
     ":standalone_FTS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak",
     "-DFMDB_SQLITE_STANDALONE"
   ] + select(
@@ -769,7 +763,6 @@ objc_library(
     ":SQLCipher_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FMDB/",
     "-fobjc-weak",
     "-DSQLITE_HAS_CODEC",
     "-DHAVE_USLEEP=1"

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -125,7 +125,6 @@ objc_library(
     ":FolioReaderKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/FolioReaderKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -125,10 +125,7 @@ objc_library(
     ":FolioReaderKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/FolioReaderKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -125,11 +125,16 @@ objc_library(
     ":FolioReaderKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/FolioReaderKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -132,7 +132,6 @@ objc_library(
     ":Folly_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Folly/",
     "-std=c++14",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -132,13 +132,15 @@ objc_library(
     ":Folly_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/Folly/",
     "-std=c++14",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -114,7 +114,6 @@ objc_library(
     ":GoogleAppIndexing_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleAppIndexing/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -114,11 +114,16 @@ objc_library(
     ":GoogleAppIndexing_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleAppIndexing/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -114,10 +114,7 @@ objc_library(
     ":GoogleAppIndexing_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleAppIndexing/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -106,7 +106,6 @@ objc_library(
     ":GoogleAppUtilities_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleAppUtilities/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -106,11 +106,16 @@ objc_library(
     ":GoogleAppUtilities_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleAppUtilities/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -106,10 +106,7 @@ objc_library(
     ":GoogleAppUtilities_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleAppUtilities/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":GoogleAuthUtilities_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleAuthUtilities/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":GoogleAuthUtilities_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleAuthUtilities/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":GoogleAuthUtilities_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleAuthUtilities/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -109,7 +109,6 @@ objc_library(
     ":GoogleNetworkingUtilities_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleNetworkingUtilities/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -109,11 +109,16 @@ objc_library(
     ":GoogleNetworkingUtilities_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleNetworkingUtilities/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -109,10 +109,7 @@ objc_library(
     ":GoogleNetworkingUtilities_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleNetworkingUtilities/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -118,10 +118,7 @@ objc_library(
     ":GoogleSignIn_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleSignIn/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -118,7 +118,6 @@ objc_library(
     ":GoogleSignIn_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleSignIn/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -118,11 +118,16 @@ objc_library(
     ":GoogleSignIn_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleSignIn/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -103,7 +103,6 @@ objc_library(
     ":GoogleSymbolUtilities_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleSymbolUtilities/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -103,10 +103,7 @@ objc_library(
     ":GoogleSymbolUtilities_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleSymbolUtilities/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -103,11 +103,16 @@ objc_library(
     ":GoogleSymbolUtilities_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleSymbolUtilities/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -113,11 +113,16 @@ objc_library(
     ":GoogleUtilities_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/GoogleUtilities/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -113,7 +113,6 @@ objc_library(
     ":GoogleUtilities_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/GoogleUtilities/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -113,10 +113,7 @@ objc_library(
     ":GoogleUtilities_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/GoogleUtilities/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -115,10 +115,7 @@ objc_library(
     ":IBActionSheet_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/IBActionSheet/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -115,7 +115,6 @@ objc_library(
     ":IBActionSheet_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IBActionSheet/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -115,11 +115,16 @@ objc_library(
     ":IBActionSheet_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/IBActionSheet/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -250,10 +250,7 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/IGListKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -577,10 +574,7 @@ objc_library(
     ":Diffing_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/IGListKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -992,10 +986,7 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/IGListKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -138,13 +138,15 @@ objc_library(
     ":IGListKit_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -248,11 +250,16 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/IGListKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -408,13 +415,15 @@ objc_library(
     ":Diffing_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -568,11 +577,16 @@ objc_library(
     ":Diffing_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/IGListKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -772,13 +786,15 @@ objc_library(
     ":Default_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -976,11 +992,16 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/IGListKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -138,7 +138,6 @@ objc_library(
     ":IGListKit_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
@@ -250,7 +249,6 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-fobjc-weak"
   ] + select(
     {
@@ -412,7 +410,6 @@ objc_library(
     ":Diffing_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
@@ -574,7 +571,6 @@ objc_library(
     ":Diffing_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-fobjc-weak"
   ] + select(
     {
@@ -780,7 +776,6 @@ objc_library(
     ":Default_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
@@ -986,7 +981,6 @@ objc_library(
     ":Default_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/IGListKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":KVOController_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KVOController/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":KVOController_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KVOController/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":KVOController_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KVOController/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -129,11 +129,16 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -225,11 +230,16 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -336,11 +346,16 @@ objc_library(
     ":KakaoNavi_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -447,11 +462,16 @@ objc_library(
     ":KakaoLink_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -558,11 +578,16 @@ objc_library(
     ":KakaoS2_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -129,7 +129,6 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
     "-fobjc-weak"
   ] + select(
     {
@@ -227,7 +226,6 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
     "-fobjc-weak"
   ] + select(
     {
@@ -340,7 +338,6 @@ objc_library(
     ":KakaoNavi_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
     "-fobjc-weak"
   ] + select(
     {
@@ -453,7 +450,6 @@ objc_library(
     ":KakaoLink_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
     "-fobjc-weak"
   ] + select(
     {
@@ -566,7 +562,6 @@ objc_library(
     ":KakaoS2_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -129,10 +129,7 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -230,10 +227,7 @@ objc_library(
     ":KakaoOpenSDK_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -346,10 +340,7 @@ objc_library(
     ":KakaoNavi_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -462,10 +453,7 @@ objc_library(
     ":KakaoLink_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -578,10 +566,7 @@ objc_library(
     ":KakaoS2_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/KakaoOpenSDK/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -128,7 +128,6 @@ objc_library(
     ":Masonry_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Masonry/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -128,11 +128,16 @@ objc_library(
     ":Masonry_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Masonry/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -128,10 +128,7 @@ objc_library(
     ":Masonry_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Masonry/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -57,7 +57,25 @@ swift_library(
   ),
   deps = [],
   data = [],
-  copts = [
+  copts = select(
+    {
+      "//conditions:default": [
+        "-enable-testing",
+        "-DDEBUG",
+        "-Xcc",
+        "-DPOD_CONFIGURATION_DEBUG=1",
+        "-Xcc",
+        "-DDEBUG=1"
+      ],
+      ":release": [
+        "-Xcc",
+        "-DPOD_CONFIGURATION_RELEASE=1"
+      ]
+    }
+  ) + [
+    "-DCOCOAPODS",
+    "-Xcc",
+    "-DCOCOAPODS=1",
     "-Xcc",
     "-I.",
     "-Xcc",
@@ -69,8 +87,12 @@ swift_library(
     "-import-underlying-module"
   ],
   swiftc_inputs = [
+<<<<<<< HEAD
     ":ObjcParentWithSwiftSubspecs_module_map",
     ":ObjcParentWithSwiftSubspecs_umbrella_header"
+=======
+    ":ObjcParentWithSwiftSubspecs_module_map"
+>>>>>>> Add copts for SwiftLibrary
   ],
   generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
   features = [
@@ -189,11 +211,16 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -312,11 +339,16 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -406,11 +438,16 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -87,12 +87,8 @@ swift_library(
     "-import-underlying-module"
   ],
   swiftc_inputs = [
-<<<<<<< HEAD
     ":ObjcParentWithSwiftSubspecs_module_map",
     ":ObjcParentWithSwiftSubspecs_umbrella_header"
-=======
-    ":ObjcParentWithSwiftSubspecs_module_map"
->>>>>>> Add copts for SwiftLibrary
   ],
   generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
   features = [
@@ -211,10 +207,7 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -339,10 +332,7 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -438,10 +428,7 @@ objc_library(
     ":ObjcParentWithSwiftSubspecs_extended_module_map"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/ObjcParentWithSwiftSubspecs/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -154,10 +154,7 @@ objc_library(
     ":OnePasswordExtension_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/OnePasswordExtension/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -154,11 +154,16 @@ objc_library(
     ":OnePasswordExtension_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/OnePasswordExtension/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -154,7 +154,6 @@ objc_library(
     ":OnePasswordExtension_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/OnePasswordExtension/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -127,11 +127,16 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINCache/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -248,11 +253,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINCache/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -365,12 +375,17 @@ objc_library(
     ":Arc-exception-safe_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINCache/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -127,7 +127,6 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINCache/",
     "-fobjc-weak"
   ] + select(
     {
@@ -250,7 +249,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINCache/",
     "-fobjc-weak"
   ] + select(
     {
@@ -369,7 +367,6 @@ objc_library(
     ":Arc-exception-safe_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINCache/",
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -127,10 +127,7 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINCache/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -253,10 +250,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINCache/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -375,10 +369,7 @@ objc_library(
     ":Arc-exception-safe_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINCache/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fobjc-arc-exceptions"
   ] + select(

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -129,7 +129,6 @@ objc_library(
     ":PINOperation_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINOperation/",
     "-std=c++14"
   ] + select(
     {
@@ -233,7 +232,6 @@ objc_library(
     ":PINOperation_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINOperation/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -233,10 +233,7 @@ objc_library(
     ":PINOperation_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINOperation/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -129,11 +129,13 @@ objc_library(
     ":PINOperation_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/PINOperation/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -231,11 +233,16 @@ objc_library(
     ":PINOperation_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINOperation/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -119,11 +119,16 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -248,11 +253,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -350,11 +360,16 @@ objc_library(
     ":iOS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -451,11 +466,16 @@ objc_library(
     ":OSX_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -548,11 +568,16 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -658,11 +683,16 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -759,12 +789,17 @@ objc_library(
     ":WebP_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DPIN_WEBP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -872,11 +907,16 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PINRemoteImage/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -119,10 +119,7 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -253,10 +250,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -360,10 +354,7 @@ objc_library(
     ":iOS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -466,10 +457,7 @@ objc_library(
     ":OSX_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -568,10 +556,7 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -683,10 +668,7 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -789,10 +771,7 @@ objc_library(
     ":WebP_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DPIN_WEBP=1"
   ] + select(
@@ -907,10 +886,7 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PINRemoteImage/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -119,7 +119,6 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -250,7 +249,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -354,7 +352,6 @@ objc_library(
     ":iOS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -457,7 +454,6 @@ objc_library(
     ":OSX_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -556,7 +552,6 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -668,7 +663,6 @@ objc_library(
     ":FLAnimatedImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {
@@ -771,7 +765,6 @@ objc_library(
     ":WebP_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak",
     "-DPIN_WEBP=1"
   ] + select(
@@ -886,7 +879,6 @@ objc_library(
     ":PINCache_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PINRemoteImage/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":PaymentKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/PaymentKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":PaymentKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/PaymentKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":PaymentKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/PaymentKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -116,11 +116,16 @@ objc_library(
     ":RadarKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/RadarKit/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -116,10 +116,7 @@ objc_library(
     ":RadarKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/RadarKit/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -116,7 +116,6 @@ objc_library(
     ":RadarKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/RadarKit/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -162,7 +162,6 @@ objc_library(
     ":React_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
@@ -257,7 +256,6 @@ objc_library(
     ":React_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1674,7 +1672,6 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
@@ -2766,7 +2763,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -2883,7 +2879,6 @@ objc_library(
     ":CxxBridge_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
@@ -3003,7 +2998,6 @@ objc_library(
     ":CxxBridge_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3152,7 +3146,6 @@ objc_library(
     ":DevSupport_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
@@ -3293,7 +3286,6 @@ objc_library(
     ":DevSupport_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -3456,7 +3448,6 @@ objc_library(
     ":RCTFabric_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3611,7 +3602,6 @@ objc_library(
     ":RCTFabric_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3724,7 +3714,6 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -3857,7 +3846,6 @@ objc_library(
     ":jschelpers_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3982,7 +3970,6 @@ objc_library(
     ":jsinspector_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
@@ -4106,7 +4093,6 @@ objc_library(
     ":PrivateDatabase_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
@@ -4253,7 +4239,6 @@ objc_library(
     ":cxxreact_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -4350,7 +4335,6 @@ objc_library(
     ":fabric_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
@@ -4486,7 +4470,6 @@ objc_library(
     ":fabric_activityindicator_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -4624,7 +4607,6 @@ objc_library(
     ":fabric_attributedstring_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -4762,7 +4744,6 @@ objc_library(
     ":fabric_core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -4900,7 +4881,6 @@ objc_library(
     ":fabric_debug_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5038,7 +5018,6 @@ objc_library(
     ":fabric_graphics_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5176,7 +5155,6 @@ objc_library(
     ":fabric_scrollview_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5314,7 +5292,6 @@ objc_library(
     ":fabric_text_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5453,7 +5430,6 @@ objc_library(
     ":fabric_textlayoutmanager_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5591,7 +5567,6 @@ objc_library(
     ":fabric_uimanager_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5731,7 +5706,6 @@ objc_library(
     ":fabric_view_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5870,7 +5844,6 @@ objc_library(
     ":RCTFabricSample_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -5983,7 +5956,6 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6093,7 +6065,6 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6211,7 +6182,6 @@ objc_library(
     ":RCTAnimation_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6349,7 +6319,6 @@ objc_library(
     ":RCTBlob_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
@@ -6491,7 +6460,6 @@ objc_library(
     ":RCTBlob_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6605,7 +6573,6 @@ objc_library(
     ":RCTCameraRoll_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6715,7 +6682,6 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6832,7 +6798,6 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -6947,7 +6912,6 @@ objc_library(
     ":RCTNetwork_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
@@ -7066,7 +7030,6 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7176,7 +7139,6 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7286,7 +7248,6 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7396,7 +7357,6 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7506,7 +7466,6 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7650,7 +7609,6 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7781,7 +7739,6 @@ objc_library(
     ":fishhook_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -7891,7 +7848,6 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -8004,7 +7960,6 @@ objc_library(
     ":RCTTest_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -8107,7 +8062,6 @@ objc_library(
     ":_ignore_me_subspec_for_linting__includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -257,10 +257,7 @@ objc_library(
     ":React_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -2769,10 +2766,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -3009,10 +3003,7 @@ objc_library(
     ":CxxBridge_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3302,10 +3293,7 @@ objc_library(
     ":DevSupport_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -3623,10 +3611,7 @@ objc_library(
     ":RCTFabric_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
@@ -3739,10 +3724,7 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6001,10 +5983,7 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6114,10 +6093,7 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6235,10 +6211,7 @@ objc_library(
     ":RCTAnimation_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6518,10 +6491,7 @@ objc_library(
     ":RCTBlob_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6635,10 +6605,7 @@ objc_library(
     ":RCTCameraRoll_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6748,10 +6715,7 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -6868,10 +6832,7 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7105,10 +7066,7 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7218,10 +7176,7 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7331,10 +7286,7 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7444,10 +7396,7 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7557,10 +7506,7 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7704,10 +7650,7 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7838,10 +7781,7 @@ objc_library(
     ":fishhook_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -7951,10 +7891,7 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -8067,10 +8004,7 @@ objc_library(
     ":RCTTest_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -8173,10 +8107,7 @@ objc_library(
     ":_ignore_me_subspec_for_linting__includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -162,12 +162,14 @@ objc_library(
     ":React_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -255,11 +257,16 @@ objc_library(
     ":React_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1670,11 +1677,13 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -2760,11 +2769,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -2875,13 +2889,15 @@ objc_library(
     ":CxxBridge_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -2993,12 +3009,17 @@ objc_library(
     ":CxxBridge_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3140,12 +3161,14 @@ objc_library(
     ":DevSupport_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3279,11 +3302,16 @@ objc_library(
     ":DevSupport_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3440,12 +3468,14 @@ objc_library(
     ":RCTFabric_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3593,12 +3623,17 @@ objc_library(
     ":RCTFabric_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3704,11 +3739,16 @@ objc_library(
     ":tvOS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3835,12 +3875,14 @@ objc_library(
     ":jschelpers_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -3958,11 +4000,13 @@ objc_library(
     ":jsinspector_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4080,11 +4124,13 @@ objc_library(
     ":PrivateDatabase_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4225,12 +4271,14 @@ objc_library(
     ":cxxreact_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4320,12 +4368,14 @@ objc_library(
     ":fabric_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4454,12 +4504,14 @@ objc_library(
     ":fabric_activityindicator_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4590,12 +4642,14 @@ objc_library(
     ":fabric_attributedstring_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4726,12 +4780,14 @@ objc_library(
     ":fabric_core_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4862,12 +4918,14 @@ objc_library(
     ":fabric_debug_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -4998,12 +5056,14 @@ objc_library(
     ":fabric_graphics_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5134,12 +5194,14 @@ objc_library(
     ":fabric_scrollview_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5270,12 +5332,14 @@ objc_library(
     ":fabric_text_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5407,12 +5471,14 @@ objc_library(
     ":fabric_textlayoutmanager_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5543,12 +5609,14 @@ objc_library(
     ":fabric_uimanager_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5681,12 +5749,14 @@ objc_library(
     ":fabric_view_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5818,12 +5888,14 @@ objc_library(
     ":RCTFabricSample_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -5929,11 +6001,16 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6037,11 +6114,16 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6153,11 +6235,16 @@ objc_library(
     ":RCTAnimation_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6289,12 +6376,14 @@ objc_library(
     ":RCTBlob_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6429,11 +6518,16 @@ objc_library(
     ":RCTBlob_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6541,11 +6635,16 @@ objc_library(
     ":RCTCameraRoll_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6649,11 +6748,16 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6764,11 +6868,16 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6877,12 +6986,14 @@ objc_library(
     ":RCTNetwork_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/React/",
     "-std=c++14",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -6994,11 +7105,16 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7102,11 +7218,16 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7210,11 +7331,16 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7318,11 +7444,16 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7426,11 +7557,16 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7568,11 +7704,16 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7697,11 +7838,16 @@ objc_library(
     ":fishhook_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7805,11 +7951,16 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -7916,11 +8067,16 @@ objc_library(
     ":RCTTest_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -8017,11 +8173,16 @@ objc_library(
     ":_ignore_me_subspec_for_linting__includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -151,7 +151,6 @@ objc_library(
     ":React_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -341,7 +340,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -451,7 +449,6 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -561,7 +558,6 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -671,7 +667,6 @@ objc_library(
     ":RCTAdSupport_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -781,7 +776,6 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -891,7 +885,6 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1001,7 +994,6 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1111,7 +1103,6 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1221,7 +1212,6 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1331,7 +1321,6 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1441,7 +1430,6 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1551,7 +1539,6 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {
@@ -1661,7 +1648,6 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/React/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -151,11 +151,16 @@ objc_library(
     ":React_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -339,11 +344,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -447,11 +457,16 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -555,11 +570,16 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -663,11 +683,16 @@ objc_library(
     ":RCTAdSupport_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -771,11 +796,16 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -879,11 +909,16 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -987,11 +1022,16 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1095,11 +1135,16 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1203,11 +1248,16 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1311,11 +1361,16 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1419,11 +1474,16 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1527,11 +1587,16 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1635,11 +1700,16 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/React/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -151,10 +151,7 @@ objc_library(
     ":React_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -344,10 +341,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -457,10 +451,7 @@ objc_library(
     ":ART_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -570,10 +561,7 @@ objc_library(
     ":RCTActionSheet_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -683,10 +671,7 @@ objc_library(
     ":RCTAdSupport_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -796,10 +781,7 @@ objc_library(
     ":RCTGeolocation_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -909,10 +891,7 @@ objc_library(
     ":RCTImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1022,10 +1001,7 @@ objc_library(
     ":RCTNetwork_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1135,10 +1111,7 @@ objc_library(
     ":RCTPushNotification_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1248,10 +1221,7 @@ objc_library(
     ":RCTSettings_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1361,10 +1331,7 @@ objc_library(
     ":RCTText_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1474,10 +1441,7 @@ objc_library(
     ":RCTVibration_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1587,10 +1551,7 @@ objc_library(
     ":RCTWebSocket_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -1700,10 +1661,7 @@ objc_library(
     ":RCTLinkingIOS_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/React/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -166,11 +166,13 @@ objc_library(
     ":SFHFKeychainUtils_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/SFHFKeychainUtils/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -277,11 +279,16 @@ objc_library(
     ":SFHFKeychainUtils_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/SFHFKeychainUtils/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -279,10 +279,7 @@ objc_library(
     ":SFHFKeychainUtils_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/SFHFKeychainUtils/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -166,7 +166,6 @@ objc_library(
     ":SFHFKeychainUtils_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/SFHFKeychainUtils/",
     "-std=c++14"
   ] + select(
     {
@@ -279,7 +278,6 @@ objc_library(
     ":SFHFKeychainUtils_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/SFHFKeychainUtils/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":SPUserResizableView+Pion_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/SPUserResizableView+Pion/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":SPUserResizableView+Pion_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/SPUserResizableView+Pion/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":SPUserResizableView+Pion_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/SPUserResizableView+Pion/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -105,11 +105,16 @@ objc_library(
     ":SevenSwitch_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/SevenSwitch/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -105,7 +105,6 @@ objc_library(
     ":SevenSwitch_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/SevenSwitch/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -105,10 +105,7 @@ objc_library(
     ":SevenSwitch_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/SevenSwitch/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -112,11 +112,16 @@ objc_library(
     ":SlackTextViewController_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/SlackTextViewController/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":SlackTextViewController_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/SlackTextViewController/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -112,10 +112,7 @@ objc_library(
     ":SlackTextViewController_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/SlackTextViewController/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -113,7 +113,6 @@ objc_library(
     ":Smartling_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Smartling/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -113,11 +113,16 @@ objc_library(
     ":Smartling_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Smartling/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -113,10 +113,7 @@ objc_library(
     ":Smartling_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Smartling/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -122,10 +122,7 @@ objc_library(
     ":Stripe_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Stripe/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -122,11 +122,16 @@ objc_library(
     ":Stripe_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Stripe/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -122,7 +122,6 @@ objc_library(
     ":Stripe_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Stripe/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -116,10 +116,7 @@ objc_library(
     ":TestArcPatternsWithExcludes_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -512,10 +509,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -116,11 +116,16 @@ objc_library(
     ":TestArcPatternsWithExcludes_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -507,11 +512,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -116,7 +116,6 @@ objc_library(
     ":TestArcPatternsWithExcludes_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
     "-fobjc-weak"
   ] + select(
     {
@@ -509,7 +508,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/TestArcPatternsWithExcludes/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -131,11 +131,16 @@ objc_library(
     ":Texture_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -264,6 +269,7 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/Texture/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++",
@@ -271,7 +277,8 @@ objc_library(
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -403,12 +410,17 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fno-exceptions -fno-objc-arc-exceptions"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -508,11 +520,16 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -613,11 +630,16 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -717,12 +739,17 @@ objc_library(
     ":Yoga_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DYOGA=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -823,12 +850,17 @@ objc_library(
     ":MapKit_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_MAPKIT=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -927,12 +959,17 @@ objc_library(
     ":Photos_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_PHOTOS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -1031,12 +1068,17 @@ objc_library(
     ":AssetsLibrary_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Texture/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_ASSETS_LIBRARY=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -131,7 +131,6 @@ objc_library(
     ":Texture_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak"
   ] + select(
     {
@@ -266,7 +265,6 @@ objc_library(
     ":Core_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++",
@@ -407,7 +405,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak",
     "-fno-exceptions -fno-objc-arc-exceptions"
   ] + select(
@@ -514,7 +511,6 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak"
   ] + select(
     {
@@ -621,7 +617,6 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak"
   ] + select(
     {
@@ -727,7 +722,6 @@ objc_library(
     ":Yoga_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak",
     "-DYOGA=1"
   ] + select(
@@ -835,7 +829,6 @@ objc_library(
     ":MapKit_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak",
     "-DAS_USE_MAPKIT=1"
   ] + select(
@@ -941,7 +934,6 @@ objc_library(
     ":Photos_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak",
     "-DAS_USE_PHOTOS=1"
   ] + select(
@@ -1047,7 +1039,6 @@ objc_library(
     ":AssetsLibrary_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Texture/",
     "-fobjc-weak",
     "-DAS_USE_ASSETS_LIBRARY=1"
   ] + select(

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -131,10 +131,7 @@ objc_library(
     ":Texture_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -410,10 +407,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-fno-exceptions -fno-objc-arc-exceptions"
   ] + select(
@@ -520,10 +514,7 @@ objc_library(
     ":PINRemoteImage_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -630,10 +621,7 @@ objc_library(
     ":IGListKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -739,10 +727,7 @@ objc_library(
     ":Yoga_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DYOGA=1"
   ] + select(
@@ -850,10 +835,7 @@ objc_library(
     ":MapKit_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_MAPKIT=1"
   ] + select(
@@ -959,10 +941,7 @@ objc_library(
     ":Photos_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_PHOTOS=1"
   ] + select(
@@ -1068,10 +1047,7 @@ objc_library(
     ":AssetsLibrary_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Texture/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DAS_USE_ASSETS_LIBRARY=1"
   ] + select(

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -248,10 +248,7 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/UICollectionViewLeftAlignedLayout/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -138,7 +138,6 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/UICollectionViewLeftAlignedLayout/",
     "-std=c++14"
   ] + select(
     {
@@ -248,7 +247,6 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/UICollectionViewLeftAlignedLayout/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -138,11 +138,13 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/UICollectionViewLeftAlignedLayout/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -246,11 +248,16 @@ objc_library(
     ":UICollectionViewLeftAlignedLayout_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/UICollectionViewLeftAlignedLayout/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -117,10 +117,7 @@ objc_library(
     ":Weixin_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/Weixin/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -117,11 +117,16 @@ objc_library(
     ":Weixin_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/Weixin/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -117,7 +117,6 @@ objc_library(
     ":Weixin_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/Weixin/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -130,7 +130,6 @@ objc_library(
     ":ZipArchive_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/ZipArchive/",
     "-fobjc-weak",
     "-Dunix"
   ] + select(

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -130,10 +130,7 @@ objc_library(
     ":ZipArchive_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/ZipArchive/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Dunix"
   ] + select(

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -130,12 +130,17 @@ objc_library(
     ":ZipArchive_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/ZipArchive/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-Dunix"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -107,10 +107,7 @@ objc_library(
     ":boost-for-react-native_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/boost-for-react-native/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -107,7 +107,6 @@ objc_library(
     ":boost-for-react-native_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/boost-for-react-native/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -107,11 +107,16 @@ objc_library(
     ":boost-for-react-native_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/boost-for-react-native/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -151,7 +151,6 @@ objc_library(
     ":glog_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/glog/",
     "-std=c++14"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -151,11 +151,13 @@ objc_library(
     ":glog_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/glog/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -116,12 +116,17 @@ objc_library(
     ":googleapis_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/googleapis/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -227,12 +232,17 @@ objc_library(
     ":Messages_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/googleapis/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -340,12 +350,17 @@ objc_library(
     ":Services_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/googleapis/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -116,10 +116,7 @@ objc_library(
     ":googleapis_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/googleapis/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
@@ -232,10 +229,7 @@ objc_library(
     ":Messages_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/googleapis/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
@@ -350,10 +344,7 @@ objc_library(
     ":Services_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/googleapis/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -116,7 +116,6 @@ objc_library(
     ":googleapis_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/googleapis/",
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
@@ -229,7 +228,6 @@ objc_library(
     ":Messages_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/googleapis/",
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(
@@ -344,7 +342,6 @@ objc_library(
     ":Services_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/googleapis/",
     "-fobjc-weak",
     "-DGPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1"
   ] + select(

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -116,7 +116,6 @@ objc_library(
     ":iOSSnapshotTestCase_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
     "-fobjc-weak"
   ] + select(
     {
@@ -248,7 +247,6 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
     "-fobjc-weak"
   ] + select(
     {
@@ -353,7 +351,6 @@ objc_library(
     ":SwiftSupport_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -116,10 +116,7 @@ objc_library(
     ":iOSSnapshotTestCase_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -251,10 +248,7 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
@@ -359,10 +353,7 @@ objc_library(
     ":SwiftSupport_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -116,11 +116,16 @@ objc_library(
     ":iOSSnapshotTestCase_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -246,11 +251,16 @@ objc_library(
     ":Core_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -349,11 +359,16 @@ objc_library(
     ":SwiftSupport_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/iOSSnapshotTestCase/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -113,10 +113,7 @@ objc_library(
     ":iRate_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/iRate/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -113,7 +113,6 @@ objc_library(
     ":iRate_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/iRate/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -113,11 +113,16 @@ objc_library(
     ":iRate_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/iRate/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -116,7 +116,6 @@ objc_library(
     ":kingpin_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/kingpin/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -116,11 +116,16 @@ objc_library(
     ":kingpin_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/kingpin/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -116,10 +116,7 @@ objc_library(
     ":kingpin_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/kingpin/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -174,7 +174,6 @@ objc_library(
     ":pop_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/pop/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
@@ -324,7 +323,6 @@ objc_library(
     ":pop_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/pop/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -324,10 +324,7 @@ objc_library(
     ":pop_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/pop/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -174,13 +174,15 @@ objc_library(
     ":pop_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/pop/",
     "-std=c++14",
     "-std=c++11",
     "-stdlib=libc++"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -322,11 +324,16 @@ objc_library(
     ":pop_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/pop/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -112,7 +112,6 @@ objc_library(
     ":yoga_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/yoga/",
     "-std=c++14",
     "-fno-omit-frame-pointer",
     "-fexceptions",

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -112,6 +112,7 @@ objc_library(
     ":yoga_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/yoga/",
     "-std=c++14",
     "-fno-omit-frame-pointer",
     "-fexceptions",
@@ -122,7 +123,8 @@ objc_library(
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -315,11 +315,13 @@ objc_library(
     ":youtube-ios-player-helper_cxx_includes"
   ],
   copts = [
+    "-I$(GENDIR)/Vendor/youtube-ios-player-helper/",
     "-std=c++14"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",
@@ -562,11 +564,16 @@ objc_library(
     ":youtube-ios-player-helper_includes"
   ],
   copts = [
+<<<<<<< HEAD
+=======
+    "-I$(GENDIR)/Vendor/youtube-ios-player-helper/",
+>>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {
       "//conditions:default": [
-        "-DPOD_CONFIGURATION_RELEASE=0"
+        "-DDEBUG=1",
+        "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
         "-DPOD_CONFIGURATION_RELEASE=1",

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -315,7 +315,6 @@ objc_library(
     ":youtube-ios-player-helper_cxx_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/youtube-ios-player-helper/",
     "-std=c++14"
   ] + select(
     {
@@ -564,7 +563,6 @@ objc_library(
     ":youtube-ios-player-helper_includes"
   ],
   copts = [
-    "-I$(GENDIR)/Vendor/youtube-ios-player-helper/",
     "-fobjc-weak"
   ] + select(
     {

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -564,10 +564,7 @@ objc_library(
     ":youtube-ios-player-helper_includes"
   ],
   copts = [
-<<<<<<< HEAD
-=======
     "-I$(GENDIR)/Vendor/youtube-ios-player-helper/",
->>>>>>> Add copts for SwiftLibrary
     "-fobjc-weak"
   ] + select(
     {

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -383,7 +383,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
 
         // Adds minimal, non specified Xcode defaults
         let extraCopts: AttrSet<[String]>
-        if case .cpp = sourceType {
+        if .cpp == sourceType {
             extraCopts = AttrSet(basic: ["-std=c++14"])
         } else {
             extraCopts = AttrSet(basic: ["-fobjc-weak"])

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -392,8 +392,8 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
         // Note: we need to include the gen dir here, unfortunately.
         // This is a hack to deal with the swift header not being in the public
         // interface. Ideally, we have a non cached headermap.
-        copts = AttrSet(basic: [
-                "-I$(GENDIR)/\(getGenfileOutputBaseDir())/"]) <>
+        copts = AttrSet(basic: moduleMap != nil ? [
+                "-I$(GENDIR)/\(getGenfileOutputBaseDir())/"] : []) <>
             extraCopts <>
             AttrSet(basic: xcconfigCopts) <>
             fallbackSpec.attr(\.compilerFlags)

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -143,7 +143,7 @@ public struct SwiftLibrary: BazelTarget {
         }
         // `swift_library` depends on the public interface
         self.deps = allDeps.map {
-	    $0.map {
+            $0.map {
                 getDependencyName(fromPodDepName: $0, podName: podName)
             }.filter {
                 $0.hasPrefix("//") || $0.hasPrefix("@")
@@ -161,6 +161,10 @@ public struct SwiftLibrary: BazelTarget {
         let includes = objcFlags.filter { $0.hasPrefix("-I") }
 
         // Insert the clang import flags
+        // This adds -DCOCOAPODS and -DCOCOAPODS=1 to the clang importer ( via
+        // -Xcc ) - by doing this, clang sees -DCOCOAPODS=1. I'm not 100% sure
+        // why it doesn't pass -DCOCOAPODS=1 to swift, but this is the behavior
+        // in Xcode make it identical
         let clangImporterCopts = (includes + ["-DCOCOAPODS=1"])
             .reduce([String]()) { $0 + ["-Xcc", $1] }
         self.copts = AttrSet(basic: [

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -150,7 +150,23 @@ public struct SwiftLibrary: BazelTarget {
             }
         }
  
-        self.copts = AttrSet.empty
+        let swiftFlags = XCConfigTransformer.defaultTransformer(
+            externalName: externalName, sourceType: .swift)
+            .compilerFlags(for: fallbackSpec)
+
+        let objcFlags = XCConfigTransformer.defaultTransformer(
+            externalName: externalName, sourceType: .objc)
+            .compilerFlags(for: fallbackSpec)
+
+        let includes = objcFlags.filter { $0.hasPrefix("-I") }
+
+        // Insert the clang import flags
+        let clangImporterCopts = (includes + ["-DCOCOAPODS=1"])
+            .reduce([String]()) { $0 + ["-Xcc", $1] }
+        self.copts = AttrSet(basic: [
+            "-DCOCOAPODS",
+        ] + swiftFlags + clangImporterCopts)
+
         self.swiftcInputs = AttrSet.empty
         self.moduleMap = moduleMap
     }
@@ -176,6 +192,7 @@ public struct SwiftLibrary: BazelTarget {
             "-Xcc",
             "-I.",
         ])
+        let deps = self.deps
         if let moduleMap = self.moduleMap {
             copts = copts <> AttrSet(basic: [
                 "-Xcc",
@@ -189,7 +206,6 @@ public struct SwiftLibrary: BazelTarget {
             swiftcInputs = swiftcInputs <> AttrSet(basic: [
                 ":" + moduleMap.name,
             ])
-
             if let umbrellaHeader = moduleMap.umbrellaHeader {
                 swiftcInputs = swiftcInputs <> AttrSet(basic: [
                     ":" + umbrellaHeader
@@ -197,18 +213,36 @@ public struct SwiftLibrary: BazelTarget {
             }
         }
 
-        let deps = self.deps.map {
+        let depsSkylark = deps.map {
             Set($0).sorted(by: (<))
         }.toSkylark()
+        let buildConfigDependenctCOpts: SkylarkNode =
+            .functionCall(name: "select",
+             arguments: [
+                 .basic([
+                     ":release": [
+                         "-Xcc", "-DPOD_CONFIGURATION_RELEASE=1",
+                      ],
+                     "//conditions:default": [
+                         "-enable-testing",
+                         "-DDEBUG",
+                         "-Xcc", "-DPOD_CONFIGURATION_DEBUG=1",
+                         "-Xcc", "-DDEBUG=1",
+                     ],
+                 ].toSkylark()
+                 ),
+             ])
+
+        let coptsSkylark = buildConfigDependenctCOpts .+. copts.toSkylark()
         return .functionCall(
             name: "swift_library",
             arguments: [
                 .named(name: "name", value: name.toSkylark()),
                 .named(name: "module_name", value: moduleName.toSkylark()),
                 .named(name: "srcs", value: sourceFiles.toSkylark()),
-                .named(name: "deps", value: deps),
+                .named(name: "deps", value: depsSkylark),
                 .named(name: "data", value: data.toSkylark()),
-                .named(name: "copts", value: copts.toSkylark()),
+                .named(name: "copts", value: coptsSkylark),
                 .named(name: "swiftc_inputs", value: swiftcInputs.toSkylark()),
                 .named(name: "generated_header_name", value: (externalName + "-Swift.h").toSkylark()),
                 .named(name: "features", value: ["swift.no_generated_module_map"].toSkylark()),


### PR DESCRIPTION
Add copts for SwiftLibrary

This PR adds default copts for SwiftLibrary. Additionally, it cleans up
a few of the methods used to build out copts from xcconfig
