### PR TITLE
Allow the replacement of execpath

### DIFF
--- a/BazelExtensions/extensions.bzl
+++ b/BazelExtensions/extensions.bzl
@@ -192,16 +192,18 @@ module {module_name}.Swift {{
     # automatically and add a _single_ include to this module map. Ideally there
     # would be an API to invoke clang with -fmodule-map= 
     if ctx.attr.module_map_name == "module.modulemap":
-        include = depset([ctx.outputs.module_map.dirname])
+        provider_hdr = [module_map] + ([umbrella_header_file] if umbrella_header_file else [])
+        objc_provider = apple_common.new_objc_provider(
+            module_map=depset([module_map]),
+            include=depset([ctx.outputs.module_map.dirname]),
+            header=depset(provider_hdr)
+        )
     else:
-        include = depset()
-
-
-    objc_provider = apple_common.new_objc_provider(
-        module_map=depset([module_map]),
-        include=include,
-        header=depset([umbrella_header_file]) if umbrella_header_file else depset(),
-    )
+        # This is an explicit module map. Currently, we use these for swift only
+        provider_hdr = [module_map] + ([umbrella_header_file] if umbrella_header_file else [])
+        objc_provider = apple_common.new_objc_provider(
+            header=depset(provider_hdr + [module_map])
+        )
 
     return struct(
         files=depset([module_map]),

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -55,7 +55,10 @@ swift_library(
       "**/*.swift"
     ]
   ),
-  deps = [],
+  deps = [
+    ":ObjcParentWithSwiftSubspecs_module_map",
+    ":ObjcParentWithSwiftSubspecs_umbrella_header"
+  ],
   data = [],
   copts = select(
     {

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -196,7 +196,7 @@ public struct SwiftLibrary: BazelTarget {
             "-Xcc",
             "-I.",
         ])
-        let deps = self.deps
+        var deps = self.deps
         if let moduleMap = self.moduleMap {
             copts = copts <> AttrSet(basic: [
                 "-Xcc",
@@ -207,13 +207,17 @@ public struct SwiftLibrary: BazelTarget {
                 "-fmodule-map-file=$(execpath " + moduleMap.name + ")",
                 "-import-underlying-module",
             ])
-            swiftcInputs = swiftcInputs <> AttrSet(basic: [
-                ":" + moduleMap.name,
-            ])
+
+            let moduleMapDep = AttrSet(basic: [ ":" + moduleMap.name ])
+            swiftcInputs = swiftcInputs <> moduleMapDep
+            deps = deps <> moduleMapDep
+
             if let umbrellaHeader = moduleMap.umbrellaHeader {
-                swiftcInputs = swiftcInputs <> AttrSet(basic: [
+                let umbrellaDep = AttrSet(basic: [
                     ":" + umbrellaHeader
                 ])
+                swiftcInputs = swiftcInputs <> umbrellaDep
+                deps = deps <> umbrellaDep
             }
         }
 


### PR DESCRIPTION
In order to use `expand_location` we need to have a dep on the input.
https://docs.bazel.build/versions/master/skylark/lib/ctx.html#expand_location

Private module maps used in swift library that were previously not
`deps`, and they are specified now specified as header, so they remain
private. If we fix `swiftc_inputs` to be expandable in Bazel this would
be unnecessary.

For xcode project generation we need to call `expand_location` and the
aspect will fail if it doesn't have it as a dep. The corresponding code is added
to Tulsi and XCHammer https://github.com/bazelbuild/tulsi/pull/157