### PR TITLE
Stop setting -DNS_BLOCK_ASSERTIONS=1 for :release

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -134,8 +134,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -260,8 +259,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -383,8 +381,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -506,8 +503,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -629,8 +625,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -157,8 +157,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -278,8 +277,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1536,8 +1534,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -2948,8 +2945,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -247,8 +246,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -404,8 +402,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -142,8 +142,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -266,8 +265,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -381,8 +379,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -498,8 +495,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -611,8 +607,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -738,8 +733,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -854,8 +848,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -999,8 +992,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1122,8 +1114,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1254,8 +1245,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1388,8 +1378,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1518,8 +1507,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1646,8 +1634,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -240,8 +239,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -357,8 +355,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -181,8 +181,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -300,8 +299,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -131,8 +131,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -125,8 +125,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -234,8 +233,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -337,8 +335,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -446,8 +443,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -625,8 +621,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -723,8 +718,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -221,8 +221,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -390,8 +389,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -164,8 +164,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -291,8 +290,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -799,8 +797,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1344,8 +1341,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1814,8 +1810,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -299,8 +299,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1133,8 +1132,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -139,8 +139,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -295,8 +294,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -137,8 +137,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -305,8 +305,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -126,8 +126,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -134,8 +134,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -232,8 +231,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -341,8 +339,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -434,8 +431,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -544,8 +540,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -660,8 +655,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -773,8 +767,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -133,8 +133,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -142,8 +142,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ),

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -122,8 +122,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -114,8 +114,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -117,8 +117,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -126,8 +126,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -111,8 +111,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -121,8 +121,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -123,8 +123,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -148,8 +148,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -257,8 +256,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -420,8 +418,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -579,8 +576,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -786,8 +782,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -989,8 +984,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -137,8 +137,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -234,8 +233,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -346,8 +344,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -458,8 +455,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -570,8 +566,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -136,8 +136,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -219,8 +219,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -344,8 +343,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -440,8 +438,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -162,8 +162,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -135,8 +135,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -257,8 +256,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -376,8 +374,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -137,8 +137,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -240,8 +239,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -127,8 +127,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -257,8 +256,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -360,8 +358,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -462,8 +459,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -560,8 +556,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -671,8 +666,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -774,8 +768,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -887,8 +880,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -124,8 +124,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -171,8 +171,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -264,8 +263,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1680,8 +1678,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -2771,8 +2768,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -2889,8 +2885,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3007,8 +3002,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3155,8 +3149,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3294,8 +3287,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3457,8 +3449,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3611,8 +3602,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3722,8 +3712,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3855,8 +3844,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -3978,8 +3966,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4101,8 +4088,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4248,8 +4234,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4344,8 +4329,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4479,8 +4463,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4616,8 +4599,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4753,8 +4735,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -4890,8 +4871,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5027,8 +5007,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5164,8 +5143,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5301,8 +5279,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5439,8 +5416,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5576,8 +5552,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5715,8 +5690,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5853,8 +5827,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -5964,8 +5937,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6073,8 +6045,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6190,8 +6161,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6328,8 +6298,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6468,8 +6437,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6581,8 +6549,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6690,8 +6657,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6806,8 +6772,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -6921,8 +6886,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7038,8 +7002,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7147,8 +7110,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7256,8 +7218,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7365,8 +7326,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7474,8 +7434,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7617,8 +7576,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7747,8 +7705,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7856,8 +7813,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -7968,8 +7924,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -8070,8 +8025,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -159,8 +159,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -348,8 +347,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -457,8 +455,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -566,8 +563,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -675,8 +671,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -784,8 +779,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -893,8 +887,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1002,8 +995,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1111,8 +1103,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1220,8 +1211,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1329,8 +1319,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1438,8 +1427,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1547,8 +1535,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1656,8 +1643,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -174,8 +174,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -286,8 +285,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -113,8 +113,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -120,8 +120,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -121,8 +121,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -130,8 +130,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -124,8 +124,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -516,8 +515,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -139,8 +139,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -276,8 +275,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -414,8 +412,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -519,8 +516,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -625,8 +621,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -731,8 +726,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -838,8 +832,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -943,8 +936,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -1048,8 +1040,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -146,8 +146,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -255,8 +254,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -125,8 +125,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -139,8 +139,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -115,8 +115,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -159,8 +159,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ),

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -125,8 +125,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -237,8 +236,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -351,8 +349,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -124,8 +124,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -255,8 +254,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -359,8 +357,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -121,8 +121,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -124,8 +124,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -184,8 +184,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -331,8 +330,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -126,8 +126,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -323,8 +323,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [
@@ -571,8 +570,7 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1",
-        "-DNS_BLOCK_ASSERTIONS=1"
+        "-DPOD_CONFIGURATION_RELEASE=1"
       ]
     }
   ) + [

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -896,8 +896,7 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
              arguments: [
                  .basic([
                      ":release": [
-                         "-DPOD_CONFIGURATION_RELEASE=1",
-                         "-DNS_BLOCK_ASSERTIONS=1"
+                         "-DPOD_CONFIGURATION_RELEASE=1"
                      ],
                      "//conditions:default": [
                          "-DDEBUG=1",


### PR DESCRIPTION
As of Bazel 3.5.0, this is already set for the :opt profile on all Apple
platforms (which is what :release uses):

https://github.com/bazelbuild/bazel/commit/174ed30685ef3ed30e50e01f547c2fb7a003c12e