### PR TITLE
Spell 'sdk_frameworks' as expected

### DIFF
--- a/BazelExtensions/workspace.bzl
+++ b/BazelExtensions/workspace.bzl
@@ -256,7 +256,7 @@ def new_pod_repository(name,
          PlusEquals ( += ). Add an item to an array
 
          Implemented for:
-         `objc_library` [ `copts`, `deps`, `sdkFrameworks` ]
+         `objc_library` [ `copts`, `deps`, `sdk_frameworks` ]
 
          Example usage: add a custom define to the target, Texture's `copts`
          field

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ new_pod_repository(
 ```
 
 On `objc_library`, the following fields are supported: `copts`, `deps`,
-`sdkFrameworks`
+`sdk_frameworks`
 
 ### Acknowledgements Plist and Settings.bundle
 
@@ -218,7 +218,7 @@ Supported operators:
 PlusEquals ( += ). Add an item to an array
 
 Implemented for:
-`objc_library`. Supported fields: `copts`, `deps`, `sdkFrameworks`
+`objc_library`. Supported fields: `copts`, `deps`, `sdk_frameworks`
 
 Example usage: add a custom define to the target, Texture's `copts`
 field

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -392,7 +392,7 @@ def new_pod_repository(name,
          PlusEquals ( += ). Add an item to an array
 
          Implemented for:
-         `objc_library` [ `copts`, `deps`, `sdkFrameworks` ]
+         `objc_library` [ `copts`, `deps`, `sdk_frameworks` ]
 
          Example usage: add a custom define to the target, Texture's `copts`
          field


### PR DESCRIPTION
We use the name 'sdkFrameworks' in the internal Swift code, but all
PodToBUILD users should spell this as 'sdk_frameworks' in Bazel-land.