### PR TITLE
Revert "Stop setting -DNS_BLOCK_ASSERTIONS=1 for :release

### DIFF
--- a/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Adjust.podspec.json.goldmaster
@@ -134,7 +134,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -259,7 +260,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -381,7 +383,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -503,7 +506,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -625,7 +629,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/BUILD
+++ b/IntegrationTests/GoldMaster/BUILD
@@ -157,7 +157,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -277,7 +278,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1534,7 +1536,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -2945,7 +2948,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Bolts.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -246,7 +247,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -402,7 +404,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Braintree.podspec.json.goldmaster
@@ -142,7 +142,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -265,7 +266,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -379,7 +381,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -495,7 +498,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -607,7 +611,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -733,7 +738,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -848,7 +854,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -992,7 +999,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1114,7 +1122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1245,7 +1254,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1378,7 +1388,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1507,7 +1518,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1634,7 +1646,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Branch.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -239,7 +240,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -355,7 +357,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Calabash.podspec.json.goldmaster
@@ -181,7 +181,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -299,7 +300,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CardIO.podspec.json.goldmaster
@@ -131,7 +131,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/CocoaLumberjack.podspec.json.goldmaster
@@ -125,7 +125,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -233,7 +234,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -335,7 +337,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -443,7 +446,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -621,7 +625,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -718,7 +723,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ColorCube.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/EarlGrey.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBAllocationTracker.0.1.3.podspec.json.goldmaster
@@ -221,7 +221,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -389,7 +390,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.7.1.0.podspec.json.goldmaster
@@ -164,7 +164,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -290,7 +291,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -797,7 +799,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1341,7 +1344,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1810,7 +1814,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKCoreKit.podspec.json.goldmaster
@@ -299,7 +299,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1132,7 +1133,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.7.1.0.podspec.json.goldmaster
@@ -139,7 +139,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -294,7 +295,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKLoginKit.podspec.json.goldmaster
@@ -137,7 +137,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKMessengerShareKit.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FBSDKShareKit.podspec.json.goldmaster
@@ -305,7 +305,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLAnimatedImage.podspec.json.goldmaster
@@ -126,7 +126,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FLEX.podspec.json.goldmaster
@@ -134,7 +134,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FMDB.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -231,7 +232,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -339,7 +341,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -431,7 +434,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -540,7 +544,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -655,7 +660,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -767,7 +773,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/FolioReaderKit.podspec.json.goldmaster
@@ -133,7 +133,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Folly.podspec.json.goldmaster
@@ -142,7 +142,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ),

--- a/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppIndexing.podspec.json.goldmaster
@@ -122,7 +122,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAppUtilities.podspec.json.goldmaster
@@ -114,7 +114,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleAuthUtilities.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleNetworkingUtilities.podspec.json.goldmaster
@@ -117,7 +117,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSignIn.podspec.json.goldmaster
@@ -126,7 +126,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleSymbolUtilities.podspec.json.goldmaster
@@ -111,7 +111,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/GoogleUtilities.podspec.json.goldmaster
@@ -121,7 +121,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IBActionSheet.podspec.json.goldmaster
@@ -123,7 +123,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/IGListKit.podspec.json.goldmaster
@@ -148,7 +148,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -256,7 +257,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -418,7 +420,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -576,7 +579,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -782,7 +786,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -984,7 +989,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KVOController.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/KakaoOpenSDK.podspec.json.goldmaster
@@ -137,7 +137,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -233,7 +234,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -344,7 +346,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -455,7 +458,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -566,7 +570,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Masonry.podspec.json.goldmaster
@@ -136,7 +136,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -219,7 +219,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -343,7 +344,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -438,7 +440,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/OnePasswordExtension.podspec.json.goldmaster
@@ -162,7 +162,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINCache.podspec.json.goldmaster
@@ -135,7 +135,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -256,7 +257,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -374,7 +376,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINOperation.podspec.json.goldmaster
@@ -137,7 +137,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -239,7 +240,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PINRemoteImage.podspec.json.goldmaster
@@ -127,7 +127,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -256,7 +257,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -358,7 +360,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -459,7 +462,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -556,7 +560,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -666,7 +671,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -768,7 +774,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -880,7 +887,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/PaymentKit.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/RadarKit.podspec.json.goldmaster
@@ -124,7 +124,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.57.0.podspec.json.goldmaster
@@ -171,7 +171,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -263,7 +264,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1678,7 +1680,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -2768,7 +2771,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -2885,7 +2889,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3002,7 +3007,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3149,7 +3155,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3287,7 +3294,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3449,7 +3457,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3602,7 +3611,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3712,7 +3722,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3844,7 +3855,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -3966,7 +3978,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4088,7 +4101,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4234,7 +4248,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4329,7 +4344,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4463,7 +4479,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4599,7 +4616,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4735,7 +4753,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -4871,7 +4890,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5007,7 +5027,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5143,7 +5164,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5279,7 +5301,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5416,7 +5439,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5552,7 +5576,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5690,7 +5715,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5827,7 +5853,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -5937,7 +5964,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6045,7 +6073,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6161,7 +6190,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6298,7 +6328,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6437,7 +6468,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6549,7 +6581,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6657,7 +6690,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6772,7 +6806,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -6886,7 +6921,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7002,7 +7038,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7110,7 +7147,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7218,7 +7256,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7326,7 +7365,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7434,7 +7474,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7576,7 +7617,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7705,7 +7747,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7813,7 +7856,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -7924,7 +7968,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -8025,7 +8070,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/React.0.9.0.podspec.json.goldmaster
@@ -159,7 +159,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -347,7 +348,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -455,7 +457,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -563,7 +566,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -671,7 +675,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -779,7 +784,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -887,7 +893,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -995,7 +1002,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1103,7 +1111,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1211,7 +1220,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1319,7 +1329,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1427,7 +1438,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1535,7 +1547,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1643,7 +1656,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SFHFKeychainUtils.podspec.json.goldmaster
@@ -174,7 +174,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -285,7 +286,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SPUserResizableView+Pion.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SevenSwitch.podspec.json.goldmaster
@@ -113,7 +113,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/SlackTextViewController.podspec.json.goldmaster
@@ -120,7 +120,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Smartling.podspec.json.goldmaster
@@ -121,7 +121,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Stripe.podspec.json.goldmaster
@@ -130,7 +130,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/TestArcPatternsWithExcludes.podspec.json.goldmaster
@@ -124,7 +124,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -515,7 +516,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Texture.podspec.json.goldmaster
@@ -139,7 +139,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -275,7 +276,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -412,7 +414,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -516,7 +519,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -621,7 +625,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -726,7 +731,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -832,7 +838,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -936,7 +943,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -1040,7 +1048,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/UICollectionViewLeftAlignedLayout.podspec.json.goldmaster
@@ -146,7 +146,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -254,7 +255,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/Weixin.podspec.json.goldmaster
@@ -125,7 +125,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ZipArchive.podspec.json.goldmaster
@@ -139,7 +139,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/boost-for-react-native.podspec.json.goldmaster
@@ -115,7 +115,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/glog.podspec.json.goldmaster
@@ -159,7 +159,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ),

--- a/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/googleapis.podspec.json.goldmaster
@@ -125,7 +125,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -236,7 +237,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -349,7 +351,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iOSSnapshotTestCase.podspec.json.goldmaster
@@ -124,7 +124,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -254,7 +255,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -357,7 +359,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/iRate.podspec.json.goldmaster
@@ -121,7 +121,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/kingpin.podspec.json.goldmaster
@@ -124,7 +124,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/pop.podspec.json.goldmaster
@@ -184,7 +184,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -330,7 +331,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/yoga.0.46.3.React.podspec.json.goldmaster
@@ -126,7 +126,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/youtube-ios-player-helper.podspec.json.goldmaster
@@ -323,7 +323,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [
@@ -570,7 +571,8 @@ objc_library(
         "-DPOD_CONFIGURATION_DEBUG=1"
       ],
       ":release": [
-        "-DPOD_CONFIGURATION_RELEASE=1"
+        "-DPOD_CONFIGURATION_RELEASE=1",
+        "-DNS_BLOCK_ASSERTIONS=1"
       ]
     }
   ) + [

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -913,7 +913,8 @@ public struct ObjcLibrary: BazelTarget, UserConfigurable, SourceExcludable {
              arguments: [
                  .basic([
                      ":release": [
-                         "-DPOD_CONFIGURATION_RELEASE=1"
+                         "-DPOD_CONFIGURATION_RELEASE=1",
+                         "-DNS_BLOCK_ASSERTIONS=1"
                      ],
                      "//conditions:default": [
                          "-DDEBUG=1",


### PR DESCRIPTION
This reverts commit 599a84c5d25bd55af32df685a114498b4a241ebe.

This was the right long-term decision, but it's caused some regressions
for build environments that expected this to be set due to customized
cc_toolchains, so let's revert it for now.