### PR TITLE
Set generates_header when generated_header_name is provided

### DIFF
--- a/Examples/FBSDK/WORKSPACE
+++ b/Examples/FBSDK/WORKSPACE
@@ -7,8 +7,21 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "a41a75c291c69676b9974458ceee09aea60cee0e1ee282e27cdc90b679dfd30f",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.21.2/rules_apple.0.21.2.tar.gz",
+    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
+)
+
+http_archive(
+    name = "build_bazel_rules_swift",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
+    sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-all-3.19.1.tar.gz"],
+    sha256 = "80631d5a18d51daa3a1336e340001ad4937e926762f21144c62d26fe2a8d71fe",
+    strip_prefix = "protobuf-3.19.1",
 )
 
 load(
@@ -38,4 +51,3 @@ load(
 )
 
 protobuf_deps()
-

--- a/Examples/SwiftSubspec/WORKSPACE
+++ b/Examples/SwiftSubspec/WORKSPACE
@@ -7,8 +7,21 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "a41a75c291c69676b9974458ceee09aea60cee0e1ee282e27cdc90b679dfd30f",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.21.2/rules_apple.0.21.2.tar.gz",
+    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
+)
+
+http_archive(
+    name = "build_bazel_rules_swift",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
+    sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-all-3.19.1.tar.gz"],
+    sha256 = "80631d5a18d51daa3a1336e340001ad4937e926762f21144c62d26fe2a8d71fe",
+    strip_prefix = "protobuf-3.19.1",
 )
 
 load(

--- a/Examples/SwiftSubspec/WORKSPACE
+++ b/Examples/SwiftSubspec/WORKSPACE
@@ -17,13 +17,6 @@ http_archive(
     sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
 )
 
-http_archive(
-    name = "com_google_protobuf",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-all-3.19.1.tar.gz"],
-    sha256 = "80631d5a18d51daa3a1336e340001ad4937e926762f21144c62d26fe2a8d71fe",
-    strip_prefix = "protobuf-3.19.1",
-)
-
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",
@@ -44,6 +37,13 @@ load(
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -94,6 +94,7 @@ swift_library(
     ":ObjcParentWithSwiftSubspecs_umbrella_header"
   ],
   generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
+  generates_header = 1,
   features = [
     "swift.no_generated_module_map"
   ],

--- a/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
+++ b/IntegrationTests/GoldMaster/ObjcParentWithSwiftSubspecs.podspec.json.goldmaster
@@ -94,7 +94,7 @@ swift_library(
     ":ObjcParentWithSwiftSubspecs_umbrella_header"
   ],
   generated_header_name = "ObjcParentWithSwiftSubspecs-Swift.h",
-  generates_header = 1,
+  generates_header = True,
   features = [
     "swift.no_generated_module_map"
   ],

--- a/Sources/ObjcSupport/include/module.modulemap
+++ b/Sources/ObjcSupport/include/module.modulemap
@@ -1,5 +1,0 @@
-module ObjcSupport {
-   export *
-   header "CrashReporter.h"
-   header "ExceptionCatcher.h"
-}

--- a/Sources/PodToBUILD/Skylark.swift
+++ b/Sources/PodToBUILD/Skylark.swift
@@ -12,6 +12,9 @@ public indirect enum SkylarkNode {
     /// A integer in Skylark.
     case int(Int)
 
+    /// A Boolean in Skylark.
+    case bool(Bool)
+
     /// A string in Skylark.
     /// @note The string value is enclosed within ""
     case string(String)
@@ -123,6 +126,8 @@ public struct SkylarkCompiler {
         switch node {
         case let .int(value):
             return "\(value)"
+        case let .bool(value):
+            return value ? "True" : "False"
         case let .string(value):
             return "\"\(value)\""
         case let .multiLineString(value):

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -106,7 +106,7 @@ public struct SwiftLibrary: BazelTarget {
             isSplitDep: isSplitDep,
             sourceType: .swift
         )
-        self.name = name 
+        self.name = name
 
         self.sourceFiles = SwiftLibrary.getSources(spec: spec)
 
@@ -149,7 +149,7 @@ public struct SwiftLibrary: BazelTarget {
                 $0.hasPrefix("//") || $0.hasPrefix("@")
             }
         }
- 
+
         let swiftFlags = XCConfigTransformer.defaultTransformer(
             externalName: externalName, sourceType: .swift)
             .compilerFlags(for: fallbackSpec)
@@ -255,6 +255,7 @@ public struct SwiftLibrary: BazelTarget {
                 .named(name: "copts", value: coptsSkylark),
                 .named(name: "swiftc_inputs", value: swiftcInputs.toSkylark()),
                 .named(name: "generated_header_name", value: (externalName + "-Swift.h").toSkylark()),
+                .named(name: "generates_header", value: SkylarkNode.int(1)),
                 .named(name: "features", value: ["swift.no_generated_module_map"].toSkylark()),
                 .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
             ]

--- a/Sources/PodToBUILD/SwiftLibrary.swift
+++ b/Sources/PodToBUILD/SwiftLibrary.swift
@@ -255,7 +255,7 @@ public struct SwiftLibrary: BazelTarget {
                 .named(name: "copts", value: coptsSkylark),
                 .named(name: "swiftc_inputs", value: swiftcInputs.toSkylark()),
                 .named(name: "generated_header_name", value: (externalName + "-Swift.h").toSkylark()),
-                .named(name: "generates_header", value: SkylarkNode.int(1)),
+                .named(name: "generates_header", value: SkylarkNode.bool(true)),
                 .named(name: "features", value: ["swift.no_generated_module_map"].toSkylark()),
                 .named(name: "visibility", value: ["//visibility:public"].toSkylark()),
             ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,13 +12,6 @@ http_archive(
     sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
 )
 
-http_archive(
-    name = "com_google_protobuf",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-all-3.19.1.tar.gz"],
-    sha256 = "80631d5a18d51daa3a1336e340001ad4937e926762f21144c62d26fe2a8d71fe",
-    strip_prefix = "protobuf-3.19.1",
-)
-
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",
@@ -32,6 +25,13 @@ load(
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,21 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "a41a75c291c69676b9974458ceee09aea60cee0e1ee282e27cdc90b679dfd30f",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.21.2/rules_apple.0.21.2.tar.gz",
+    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
+)
+
+http_archive(
+    name = "build_bazel_rules_swift",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
+    sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protobuf-all-3.19.1.tar.gz"],
+    sha256 = "80631d5a18d51daa3a1336e340001ad4937e926762f21144c62d26fe2a8d71fe",
+    strip_prefix = "protobuf-3.19.1",
 )
 
 load(


### PR DESCRIPTION
Required by rules_swift 0.24.0, when generated_header_name is provided, generates_header has to be set to True.

Updated versions of other rules dependencies and examples/tests as well.