### PR TITLE
Support tar.xz and txz

### DIFF
--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -577,6 +577,8 @@ public enum RepoActions {
                 lowercasedFileName.hasSuffix("tar")
                 || lowercasedFileName.hasSuffix("tar.gz")
                 || lowercasedFileName.hasSuffix("tgz")
+                || lowercasedFileName.hasSuffix("txz") // txz is a txz extension
+                || lowercasedFileName.hasSuffix("tar.xz") // tar.xz is a txz extension
             {
                 return shell.command(CommandBinary.sh, arguments: [
                     "-c",
@@ -592,7 +594,7 @@ public enum RepoActions {
         assertCommandOutput(extract(), message: "Extraction of \(podName) failed")
 
         // Save artifacts to cache root
-        let export = shell.command("/bin/sh", arguments: [
+        let export = shell.command(CommandBinary.sh, arguments: [
             "-c",
             "mkdir -p " + extractDir + " && " +
                 "cd " + extractDir + " && " +


### PR DESCRIPTION
Add support to tar.xz; close #108 

You can see some information about this file from [cocoapods-downloader](https://github.com/CocoaPods/cocoapods-downloader/blob/1.6.3/lib/cocoapods-downloader/remote_file.rb) on lines 69 and 96
