### PR TITLE
Fixed source_files ending with `/` to stop generationg `srcs` like 'some//**/*'

### DIFF
--- a/Examples/PodSpecs/PhoneNumberKit.podspec.json
+++ b/Examples/PodSpecs/PhoneNumberKit.podspec.json
@@ -1,0 +1,59 @@
+{
+  "name": "PhoneNumberKit",
+  "version": "3.3.4",
+  "summary": "Swift framework for working with phone numbers",
+  "description": "A Swift framework for parsing, formatting and validating international phone numbers. Inspired by Google's libphonenumber.",
+  "homepage": "https://github.com/marmelroy/PhoneNumberKit",
+  "license": "MIT",
+  "authors": {
+    "Roy Marmelstein": "marmelroy@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/marmelroy/PhoneNumberKit.git",
+    "tag": "3.3.4"
+  },
+  "social_media_url": "http://twitter.com/marmelroy",
+  "requires_arc": true,
+  "ios": {
+    "frameworks": "CoreTelephony"
+  },
+  "osx": {
+    "frameworks": "CoreTelephony"
+  },
+  "platforms": {
+    "ios": "9.0",
+    "osx": "10.10",
+    "tvos": "10.0",
+    "watchos": "2.0"
+  },
+  "pod_target_xcconfig": {
+    "SWIFT_VERSION": "5.0"
+  },
+  "swift_versions": "5.0",
+  "subspecs": [
+    {
+      "name": "PhoneNumberKitCore",
+      "platforms": {
+        "ios": "9.0",
+        "osx": "10.10",
+        "tvos": "10.0",
+        "watchos": "2.0"
+      },
+      "source_files": "PhoneNumberKit/*.{swift}",
+      "resources": "PhoneNumberKit/Resources/PhoneNumberMetadata.json"
+    },
+    {
+      "name": "UIKit",
+      "dependencies": {
+        "PhoneNumberKit/PhoneNumberKitCore": [
+
+        ]
+      },
+      "platforms": {
+        "ios": "9.0"
+      },
+      "source_files": "PhoneNumberKit/UI/"
+    }
+  ],
+  "swift_version": "5.0"
+}

--- a/Sources/PodToBUILD/PodSpec.swift
+++ b/Sources/PodToBUILD/PodSpec.swift
@@ -223,7 +223,9 @@ public struct PodSpec: PodSpecRepresentable {
         frameworks = strings(fromJSON: fieldMap[.frameworks])
         weakFrameworks = strings(fromJSON: fieldMap[.weakFrameworks])
         excludeFiles = strings(fromJSON: fieldMap[.excludeFiles])
-        sourceFiles = strings(fromJSON: fieldMap[.sourceFiles])
+        sourceFiles = strings(fromJSON: fieldMap[.sourceFiles]).map({ 
+            $0.hasSuffix("/") ? String($0.dropLast()) : $0
+        })
         publicHeaders = strings(fromJSON: fieldMap[.publicHeaders])
         privateHeaders = strings(fromJSON: fieldMap[.privateHeaders])
 


### PR DESCRIPTION
For example `PhoneNumberKit` contains `"source_files": "PhoneNumberKit/UI/"` that will transformed to `"PhoneNumberKit/UI//**/*.h"`